### PR TITLE
Speed up generateNoiseImage ~6x (rowMeans dims = 2)

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -39,7 +39,14 @@ jobs:
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          # Best-effort upload. There is no CODECOV_TOKEN secret on this repo, and
+          # the previous expression -- `github.event_name != 'pull_request' ||
+          # secrets.CODECOV_TOKEN` -- evaluated to false on pull requests but true
+          # on pushes to main, so every merge turned the main branch red for a
+          # reason unrelated to the code. Coverage is still computed and printed in
+          # the step above; only the upload is allowed to fail. If a token is added
+          # later this can go back to true. See BACKLOG.md item 18.
+          fail_ci_if_error: false
           files: ./cobertura.xml
           plugins: noop
           disable_search: true

--- a/.session-log.md
+++ b/.session-log.md
@@ -585,8 +585,16 @@ conflict in this file. It is being written now, once, against a single true stat
   (6x end-to-end), the oracle tests, the NEWS reproducibility note, the Codecov fix, and
   backlog items 18 (fixed) and 19. Closes #122.
 
+### Merge strategy changed: squash from here on
+Ron asked for squash merges to `main` from now on. Recorded in `CLAUDE.md` under "Git and
+merge strategy". Everything up to and including #132 was an ordinary merge commit, so
+`main`'s history changes shape at #131. Note the consequence: per-commit detail on a
+branch disappears, so measurements, rejected alternatives and reproducibility impact have
+to live in the squash message or `NEWS.md`. Not enforced by repo settings — merge commits
+are still permitted, so it is on whoever merges.
+
 ### Next
-1. Merge #131 once green.
+1. Merge #131 once green — **`gh pr merge 131 --squash`**.
 2. Item 19: close the 8 resolved issues in one batch, #12 handled carefully.
 3. Item 11 leftover: `ncores == 1` serial fast path.
 4. Item 12: scaling methods, z-maps, `participants` coverage.

--- a/.session-log.md
+++ b/.session-log.md
@@ -533,4 +533,73 @@ Rscript -e 'devtools::install(quiet=TRUE, upgrade="never"); devtools::test()'
 Expect `[ FAIL 0 | PASS 129 ]` on `recovery-test`, `[ FAIL 0 | PASS 145 ]` on
 `speed-generatenoiseimage`.
 
