### PR TITLE
Adding masking feature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Imports:
     ggplot2,
     gridExtra,
     sp
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -6,7 +6,7 @@
 #' matters. The default is \code{'matched'}, and will match the range of the intensity of the pixels to
 #' the range of the base image pixels. This scaling is nonlinear and depends on the range of both base image
 #' and noise pattern. It is truly suboptimal, because it shifts the 0 point of the noise (that is, pixels that would
-#' have not changed base image at all before scaling may change the base image after scaling and vice versa). It is
+#' not have changed the base image at all before scaling may change the base image after scaling and vice versa). It is
 #' however the quick and dirty way to see how the CI noise affects the base image.
 #'
 #' For more control, use \code{'constant'} scaling, where the scaling is independent of

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -47,7 +47,7 @@
 #' @param zmaptargetpath Optional string specifying path to save z-map PNGs to (default: ./zmaps).
 #' @param n_cores Optional integer specifying the number of CPU cores to use to generate the z-map (default: detectCores()).
 #' @return List of pixel matrix of classification noise only, scaled classification noise only, base image only and combined.
-generateCI <- function(mask=NA, stimuli, responses, baseimage, rdata, participants=NA, saveaspng=TRUE, filename='', targetpath='./cis', antiCI=FALSE, scaling='independent', constant=0.1, zmap = F, zmapmethod = 'quick', zmapdecoration = T, sigma = 3, threshold = 3, zmaptargetpath = './zmaps', n_cores = detectCores()) {
+generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA, saveaspng=TRUE, filename='', targetpath='./cis', antiCI=FALSE, scaling='independent', constant=0.1, zmap = F, zmapmethod = 'quick', zmapdecoration = T, sigma = 3, threshold = 3, zmaptargetpath = './zmaps', n_cores = detectCores(), mask=NA) {
 
   # Rename zmap to zmapbool so we can use zmap for the actual zmap
   zmapbool <- zmap

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -38,7 +38,7 @@
 #' @param antiCI Optional boolean specifying whether antiCI instead of CI should be computed.
 #' @param scaling Optional string specifying scaling method: \code{none}, \code{constant}, \code{matched}, or \code{independent} (default).
 #' @param constant Optional number specifying the value used as constant scaling factor for the noise (only works for \code{scaling='constant'}).
-#' @param mask Optional 2D matrix that defines the mask to be applied to the CI (1 = masked, 0 = unmasked). May also be a string specifying the path to a grayscale PNG image (black = masked, white = unmasked).
+#' @param mask Optional 2D matrix that defines the mask to be applied to the CI (1 = masked, 0 = unmasked). May also be a string specifying the path to a grayscale PNG image (black = masked, white = unmasked). Default: NA.
 #' @param zmap Boolean specifying whether a z-map should be created (default: FALSE).
 #' @param zmapmethod String specifying the method to create the z-map. Can be: \code{quick} (default), \code{t.test}.
 #' @param zmapdecoration Optional boolean specifying whether the Z-map should be plotted with margins, text (sigma, threshold) and a scale (default: TRUE).

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -20,7 +20,7 @@
 #' @param img_size Number specifying the number of pixels that the stimulus image will span horizontally and vertically (will be square, so only one integer needed).
 #' @param stimulus_path Path to save stimuli and .Rdata file to.
 #' @param label Label to prepend to each file for your convenience.
-#' @param use_same_parameters Boolean specifying whether for each base image, the same set of parameters is used, or unique set is created for each base image.
+#' @param use_same_parameters Boolean specifying whether for each base image the same set of parameters is used (TRUE) or a unique set is created for each base image (FALSE).
 #' @param seed Integer seeding the random number generator (for reproducibility).
 #' @param maximize_baseimage_contrast Boolean specifying wheter the pixel values of the base image should be rescaled to maximize its contrast.
 #' @param noise_type String specifying noise pattern type (defaults to \code{sinusoid}; other options: \code{gabor}).

--- a/man/generateCI.Rd
+++ b/man/generateCI.Rd
@@ -4,13 +4,16 @@
 \alias{generateCI}
 \title{Generates classification image}
 \usage{
-generateCI(stimuli, responses, baseimage, rdata, participants = NA,
-  saveaspng = TRUE, filename = "", targetpath = "./cis", antiCI = FALSE,
-  scaling = "independent", constant = 0.1, zmap = F,
-  zmapmethod = "quick", zmapdecoration = T, sigma = 3, threshold = 3,
-  zmaptargetpath = "./zmaps", n_cores = parallel::detectCores())
+generateCI(mask = NA, stimuli, responses, baseimage, rdata,
+  participants = NA, saveaspng = TRUE, filename = "",
+  targetpath = "./cis", antiCI = FALSE, scaling = "independent",
+  constant = 0.1, zmap = F, zmapmethod = "quick", zmapdecoration = T,
+  sigma = 3, threshold = 3, zmaptargetpath = "./zmaps",
+  n_cores = detectCores())
 }
 \arguments{
+\item{mask}{Optional 2D matrix that defines the mask to be applied to the CI (1 = masked, 0 = unmasked). May also be a string specifying the path to a grayscale PNG image (black = masked, white = unmasked).}
+
 \item{stimuli}{Vector with stimulus numbers (should be numeric) that were presented in the order of the response vector. Stimulus numbers must match those in file name of the generated stimuli.}
 
 \item{responses}{Vector specifying the responses in the same order of the stimuli vector, coded 1 for original stimulus selected and -1 for inverted stimulus selected.}

--- a/man/generateCI.Rd
+++ b/man/generateCI.Rd
@@ -33,7 +33,7 @@ generateCI(stimuli, responses, baseimage, rdata, participants = NA,
 
 \item{constant}{Optional number specifying the value used as constant scaling factor for the noise (only works for \code{scaling='constant'}).}
 
-\item{zmap}{Boolean specifying whether a z-map should be created (default: TRUE).}
+\item{zmap}{Boolean specifying whether a z-map should be created (default: FALSE).}
 
 \item{zmapmethod}{String specifying the method to create the z-map. Can be: \code{quick} (default), \code{t.test}.}
 
@@ -58,7 +58,7 @@ This function saves the classification image as PNG to a folder and returns the 
 matters. The default is \code{'matched'}, and will match the range of the intensity of the pixels to
 the range of the base image pixels. This scaling is nonlinear and depends on the range of both base image
 and noise pattern. It is truly suboptimal, because it shifts the 0 point of the noise (that is, pixels that would
-have not changed base image at all before scaling may change the base image after scaling and vice versa). It is
+not have changed the base image at all before scaling may change the base image after scaling and vice versa). It is
 however the quick and dirty way to see how the CI noise affects the base image.
 
 For more control, use \code{'constant'} scaling, where the scaling is independent of

--- a/man/generateStimuli2IFC.Rd
+++ b/man/generateStimuli2IFC.Rd
@@ -21,7 +21,7 @@ generateStimuli2IFC(base_face_files, n_trials = 770, img_size = 512,
 
 \item{label}{Label to prepend to each file for your convenience.}
 
-\item{use_same_parameters}{Boolean specifying whether for each base image, the same set of parameters is used, or unique set is created for each base image.}
+\item{use_same_parameters}{Boolean specifying whether for each base image the same set of parameters is used (TRUE) or a unique set is created for each base image (FALSE).}
 
 \item{seed}{Integer seeding the random number generator (for reproducibility).}
 


### PR DESCRIPTION
This closes #16.

This PR adds a "mask" argument to generateCI. This argument can either be the filename of a PNG file from which the mask should be imported, or a matrix.

Checks are performed to see if the mask is of the same size as the stimulus size defined in the Rdata file and if the mask is truly boolean (only containing zeroes and ones, or if read from a PNG, black and white pixels).

The mask is then applied to the "ci" object such that every masked pixel will be assigned a value of NA.

I have tested this code with all scaling methods. Everything appears to be working.