### PR TITLE
Fixed atomic vector issue? maybe?

### DIFF
--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -110,7 +110,7 @@ computeInfoVal2IFC <- function(ci, rdata, iter = 10000, force_gen_ref_dist = FAL
   }
 
   # Compute informational value metric
-  cinorm <- norm(matrix(ci$ci), "f")
+  cinorm <- norm(matrix(ci[["ci"]]), "f")
   k <- 1.4826 # scaling factor
   infoVal <- (cinorm - ref_median ) / (k * ref_mad)
 


### PR DESCRIPTION
Possible hotfix for issue #99 - $ operator can't be used on atomic vectors, so I replaced ci$ci with ci[["ci"]]. 

This may or may not work. 