+## 2026-07-27 06:25 UTC — #132 merged; Codecov decided; #131 rebased
+
+### #132 merged
+All four checks green; merged to `main` at `d39b82c`. The recovery test is now on `main`
+with the B=100 permutation null. Ron's requested ordering held: it landed before any
+other change, so it is on record as passing against the *old* `apply()` implementation.
+
+### Codecov (item 18) — decided
+Ron chose the one-line option: `fail_ci_if_error: false`, unconditionally, replacing
+`${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}`. The `token:` input
+is left wired so adding the secret later restores reporting. A comment in the workflow
+records why, so nobody reinstates the expression thinking it was deliberate.
+
+**Stated plainly in BACKLOG.md, because it would be easy to mistake for a win:** this does
+not make coverage reporting work. No token, so no badge, no per-PR comments, and
+`codecov.yml`'s thresholds stay inert — coverage is visible only in the workflow log. What
+it fixes is narrower and more useful: a red `main` now means the package is broken.
+
+### New backlog item 19 — the tracker understates the code
+30 open issues, at least 8 already fixed: #70, #81, #113, #123, #124 (by #129), #50 (by
+#130), #12 (partially, by #130), #122 (closes with #131). #124 has been open since Sep
+2024 while the fix sits in `main`. Anyone evaluating the package from the tracker
+concludes it is unmaintained.
+
+**Do not blanket-close #12.** `NEWS.md` says "addresses", not "fixes", and that wording is
+deliberate: the ~1.5 GB per-worker array copy is gone, but the `ncores == 1` serial path
+(item 11) is still open and per-worker memory still scales with `img_size`. Comment with
+what changed and what did not.
+
+### #131 rebased onto the new `main`
+Rebased by cherry-picking the four commits worth keeping onto `d39b82c`, rather than
+replaying all six and resolving two guaranteed conflicts:
+
+- kept: the speedup, the 6x correction, the Codecov fix, backlog item 19
+- dropped `c52b8fc` — the recovery test, superseded by the B=100 version now in `main`
+- dropped `877dde7` — a session-log entry, superseded by the rewritten one that came in
+  with #132
+
+Verified after the rebase that `main`'s B=100 test survived untouched, that the log has no
+duplicated section, and that both backlog items are present. Cherry-picked cleanly, no
+conflicts.
+
+This is why the session-log entry for the Codecov decision and item 19 was deliberately
+*not* written before the rebase: putting it on either branch would have guaranteed a
+conflict in this file. It is being written now, once, against a single true state.
+
+### State
+- `main` at `d39b82c` — includes the recovery test.
+- **#131** rebased, force-pushed, CI re-running. Contains: `generateNoiseImage()` speedup
+  (6x end-to-end), the oracle tests, the NEWS reproducibility note, the Codecov fix, and
+  backlog items 18 (fixed) and 19. Closes #122.
+
+### Next
+1. Merge #131 once green.
+2. Item 19: close the 8 resolved issues in one batch, #12 handled carefully.
+3. Item 11 leftover: `ncores == 1` serial fast path.
+4. Item 12: scaling methods, z-maps, `participants` coverage.
+5. Item 1: **CRAN** — the last open P0. The archival cause (undeliverable email) no longer
+   applies and the dependency NOTEs are cleared, so resubmission is genuinely actionable
+   now. Ron's decision. Until then the README still tells users to run
+   `install.packages('rcicr')`, which does not work.
+
+### Resume commands
+```
+gh pr checks 131
+Rscript -e 'devtools::install(quiet=TRUE, upgrade="never"); devtools::test()'
+```
+Expect `[ FAIL 0 | PASS 145 ]`.
+
 <!-- END LOG — append new sections above this line -->

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -52,6 +52,7 @@ take it:
 | 11 | Cluster cleanup (`on.exit`), serial fallback | Partly done — `generateReferenceDistribution2IFC()` now takes `ncores`; cleanup and the `ncores == 1` fast path remain | M |
 | 12 | Widen test coverage (scaling methods, z-maps, `participants`) | The suite covers the fixed bugs well; these paths are still untested | M |
 | ~~18~~ | ~~Codecov step fails for want of a token~~ | **Done** — `fail_ci_if_error: false`; a red `main` now means the package is broken | S |
+| 19 | Close the 8 issues already fixed in `main` | Cheapest credibility win available; the tracker currently makes the package look unmaintained | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -383,6 +384,42 @@ thresholds are inert. Coverage numbers are visible only in the workflow log. If 
 reporting is wanted later, add the token and set this back to `true` — the first bullet
 above is the recipe. The point of this change is narrower: a red `main` should mean the
 package is broken, and it now does.
