### PR TITLE
speed improvement to generateNoiseImage

### DIFF
--- a/R/generateNoiseImage.R
+++ b/R/generateNoiseImage.R
@@ -30,7 +30,9 @@ generateNoiseImage <- function(params, p) {
     p <- list(patches=p$sinusoids, patchIdx=p$sinIdx, noise_type='sinusoid')
   }
 
-  noise <- apply(p$patches * array(params[p$patchIdx], dim(p$patches)), 1:2, mean)
+  patch_indices <- p$patchIdx
+  patch_params <- array(params[patch_indices], dim(p$patches))
+  reshaped_matrix <- array(p$patches * patch_params, dim(p$patches))
+  noise <- array(rowMeans(reshaped_matrix), dim(p$patches)[1:2])
   return(noise)
-
 }


### PR DESCRIPTION
Hi, 

the following pull request modifies the `generateNoiseImage` function, where the `apply` function is replaced with a new implementation which leverages vectorization for computing the dot product. Vectorization allows the matrices to be computed in parallel, whereas `apply` does it sequentially and thus much slower. The impact is high since the `generateNoiseImage` function is used for both computing CIs as well as zmaps. Below is a comparison of the outputs of both implementation variants as well as a benchmark script comparing the computation speed. The following [RData file](https://1drv.ms/u/s!Ao4a7I0piAfzibcUMMROQgLpEPJWWQ?e=B3LMqe) has been used for both scripts outlined below and has been extracted from a genuine dataset. This pull request should be a drop-in replacement, since it does not use any additional packages.

The script below evaluates the output of the original `apply` function and that of the newer implementation:
```
# Sample data
set.seed(42)

load("test.RData")

# Original apply function
original_noise <- apply(p$patches * array(params[p$patchIdx], dim(p$patches)), 1:2, mean)

# Improved code for performance
patch_indices <- p$patchIdx
patch_params <- array(params[patch_indices], dim(p$patches))
reshaped_matrix <- array(p$patches * patch_params, dim(p$patches))
noise <- array(rowMeans(reshaped_matrix), dim(p$patches)[1:2])

# Print array dimensions of each alternative
print(dim(original_noise))
print(dim(improved_noise))

# Check if the arrays are identical
are_identical <- identical(original_noise, improved_noise)

if (are_identical) {
  cat("The computed arrays are identical.\n")
} else {
  cat("The computed arrays are NOT identical.\n")
}

if (length(original_noise) != length(improved_noise)) {
  stop("Arrays must have the same length.")
}

# Calculate absolute differences element-wise
abs_diff <- abs(original_noise - improved_noise)

# Sum of the deviations across each compared pair
total_deviation <- sum(abs_diff)

# Maximum deviation
max_deviation <- max(abs_diff)

# Minimum deviation
min_deviation <- min(abs_diff)

# Print the results
cat("Sum of deviations:", total_deviation, "\n")
cat("Maximum deviation:", max_deviation, "\n")
cat("Minimum deviation:", min_deviation, "\n")

# Compare element-wise
comparison_result <- original_noise == improved_noise

# Check if all elements are the same
all_same <- all(comparison_result)

# Print the aggregated result
if (all_same) {
  print("All elements are the same.")
} else {
  print("Not all elements are the same.")
}

# Count the number of identical (TRUE) and different (FALSE) values
value_counts <- table(comparison_result)

# Print the counts
print(value_counts)
```


the output from running the script on the linked file is:
```
[1] 512 512
[1] 512 512
The computed arrays are NOT identical.
Sum of deviations: 1.250356e-16 
Maximum deviation: 1.387779e-17 
Minimum deviation: 0 
[1] "Not all elements are the same."
comparison_result
 FALSE   TRUE 
   955 261189 
```
Differences occur only for 0.003% (or 955 elements) of the noise matrix, with the largest deviation being $\approx1.38\times10^{-17}$. The results differ on a marginal part of the test data, and the aggregate sum of errors is also negligible ($\approx1.25\times10^{-16}$). The reason for this deviation is presumably due to differences in how the last bits are rounded.

Below is a benchmark evaluating the old and new implementation on performing a computation on RData file linked above:
```
# Load the necessary data
load("test.RData")

# Define the original apply function
original_apply <- function() {
  original_noise <- apply(p$patches * array(params[p$patchIdx], dim(p$patches)), 1:2, mean)
}

# Define the improved code
improved_code <- function() {
  # Improved code for calculating 3D dot product
  patch_indices <- p$patchIdx
  patch_params <- array(params[patch_indices], dim(p$patches))
  reshaped_matrix <- array(p$patches * patch_params, dim(p$patches))
  noise <- array(rowMeans(reshaped_matrix), dim(p$patches)[1:2])
}

# Benchmark the original apply function
original_time <- system.time(original_apply())

# Benchmark the improved code
improved_time <- system.time(improved_code())

# Print the benchmark results
cat("Original apply function time:", original_time[["elapsed"]], "seconds\n")
cat("Improved code time:", improved_time[["elapsed"]], "seconds\n")
```
Below are the results:
```
Original apply function time: 2.23 seconds
Improved code time: 0.23 seconds
```
The newer implementation yields around 9x speed increase. Realistically, since this method is (almost) always called in parallel from multiple threads on multiple different matrices, the speed increase is around 6x due to CPU bottlenecks. In terms of memory usage, both implementations are roughly equal.