### PR TITLE
replaced returnAsList parameter of generateStimuli2IFC with returnAsDataframe parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,4 +39,4 @@ Imports:
     ggplot2,
     gridExtra,
     sp
-RoxygenNote: 6.0.1
+RoxygenNote: 5.0.1

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -27,8 +27,8 @@
 #' @param nscales Integer specifying the number of incremental spatial scales. Defaults to 5. Higher numbers will add higher spatial frequency scales.
 #' @param sigma Number specifying the sigma of the Gabor patch if noise_type is set to \code{gabor} (defaults to 25).
 #' @param ncores Number of CPU cores to use (default: detectCores()).
-#' @param returnAsDataframe Boolean specifying whether to return a data frame with the raw noise of the stimuli that were generated (default: FALSE). Data frame columns are stimuli, rows are vectorized pixels
-#' @return Nothing, everything is saved to files, unless returnAsList or returnAsMatrix are set to TRUE.
+#' @param returnAsDataframe Boolean specifying whether to return a data frame with the raw noise of the stimuli that were generated (default: FALSE). Data frame columns represent pixel values, data frame rows represent stimuli.
+#' @return Nothing, everything is saved to files, unless returnAsDataframe is set to TRUE.
 generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, stimulus_path='./stimuli', label='rcic', use_same_parameters=TRUE, seed=1, maximize_baseimage_contrast=TRUE, noise_type='sinusoid', nscales=5, sigma=25, ncores=parallel::detectCores(), returnAsDataframe=FALSE) {
 
   # Initialize #

--- a/man/generateCI.Rd
+++ b/man/generateCI.Rd
@@ -4,16 +4,13 @@
 \alias{generateCI}
 \title{Generates classification image}
 \usage{
-generateCI(mask = NA, stimuli, responses, baseimage, rdata,
-  participants = NA, saveaspng = TRUE, filename = "",
-  targetpath = "./cis", antiCI = FALSE, scaling = "independent",
-  constant = 0.1, zmap = F, zmapmethod = "quick", zmapdecoration = T,
-  sigma = 3, threshold = 3, zmaptargetpath = "./zmaps",
-  n_cores = detectCores())
+generateCI(stimuli, responses, baseimage, rdata, participants = NA,
+  saveaspng = TRUE, filename = "", targetpath = "./cis", antiCI = FALSE,
+  scaling = "independent", constant = 0.1, zmap = F,
+  zmapmethod = "quick", zmapdecoration = T, sigma = 3, threshold = 3,
+  zmaptargetpath = "./zmaps", n_cores = detectCores(), mask = NA)
 }
 \arguments{
-\item{mask}{Optional 2D matrix that defines the mask to be applied to the CI (1 = masked, 0 = unmasked). May also be a string specifying the path to a grayscale PNG image (black = masked, white = unmasked).}
-
 \item{stimuli}{Vector with stimulus numbers (should be numeric) that were presented in the order of the response vector. Stimulus numbers must match those in file name of the generated stimuli.}
 
 \item{responses}{Vector specifying the responses in the same order of the stimuli vector, coded 1 for original stimulus selected and -1 for inverted stimulus selected.}
@@ -49,6 +46,8 @@ generateCI(mask = NA, stimuli, responses, baseimage, rdata,
 \item{zmaptargetpath}{Optional string specifying path to save z-map PNGs to (default: ./zmaps).}
 
 \item{n_cores}{Optional integer specifying the number of CPU cores to use to generate the z-map (default: detectCores()).}
+
+\item{mask}{Optional 2D matrix that defines the mask to be applied to the CI (1 = masked, 0 = unmasked). May also be a string specifying the path to a grayscale PNG image (black = masked, white = unmasked). Default: NA.}
 }
 \value{
 List of pixel matrix of classification noise only, scaled classification noise only, base image only and combined.

--- a/man/generateStimuli2IFC.Rd
+++ b/man/generateStimuli2IFC.Rd
@@ -8,7 +8,7 @@ generateStimuli2IFC(base_face_files, n_trials = 770, img_size = 512,
   stimulus_path = "./stimuli", label = "rcic", use_same_parameters = TRUE,
   seed = 1, maximize_baseimage_contrast = TRUE, noise_type = "sinusoid",
   nscales = 5, sigma = 25, ncores = parallel::detectCores(),
-  returnAsList = FALSE)
+  returnAsDataframe = FALSE)
 }
 \arguments{
 \item{base_face_files}{List containing base face file names used as base images for stimuli. Accepts JPEG and PNG images.}
@@ -35,10 +35,10 @@ generateStimuli2IFC(base_face_files, n_trials = 770, img_size = 512,
 
 \item{ncores}{Number of CPU cores to use (default: detectCores()).}
 
-\item{returnAsList}{Boolean specifying whether to return a list of the raw noise of the stimuli that were generated (default: FALSE).}
+\item{returnAsDataframe}{Boolean specifying whether to return a data frame with the raw noise of the stimuli that were generated (default: FALSE). Data frame columns are stimuli, rows are vectorized pixels}
 }
 \value{
-Nothing, everything is saved to files, unless returnAsList are set to TRUE.
+Nothing, everything is saved to files, unless returnAsList or returnAsMatrix are set to TRUE.
 }
 \description{
 Generate stimuli for 2 images forced choice reverse correlation task.


### PR DESCRIPTION
 -- this representation is ready for follow-up computations, whereas a list takes a long while to transform.