+
+### 19. Eight issues are fixed in `main` but still open on the tracker  **[own review]**
+
+Not a code task, but it is the largest gap between what the package *is* and what a
+prospective user *sees*. As of 2026-07-27 the tracker has 30 open issues, and at least
+these are already fixed:
+
+| issue | what | fixed by |
+|---|---|---|
+| #70 | `generateCI()` cannot handle tibbles | #129 (P0 item 4) |
+| #81 | `nscales` not saved in `.Rdata` | #129 (P0 item 2) |
+| #113 | `force_gen_ref_dist` does nothing | #129 (P0 item 3) |
+| #123 | `aggregate.data.frame` length error | #129 (P0 item 4, same cause as #70) |
+| #124 | `non-conformable arrays` from `generateStimuli2IFC()` | #129 (P0 item 7) |
+| #50 | "closing unused connections" warnings | #130 (`on.exit()` cluster cleanup) |
+| #12 | large stimulus sets exhaust memory | #130 — **partially**, see below |
+| #122 | `generateNoiseImage()` speed (a PR) | closed by #131 |
+
+Why this matters more than it sounds: someone hitting the `non-conformable arrays` error
+today searches the tracker, finds #124 open since September 2024 with no resolution, and
+concludes the package is unmaintained — while the fix sits in `main`. The tracker is the
+package's public health signal and it currently understates the state of the code badly.
+
+- [ ] Close each with a short comment naming the version that fixes it and how to get it
+      (`devtools::install_github("rdotsch/rcicr")` until the CRAN question in item 1 is
+      settled), plus a pointer to the `NEWS.md` entry.
+- [ ] **Do not blanket-close #12.** `NEWS.md` says "addresses", not "fixes", and that
+      wording is deliberate: #130 removed the ~1.5 GB array copied to every worker, which
+      was the dominant cost, but the `ncores == 1` serial path in item 11 is still open and
+      per-worker memory still scales with `img_size`. Comment with what changed and what
+      did not, and leave it open, or close it explicitly scoped to the array copy.
+- [ ] Sweep the remaining ~22 open issues the same way — some are likely stale or already
+      resolved by earlier releases. This has not been done; the eight above are only the
+      ones this modernization pass touched directly.
+
+Best done as one batch after #131 merges, so #122 closes with it rather than by hand.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -51,6 +51,7 @@ take it:
 | 1 | CRAN archived | Highest reach of anything here, but a process/decision task rather than a code fix | M |
 | 11 | Cluster cleanup (`on.exit`), serial fallback | Partly done — `generateReferenceDistribution2IFC()` now takes `ncores`; cleanup and the `ncores == 1` fast path remain | M |
 | 12 | Widen test coverage (scaling methods, z-maps, `participants`) | The suite covers the fixed bugs well; these paths are still untested | M |
+| 18 | Codecov step fails for want of a token | A red X on every PR that has nothing to do with the code; needs a decision, not a fix | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -338,6 +339,39 @@ an end-to-end smoke test. Gaps worth closing:
       `test-fixed-bugs.R`.
 - [ ] Cover the `zmap = TRUE` paths (`quick` and `t.test`).
 - [ ] Cover `participants` (per-participant → group averaging).
+
+### 18. The Codecov CI step fails without a repository token
+
+`.github/workflows/test-coverage.yaml` runs `covr::package_coverage()` and uploads the
+result to Codecov, which needs a `CODECOV_TOKEN` repository secret. That secret does not
+exist, so the upload step fails. The coverage *computation* itself is fine — it is only
+the upload that fails.
+
+Note the exact trigger, because it is easy to misread: the step sets
+
+```yaml
+fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+```
+
+so on a **pull request** it is `false` and a missing token is tolerated, but on a **push
+to `main`** it is `true` and the run goes red. That is why every PR so far has been green
+while `main` shows a failing badge — the merge of #130 on 2026-07-27 is the current
+example. Anyone judging the health of the repo from the front page sees a red X.
+
+Three ways out; this needs a decision rather than a fix:
+
+- [ ] **Get a token.** Sign in to codecov.io with the GitHub account, add `rdotsch/rcicr`,
+      copy the upload token into Settings → Secrets → Actions as `CODECOV_TOKEN`. Keeps
+      the coverage badge and per-PR coverage comments. Codecov is free for public repos.
+- [ ] **Or drop the upload.** Delete `.github/workflows/test-coverage.yaml` (and
+      `codecov.yml`, plus its `.Rbuildignore` line). Coverage is deliberately partial
+      here — I/O-heavy functions get lighter tests by design — so the reporting is of
+      limited value, and `R CMD check` on release and devel is the check that actually
+      matters.
+- [ ] **Or keep the workflow but stop it failing.** Set `fail_ci_if_error: false`
+      unconditionally. Coverage still gets computed and printed in the log; only the
+      upload becomes best-effort. This is the smallest change and keeps the option of
+      adding a token later.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -51,7 +51,7 @@ take it:
 | 1 | CRAN archived | Highest reach of anything here, but a process/decision task rather than a code fix | M |
 | 11 | Cluster cleanup (`on.exit`), serial fallback | Partly done — `generateReferenceDistribution2IFC()` now takes `ncores`; cleanup and the `ncores == 1` fast path remain | M |
 | 12 | Widen test coverage (scaling methods, z-maps, `participants`) | The suite covers the fixed bugs well; these paths are still untested | M |
-| 18 | Codecov step fails for want of a token | A red X on every PR that has nothing to do with the code; needs a decision, not a fix | S |
+| ~~18~~ | ~~Codecov step fails for want of a token~~ | **Done** — `fail_ci_if_error: false`; a red `main` now means the package is broken | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -340,7 +340,7 @@ an end-to-end smoke test. Gaps worth closing:
 - [ ] Cover the `zmap = TRUE` paths (`quick` and `t.test`).
 - [ ] Cover `participants` (per-participant → group averaging).
 
-### 18. The Codecov CI step fails without a repository token
+### 18. The Codecov CI step fails without a repository token  ✅ **FIXED**
 
 `.github/workflows/test-coverage.yaml` runs `covr::package_coverage()` and uploads the
 result to Codecov, which needs a `CODECOV_TOKEN` repository secret. That secret does not
@@ -358,20 +358,31 @@ to `main`** it is `true` and the run goes red. That is why every PR so far has b
 while `main` shows a failing badge — the merge of #130 on 2026-07-27 is the current
 example. Anyone judging the health of the repo from the front page sees a red X.
 
-Three ways out; this needs a decision rather than a fix:
+Three ways out were put to Ron, who chose the third:
 
 - [ ] **Get a token.** Sign in to codecov.io with the GitHub account, add `rdotsch/rcicr`,
       copy the upload token into Settings → Secrets → Actions as `CODECOV_TOKEN`. Keeps
       the coverage badge and per-PR coverage comments. Codecov is free for public repos.
+      *Still available later — see below.*
 - [ ] **Or drop the upload.** Delete `.github/workflows/test-coverage.yaml` (and
       `codecov.yml`, plus its `.Rbuildignore` line). Coverage is deliberately partial
       here — I/O-heavy functions get lighter tests by design — so the reporting is of
       limited value, and `R CMD check` on release and devel is the check that actually
       matters.
-- [ ] **Or keep the workflow but stop it failing.** Set `fail_ci_if_error: false`
-      unconditionally. Coverage still gets computed and printed in the log; only the
-      upload becomes best-effort. This is the smallest change and keeps the option of
-      adding a token later.
+- [x] **Keep the workflow but stop it failing.** `fail_ci_if_error: false`,
+      unconditionally. Coverage is still computed and printed in the step log; only the
+      upload is best-effort. Smallest change, and it keeps the token option open.
+
+**Chosen and applied.** The conditional expression is gone; the setting is now a plain
+`false` with a comment recording why, so nobody restores the old expression thinking it
+was deliberate.
+
+What this does *not* do: it does not make coverage reporting work. There is still no
+Codecov token, so no badge, no per-PR coverage comments, and the `codecov.yml`
+thresholds are inert. Coverage numbers are visible only in the workflow log. If that
+reporting is wanted later, add the token and set this back to `true` — the first bullet
+above is the recipe. The point of this change is narrower: a red `main` should mean the
+package is broken, and it now does.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,22 @@ Version/date/dependency metadata lives in `DESCRIPTION`; user-facing changes sho
   - `.Rbuildignore` itself was listed in `.gitignore` from 2016 until recently (likely an unintentional RStudio-template leftover), so it never actually shipped to CI or other contributors — don't re-add it there.
 - `.pre-commit-config.yaml` drives the pre-commit.ci GitHub App, which runs on every PR. It uses only minimal language-agnostic hooks (trailing whitespace, end-of-file, YAML/merge-conflict checks). R-specific hooks (`styler`/`lintr`/`roxygenize`) were deliberately left out — `styler` would reformat nearly every file in one sweep and destroy `git blame`.
 
+## Git and merge strategy
+
+- **Merge pull requests to `main` with squash merges** (`gh pr merge <n> --squash`, or the
+  "Squash and merge" button). Decided 2026-07-27; PRs up to and including #132 were
+  ordinary merge commits, so `main`'s history changes shape from #131 onward. One commit
+  per PR on `main` keeps the history readable and makes `git revert` of a whole change
+  straightforward, which matters here because a single PR is usually one self-contained
+  fix plus its test and its `NEWS.md` entry.
+- The squash commit message is the place to preserve *why* a change was made — the
+  per-commit detail on the branch disappears, so anything that a future reader needs
+  (measurements, rejected alternatives, reproducibility impact) belongs in the squash
+  message or in `NEWS.md`, not only in the branch commits.
+- Note this is repo convention, not enforced by GitHub settings — merge commits and
+  rebase merges are still permitted in the repository settings, so it is on whoever
+  merges to pick the right one.
+
 ## Backlog
 
 `BACKLOG.md` is the prioritized modernization backlog — read it before starting substantial work, and update it when you close something out. It was compiled from the open GitHub issues, the published literature, and a direct source review, and it records:

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,13 +49,15 @@
   Addresses issue #12.
 - Parallel clusters are now stopped via `on.exit()`, so workers are released even when an
   error interrupts the loop. Fixes the "closing unused connections" warnings (issue #50).
-- `generateNoiseImage()` is about 29x faster — 1.38s to 0.05s at the default 512px with
-  `nscales = 5` — and allocates roughly a third less memory. The per-pixel average across
-  patch layers is now computed with `rowMeans(..., dims = 2)` instead of
-  `apply(..., 1:2, mean)`. Because this function is called for every trial during stimulus
-  generation and again for every CI and z-map, the saving compounds. Thanks to
-  [@hvalev](https://github.com/hvalev), who diagnosed this and benchmarked it in #122.
-  See "Reproducibility impact" below — the result is not *bit*-identical to the old one.
+- `generateNoiseImage()` is about **6x faster** — 1.66s to 0.28s per call at the default
+  512px with `nscales = 5` — and allocates about 30% less memory. The per-pixel average
+  across patch layers is now computed with `rowMeans(..., dims = 2)` instead of
+  `apply(..., 1:2, mean)`; that step alone is ~31x faster, and what remains is building
+  the weighted patch array, which is unavoidable. Because this function is called for
+  every trial during stimulus generation and again for every CI and z-map, the saving
+  compounds. Thanks to [@hvalev](https://github.com/hvalev), who diagnosed this and
+  benchmarked it in #122. See "Reproducibility impact" below — the result is not
+  *bit*-identical to the old one.
 - `Imports` shrank from 27 packages to 15; none of the removed ones were used.
 - Deprecated calls replaced: `dplyr::progress_estimated()`, `purrr::rbernoulli()`, and
   `citEntry()`/`personList()` in `inst/CITATION`. The `rbernoulli()` replacement was

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,13 @@
   Addresses issue #12.
 - Parallel clusters are now stopped via `on.exit()`, so workers are released even when an
   error interrupts the loop. Fixes the "closing unused connections" warnings (issue #50).
+- `generateNoiseImage()` is about 29x faster — 1.38s to 0.05s at the default 512px with
+  `nscales = 5` — and allocates roughly a third less memory. The per-pixel average across
+  patch layers is now computed with `rowMeans(..., dims = 2)` instead of
+  `apply(..., 1:2, mean)`. Because this function is called for every trial during stimulus
+  generation and again for every CI and z-map, the saving compounds. Thanks to
+  [@hvalev](https://github.com/hvalev), who diagnosed this and benchmarked it in #122.
+  See "Reproducibility impact" below — the result is not *bit*-identical to the old one.
 - `Imports` shrank from 27 packages to 15; none of the removed ones were used.
 - Deprecated calls replaced: `dplyr::progress_estimated()`, `purrr::rbernoulli()`, and
   `citEntry()`/`personList()` in `inst/CITATION`. The `rbernoulli()` replacement was
@@ -123,6 +130,30 @@ obtained result changes:
   `.Rdata` file between calls, in which case the old code either errored with
   `cannot open the connection` or wrote the reference distribution back to the file's
   former path. The `ncores` half affects speed only. No infoVal changes.
+
+### Changed, but below any scale that can matter: the patch average
+
+`generateNoiseImage()` now averages patch layers with `rowMeans(..., dims = 2)`
+rather than `apply(..., 1:2, mean)`. These compute the same quantity but sum in a
+different order, so they are **not bit-identical**: they differ by about one unit
+in the last place, ~1e-19 in absolute terms on pixel values of order 0.01.
+
+This is a different class of thing from the `rbernoulli` case below. That one would
+have changed the random *stream* — a large, systematic divergence. This is
+floating-point summation order, and it was checked against an independent oracle
+(the average written as an explicit triple loop, using neither `apply()` nor
+`rowMeans()`) across noise types, spatial scales and seeds: both the old and new
+forms sit ~5.6e-17 from that oracle. Neither is "more correct" than the other.
+
+- **Affected:** nothing you would report. No CI, z-map, infoVal or scaling decision
+  changes at any precision a paper prints, and the difference is far below the
+  noise you would get from re-running with a different seed.
+- **At the configuration the golden master pins**, the results came out bit-identical.
+- It is recorded here anyway, because the standard for this package is that any
+  numeric change is written down rather than discovered later by someone re-running
+  a five-year-old script.
+- `tests/testthat/test-generateNoiseImage.R` now pins the new implementation against
+  the original `apply()` form across 12 configurations, so it cannot drift further.
 
 ### Deliberately unchanged: the random number stream
 

--- a/R/generateNoiseImage.R
+++ b/R/generateNoiseImage.R
@@ -34,11 +34,13 @@ generateNoiseImage <- function(params, p) {
   }
 
   # Average the weighted patches over the third dimension, i.e. one mean per
-  # pixel across all patch layers. rowMeans() with dims=2 does exactly that and
-  # is ~29x faster than the apply() it replaces (1.38s -> 0.05s at 512px,
-  # nscales=5). Note that dims MUST be given: rowMeans() on a 3-D array defaults
-  # to dims=1, which collapses dimensions 2 and 3 and silently returns a vector
-  # that array() would then recycle. See PR #122.
+  # pixel across all patch layers. rowMeans() with dims=2 does exactly that.
+  # It replaces apply(..., 1:2, mean), which was ~31x slower at the averaging
+  # step (1.47s -> 0.05s at 512px, nscales=5); the whole call is ~6x faster,
+  # the rest being the weighted array above, which both forms have to build.
+  # Note that dims MUST be given: rowMeans() on a 3-D array defaults to dims=1,
+  # which collapses dimensions 2 and 3 and silently returns a vector that
+  # array() would then recycle. See PR #122.
   noise <- rowMeans(p$patches * array(params[p$patchIdx], dim(p$patches)), dims = 2)
   return(noise)
 

--- a/R/generateNoiseImage.R
+++ b/R/generateNoiseImage.R
@@ -33,7 +33,13 @@ generateNoiseImage <- function(params, p) {
     }
   }
 
-  noise <- apply(p$patches * array(params[p$patchIdx], dim(p$patches)), 1:2, mean)
+  # Average the weighted patches over the third dimension, i.e. one mean per
+  # pixel across all patch layers. rowMeans() with dims=2 does exactly that and
+  # is ~29x faster than the apply() it replaces (1.38s -> 0.05s at 512px,
+  # nscales=5). Note that dims MUST be given: rowMeans() on a 3-D array defaults
+  # to dims=1, which collapses dimensions 2 and 3 and silently returns a vector
+  # that array() would then recycle. See PR #122.
+  noise <- rowMeans(p$patches * array(params[p$patchIdx], dim(p$patches)), dims = 2)
   return(noise)
 
 }

--- a/tests/testthat/test-generateNoiseImage.R
+++ b/tests/testthat/test-generateNoiseImage.R
@@ -33,3 +33,77 @@ test_that("all-zero params gives an all-zero image", {
   result <- generateNoiseImage(rep(0, max(p$patchIdx)), p)
   expect_equal(result, matrix(0, 16, 16))
 })
+
+# The patch averaging is vectorised with rowMeans(..., dims = 2). rowMeans() on
+# a 3-D array defaults to dims = 1, which collapses dimensions 2 and 3 and
+# returns a vector that gets silently recycled back to img_size x img_size. The
+# two tests below pin the intended behaviour against an independent oracle so
+# that mistake cannot creep back in. See PR #122.
+
+test_that("noise is the per-pixel mean across patch layers (independent oracle)", {
+  # A NON-square patch stack: a square one would hide a transposition.
+  set.seed(42)
+  patches <- array(rnorm(4 * 6 * 3), dim = c(4, 6, 3))
+  p <- list(patches = patches, patchIdx = array(1:3, dim = c(4, 6, 3)),
+            noise_type = "sinusoid")
+  params <- c(0.5, -2, 1.5)
+
+  # The definition, written out by hand: neither apply() nor rowMeans().
+  oracle <- matrix(NA_real_, 4, 6)
+  for (i in 1:4) {
+    for (j in 1:6) {
+      total <- 0
+      for (k in 1:3) total <- total + patches[i, j, k] * params[p$patchIdx[i, j, k]]
+      oracle[i, j] <- total / 3
+    }
+  }
+
+  result <- generateNoiseImage(params, p)
+  expect_equal(dim(result), c(4, 6))
+  expect_equal(result, oracle)
+})
+
+test_that("vectorised averaging matches the original apply() implementation", {
+  # Before 1.1.0 the average was computed as
+  #   apply(p$patches * array(params[p$patchIdx], dim(p$patches)), 1:2, mean)
+  # This pins the current implementation to that one across noise types, spatial
+  # scales and seeds. The two are not bit-identical -- they sum in a different
+  # order, so they differ by about 1 ULP -- hence a tolerance rather than
+  # identical(). Anything larger than that means the averaging changed.
+  configs <- expand.grid(
+    noise_type = c("sinusoid", "gabor"),
+    nscales = 1:3,
+    seed = c(1, 2),
+    stringsAsFactors = FALSE
+  )
+
+  worst <- 0
+  for (i in seq_len(nrow(configs))) {
+    cfg <- configs[i, ]
+    p <- generateNoisePattern(16, nscales = cfg$nscales,
+                              noise_type = cfg$noise_type, sigma = 5)
+    set.seed(cfg$seed)
+    params <- rnorm(max(p$patchIdx))
+
+    original <- apply(p$patches * array(params[p$patchIdx], dim(p$patches)),
+                      1:2, mean)
+    current <- generateNoiseImage(params, p)
+
+    label <- paste0(cfg$noise_type, ", nscales=", cfg$nscales, ", seed=", cfg$seed)
+    expect_equal(current, original, tolerance = 1e-12, info = label)
+    worst <- max(worst, max(abs(current - original)))
+  }
+
+  # Absolute agreement, independent of the relative tolerance above. Patch
+  # values are O(1), so 1e-14 is still several orders of magnitude of headroom
+  # over the ~1e-17 that differing summation order actually produces.
+  expect_lt(worst, 1e-14)
+})
+
+test_that("noise columns are not recycled copies of a single column", {
+  # The dims = 1 bug produces an image whose every column is identical.
+  set.seed(1)
+  p <- generateNoisePattern(16, nscales = 1)
+  result <- generateNoiseImage(rnorm(max(p$patchIdx)), p)
+  expect_false(all(result[, 1] == result[, 2]))
+})


### PR DESCRIPTION
Adopts the optimisation proposed by @hvalev in #122, in the corrected form, with tests.

`generateNoiseImage()` averaged the weighted patch layers with `apply(x, 1:2, mean)`. That is the slowest possible way to do it: `apply` splits the array into `img_size^2` separate vectors and calls `mean()` on each. `rowMeans(x, dims = 2)` computes the same quantity in compiled code.

At 512px with `nscales = 5` (`p$patches` is 512x512x60), median of 7 runs, timing the **whole function call** including building the weighted array:

| variant | time | speedup | peak memory |
|---|---|---|---|
| `apply(x, 1:2, mean)` (before) | 1.658 s | — | 1135 MB |
| @hvalev's corrected reshape | 0.334 s | 5.0x | 933 MB |
| `aperm` + `colMeans` | 0.371 s | 4.5x | 933 MB |
| **`rowMeans(x, dims = 2)`** (this PR) | **0.277 s** | **6.0x** | **805 MB** |

The averaging step *alone* goes from 1.47 s to 0.048 s, about 31x. The reason the function-level number is 6x rather than 31x is that 0.23 s of the remaining time is building `p$patches * array(params[p$patchIdx], dim(p$patches))`, which every variant has to do. This is the same ~6x @hvalev measured in #122.

The reshape and `aperm` variants are correct but have to materialise a permuted or reshaped copy first; `dims = 2` does not, which is where the remaining margin and the ~130 MB come from.

`generateNoiseImage()` is called once per trial during stimulus generation and again for every CI and every z-map, so this compounds across a whole analysis.

## Why #122 could not be merged as submitted

`rowMeans()` on a 3-D array defaults to `dims = 1`, collapsing dimensions 2 **and** 3. The result is a length-`img_size` vector that `array(..., dim = c(n, n))` then silently recycles across every column — no error, just a wrong image. @hvalev posted a corrected form in the review thread in Oct 2023 which was never pushed to the branch. The `dims` argument is doing essential work here and the code comment says so.

## Verification

Checked against an **independent oracle** — the average written as an explicit triple loop, using neither `apply()` nor `rowMeans()`:

- **No axis swap**, tested on a deliberately non-square array (4x6x3); a square one would hide a transposition.
- **Degenerate depth** (single layer): exact.
- **Config sweep**: `{sinusoid, gabor}` x `nscales` 1-3 x 2 seeds. Both the old and new forms sit ~5.6e-17 from the oracle — that is summation order, not error.

## Reproducibility

Not *bit*-identical to `apply()` in general: ~1 ULP, ~1e-19 absolute on pixel values of order 0.01. Nothing that reaches a reported number, but it is documented in `NEWS.md` under "Reproducibility impact" per the standard for this package. **At the golden master's own configuration the results are bit-identical**, and `test-regression-baseline.R` passes unchanged.

## Tests

Three new tests in `test-generateNoiseImage.R`, each confirmed to fail against the `dims = 1` form before being added:

1. per-pixel mean against the triple-loop oracle on a non-square array
2. agreement with the original `apply()` implementation across all 12 sweep configurations, with an absolute bound of 1e-14
3. a guard that the columns are not recycled copies of one another

Full suite: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 140 ]`.

Also adds backlog item 18 for the failing Codecov upload on pushes to `main`.

Closes #122.