### PR TITLE
Add an end-to-end test that the CI recovers a known template

### DIFF
--- a/.session-log.md
+++ b/.session-log.md
@@ -418,4 +418,106 @@ golden master green, ~8 orders of magnitude of headroom against its 1e-8 toleran
 Conclusion: the `dims = 2` form is safe to adopt. Still awaiting Ron's decision on *how*
 (apply ourselves with credit vs. reply to @hvalev first) — see the previous log section.
 
+## 2026-07-27 05:40 UTC — PR #130 merged, #122 answered and adopted as #131
+
+Both deferred decisions were taken by Ron this session.
+
+### Decision 1: #130 merged
+Merged to `main` at `a099fa2`. Backlog items 9, 10, 16 and most of 11.
+
+### Decision 2: #122 — replied first, then adopted ourselves
+Ron asked to comment on the thread rather than act silently. Two comments posted.
+
+**The thread had gone further than the previous session's notes recorded.** Ron had
+already caught the `dims` bug in Oct 2023 (sum of deviations 10980.83) and proposed
+`aperm` + `colMeans`; @hvalev then posted a *correct* reshape form on 2023-10-30 that
+was never pushed to the branch. So the PR diff still showed the broken version while
+the thread already contained a working one. **Read the review comments, not just the
+diff, before summarising a PR.**
+
+Landed as **PR #131** on branch `speed-generatenoiseimage`, not by pushing to the
+contributor's fork: their branch is their fork's `main`, the change needed a NEWS entry
+and tests beyond the one-liner, and it was ~3 years stale. Credit via a
+`Co-authored-by:` trailer. #131 closes #122.
+
+### A measurement error I made and had to correct publicly
+The first benchmark precomputed the weighted patch array *outside* the timed call, so it
+measured only the averaging step and I reported **29x**. The whole `generateNoiseImage()`
+call also builds that array (0.23s, unchanged), so end-to-end it is **6.1x** — which is
+exactly what @hvalev reported in 2023. Corrected in the code comment, NEWS.md, the #131
+title and body, a follow-up comment on #122, and a warning banner + struck table added to
+the original #122 comment so the wrong numbers are not read on their own.
+
+**Benchmark the whole call, not the step you changed.** Amdahl's law is not optional.
+
+### New backlog item 18: Codecov
+`test-coverage.yaml` sets
+`fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}`,
+so it tolerates a missing token on PRs but **fails on pushes to `main`** — which is why
+every PR was green while `main` shows red (the #130 merge is the live example). Three
+options written up in `BACKLOG.md`: get a token, delete the workflow, or set
+`fail_ci_if_error: false`. Needs Ron's decision.
+
+## 2026-07-27 06:00 UTC — recovery test split out into its own PR #132
+
+Ron asked for the 512px stimulus/CI demo to become a fast test, then asked that **the
+recovery test land on `main` before any other change**. It had been committed onto
+`speed-generatenoiseimage` (#131); it is now split out.
+
+### PR #132 — `recovery-test` branch, off `main`
+Single cherry-picked commit touching only `tests/testthat/test-recovery.R`, so no
+conflicts. **Verified against `main`'s code**, i.e. the old `apply()` implementation, not
+just the sped-up one — this is the point of the split, and it passes: 5 recovery tests,
+129 in the full suite. Takes 13.3s on `main`; drops to 6.8s once #131 lands, since
+`generateNoiseImage()` is the bottleneck. That timing is the only interaction between
+the two PRs.
+
+### What the test does and why it is built that way
+Simulates an observer whose template is known exactly, runs their 2IFC choices through
+`generateCI()`, asserts the CI correlates with the template.
+
+**The null is calibrated, not a fixed threshold.** With 60 patches and 300 trials a
+random response vector can reach |r| = 0.45 by chance — measured, not assumed — so
+`expect_gt(cor, 0.5)` alone would be flaky or vacuous. The null is the *same responses in
+shuffled order*: it preserves the 1/-1 balance and destroys only the response-to-stimulus
+pairing, which is exactly what the CI exploits. Real CI beats all 20 shuffles; margin
+0.29-0.55 across 10 templates.
+
+**Sensitivity established by mutation, not assertion.** Correct pairing 0.71; sign flip
+-0.74; responses reversed -0.18; shifted one trial 0.24. All caught.
+
+**Documented limitation:** it cannot catch a transformation applied consistently inside
+`generateNoiseImage()` (e.g. a transposition), because the template is built through the
+same function and the error cancels. The oracle test in #131 covers that. An earlier
+draft of the header claimed otherwise; corrected.
+
+### Ordering and what it costs
+Merging #132 first means `main` briefly carries a test that runs ~2x slower than it needs
+to. Harmless, and it buys the stronger property: the recovery test is proven to pass
+independently of the change it was written alongside.
+
+### State
+- `main` at `a099fa2`.
+- **PR #132** (`recovery-test`) — open, CI running. Merge this first.
+- **PR #131** (`speed-generatenoiseimage`) — open at `877dde7`, CI green on the earlier
+  commits. **Needs rebasing onto `main` after #132 merges**, dropping commit `c52b8fc`
+  (the recovery test, now in #132) and `877dde7` (the session-log entry, superseded by
+  this one). What remains is the speedup, the oracle tests, the NEWS entry, backlog 18.
+
+### Next
+1. Merge #132 once green.
+2. Rebase and merge #131.
+3. Backlog 18 (Codecov) — Ron's decision.
+4. Item 11 leftover: `ncores == 1` serial fast path.
+5. Item 12: scaling methods, z-maps, `participants`.
+6. Item 1: CRAN — still the last open P0, still Ron's call.
+
+### Resume commands
+```
+gh pr checks 132 && gh pr checks 131
+Rscript -e 'devtools::install(quiet=TRUE, upgrade="never"); devtools::test()'
+```
+Expect `[ FAIL 0 | PASS 129 ]` on `recovery-test`, `[ FAIL 0 | PASS 145 ]` on
+`speed-generatenoiseimage`.
+
 <!-- END LOG — append new sections above this line -->

--- a/.session-log.md
+++ b/.session-log.md
@@ -470,18 +470,31 @@ conflicts. **Verified against `main`'s code**, i.e. the old `apply()` implementa
 just the sped-up one — this is the point of the split, and it passes: 5 recovery tests,
 129 in the full suite. Takes 13.3s on `main`; drops to 6.8s once #131 lands, since
 `generateNoiseImage()` is the bottleneck. That timing is the only interaction between
-the two PRs.
+the two PRs. (Now 15.9s after raising the permutation null to B=100.)
 
 ### What the test does and why it is built that way
 Simulates an observer whose template is known exactly, runs their 2IFC choices through
 `generateCI()`, asserts the CI correlates with the template.
 
-**The null is calibrated, not a fixed threshold.** With 60 patches and 300 trials a
-random response vector can reach |r| = 0.45 by chance — measured, not assumed — so
-`expect_gt(cor, 0.5)` alone would be flaky or vacuous. The null is the *same responses in
-shuffled order*: it preserves the 1/-1 balance and destroys only the response-to-stimulus
-pairing, which is exactly what the CI exploits. Real CI beats all 20 shuffles; margin
-0.29-0.55 across 10 templates.
+**The null is calibrated, not a fixed threshold.** It is a one-sided Monte Carlo
+permutation test: statistic = cor(vec(CI), vec(template)), null = permuting the response
+labels across trials, which preserves the noise images and the 1/-1 balance and destroys
+only the response-to-stimulus pairing that `generateCI()` exploits. B = 100, so the
+smallest achievable p is 1/101 = 0.0099. Real CI beats the largest of 100 permutations by
+0.26-0.48 across 10 templates.
+
+**Why permutation and not a parametric test on r** — this is the part worth carrying
+forward. A t-test on Pearson r would use df = n_pixels - 2 = 1022 and be wildly
+anticonservative: the basis has 60 patches, so a 32x32 CI has effective dimensionality
+~60, not 1024, and neighbouring pixels are autocorrelated by construction. Measured null
+correlations reach |r| = 0.454, which a parametric test on 1022 df would call
+overwhelmingly significant. Every null CI is built from the same basis, so the null
+inherits the identical autocorrelation — that is what makes it *correct*, not merely
+convenient.
+
+The separate `expect_gt(observed, 0.5)` is not a statistical test but a floor calibrated
+from the observed 0.71-0.84 range. The two are complementary: the permutation asks "is
+there any signal", the threshold catches partial degradation a max-null test could miss.
 
 **Sensitivity established by mutation, not assertion.** Correct pairing 0.71; sign flip
 -0.74; responses reversed -0.18; shifted one trial 0.24. All caught.

--- a/tests/testthat/test-recovery.R
+++ b/tests/testthat/test-recovery.R
@@ -77,14 +77,40 @@ test_that("the CI recovers a simulated observer's template", {
   # 0.5 leaves room for the run-to-run variation without being vacuous.
   expect_gt(observed, 0.5)
 
-  # And it must beat chance. The null here is the same responses in a shuffled
-  # order: that keeps the number of 1s and -1s identical and destroys only the
-  # pairing between a response and the stimulus that produced it, which is
-  # exactly the relationship the CI is supposed to exploit. A fixed threshold
-  # would not do -- with 60 patches and 300 trials a random response vector can
-  # reach |r| = 0.45 by chance, so the null is calibrated rather than assumed.
+  # And it must beat chance. This is a one-sided Monte Carlo permutation test:
+  # the statistic is the correlation above, and the null distribution comes
+  # from permuting the response labels across trials. That keeps the noise
+  # images and the count of 1s and -1s exactly as they are, and destroys only
+  # the pairing between a response and the stimulus that produced it -- which
+  # is the relationship generateCI() exploits, so it is the right thing to
+  # break. Exchangeability holds by construction, since the per-trial
+  # parameter vectors are drawn i.i.d.
+  #
+  # WHY A PERMUTATION TEST AND NOT A PARAMETRIC ONE ON r
+  #
+  # A t-test on Pearson r would take df = n_pixels - 2, here 1022, and be
+  # wildly anticonservative, because the pixels are nowhere near independent.
+  # The noise basis has only 60 patches, so the effective dimensionality of a
+  # 32x32 CI is about 60, not 1024, and neighbouring pixels are strongly
+  # autocorrelated by construction -- that is what a sinusoid basis *is*.
+  #
+  # The size of the error is not subtle. Permuting responses here produces
+  # null correlations reaching |r| = 0.45, which a parametric test on 1022 df
+  # would report as overwhelmingly significant. Any fixed threshold picked
+  # without measuring this would be either flaky or vacuous.
+  #
+  # Every null CI is built from the same basis as the real one, so the null
+  # inherits the identical spatial autocorrelation. That is what makes it the
+  # correct reference distribution rather than merely a convenient one.
+  #
+  # B = 100 puts the smallest achievable p-value at 1/(B+1) = 0.0099. Note the
+  # seed: this is a deterministic regression guard, not live inference, so
+  # that figure is the resolution of the procedure and not a result. What
+  # actually makes the test safe is the margin, measured across 10 different
+  # templates at this B: the real CI beat the largest of 100 permutations by
+  # 0.26 to 0.48, never less.
   set.seed(42)
-  null_cors <- vapply(1:20, function(i) {
+  null_cors <- vapply(1:100, function(i) {
     shuffled <- generateCI(
       stimuli = seq_len(obs$n_trials), responses = sample(obs$responses),
       baseimage = "base", rdata = rdata, save_as_png = FALSE

--- a/tests/testthat/test-recovery.R
+++ b/tests/testthat/test-recovery.R
@@ -1,0 +1,122 @@
+# Does the pipeline actually work? Every other test checks a part in isolation:
+# that a function returns the right shape, errors when it should, or matches a
+# pinned number. None of them checks the thing the package exists to do, which
+# is to recover an observer's internal template from their 2IFC choices.
+#
+# This test simulates an observer whose template is known exactly, feeds their
+# choices through generateCI(), and asks whether the classification image looks
+# like the template they were responding to. If a future refactor breaks the
+# link between responses and parameters -- a sign flip, an off-by-one in the
+# stimulus index, responses paired with the wrong rows -- the shape assertions
+# elsewhere would all still pass and this is the test that would fail.
+#
+# What it does NOT catch, deliberately: any transformation applied consistently
+# by generateNoiseImage() itself, such as a transposition, because the template
+# is built through that same function and the error cancels. The oracle test in
+# test-generateNoiseImage.R covers that; this one covers the wiring around it.
+#
+# Kept small on purpose: 32px, nscales = 2, 300 trials, about 6 seconds.
+
+simulate_observer <- function(rdata, template_seed, response_seed, internal_noise = 1) {
+  e <- new.env()
+  load(rdata, envir = e)
+  p <- e$p
+  params <- e$stimuli_params[["base"]]
+  n_trials <- nrow(params)
+
+  # The observer's template is itself a noise image, so it is exactly
+  # representable in the basis the stimuli are drawn from. That isolates what
+  # is being tested (does the weighting recover it?) from a separate question
+  # (can this basis express an arbitrary picture?).
+  set.seed(template_seed)
+  template <- generateNoiseImage(rnorm(max(p$patchIdx)), p)
+
+  # On each trial the observer picks whichever of the pair looks more like the
+  # template. The inverted stimulus carries exactly the negated noise, so the
+  # sign of the match decides the choice; internal_noise makes them imperfect.
+  stack <- vapply(seq_len(n_trials),
+                  function(i) generateNoiseImage(params[i, ], p),
+                  matrix(0, e$img_size, e$img_size))
+  evidence <- apply(stack, 3, function(z) base::sum(z * template))
+  evidence <- evidence / sd(evidence)
+
+  set.seed(response_seed)
+  responses <- ifelse(evidence + rnorm(n_trials, 0, internal_noise) > 0, 1, -1)
+
+  list(template = template, responses = responses, n_trials = n_trials)
+}
+
+# One stimulus set for the whole file: generating it is the slow part, and all
+# three tests want the same one. Torn down when the file finishes.
+recovery_rdata <- local({
+  dir <- withr::local_tempdir(.local_envir = testthat::teardown_env())
+  png_path <- file.path(dir, "base.png")
+  make_square_png(png_path, size = 32)
+  suppressWarnings(
+    generateStimuli2IFC(
+      base_face_files = list(base = png_path),
+      n_trials = 300, img_size = 32, stimulus_path = dir,
+      seed = 1, ncores = 1, nscales = 2,
+      save_as_png = FALSE, save_rdata = TRUE
+    )
+  )
+  list.files(dir, pattern = "\\.Rdata$", full.names = TRUE)[1]
+})
+
+test_that("the CI recovers a simulated observer's template", {
+  rdata <- recovery_rdata
+  obs <- simulate_observer(rdata, template_seed = 1, response_seed = 1)
+
+  ci <- generateCI(
+    stimuli = seq_len(obs$n_trials), responses = obs$responses,
+    baseimage = "base", rdata = rdata, save_as_png = FALSE
+  )
+  observed <- cor(as.vector(ci$ci), as.vector(obs$template))
+
+  # Measured across 10 different templates the correlation ranged 0.71-0.84;
+  # 0.5 leaves room for the run-to-run variation without being vacuous.
+  expect_gt(observed, 0.5)
+
+  # And it must beat chance. The null here is the same responses in a shuffled
+  # order: that keeps the number of 1s and -1s identical and destroys only the
+  # pairing between a response and the stimulus that produced it, which is
+  # exactly the relationship the CI is supposed to exploit. A fixed threshold
+  # would not do -- with 60 patches and 300 trials a random response vector can
+  # reach |r| = 0.45 by chance, so the null is calibrated rather than assumed.
+  set.seed(42)
+  null_cors <- vapply(1:20, function(i) {
+    shuffled <- generateCI(
+      stimuli = seq_len(obs$n_trials), responses = sample(obs$responses),
+      baseimage = "base", rdata = rdata, save_as_png = FALSE
+    )
+    cor(as.vector(shuffled$ci), as.vector(obs$template))
+  }, numeric(1))
+
+  expect_gt(observed, max(null_cors))
+})
+
+test_that("a more reliable observer yields a better CI than a noisier one", {
+  rdata <- recovery_rdata
+  clean <- simulate_observer(rdata, 2, 1, internal_noise = 0.2)
+  noisy <- simulate_observer(rdata, 2, 1, internal_noise = 4.0)
+
+  ci_of <- function(o) {
+    ci <- generateCI(seq_len(o$n_trials), o$responses, "base", rdata,
+                     save_as_png = FALSE)
+    cor(as.vector(ci$ci), as.vector(o$template))
+  }
+  expect_gt(ci_of(clean), ci_of(noisy))
+})
+
+test_that("antiCI is the negation of the CI", {
+  rdata <- recovery_rdata
+  obs <- simulate_observer(rdata, template_seed = 3, response_seed = 1)
+
+  args <- list(stimuli = seq_len(obs$n_trials), responses = obs$responses,
+               baseimage = "base", rdata = rdata, save_as_png = FALSE)
+  ci <- do.call(generateCI, args)
+  anti <- do.call(generateCI, c(args, list(antiCI = TRUE)))
+
+  expect_equal(anti$ci, -ci$ci)
+  expect_lt(cor(as.vector(anti$ci), as.vector(obs$template)), -0.5)
+})


### PR DESCRIPTION
Every existing test checks a part in isolation: a returned shape, an error that should fire, a pinned number. None of them checks the thing the package exists to do — recover an observer's internal template from their 2IFC choices.

`tests/testthat/test-recovery.R` simulates an observer whose template is known exactly, runs their choices through `generateCI()`, and asserts the classification image looks like the template they were responding to.

## The statistical test, and why it is a permutation test

A one-sided Monte Carlo permutation test. The statistic is the Pearson correlation between the vectorized CI and the vectorized template; the null comes from permuting the response labels across trials, which keeps the noise images and the count of 1s/-1s exactly as they are and destroys only the pairing between a response and the stimulus that produced it. That pairing is what `generateCI()` exploits, so it is the right thing to break. Exchangeability holds by construction, since the per-trial parameter vectors are drawn i.i.d.

**Why not a parametric test on r.** A t-test would take df = n_pixels - 2 = 1022 and be wildly anticonservative, because the pixels are nowhere near independent: the noise basis has only 60 patches, so the effective dimensionality of a 32x32 CI is about 60, not 1024, and neighbouring pixels are strongly autocorrelated by construction — that is what a sinusoid basis *is*.

The size of that error is not subtle. **Permuting responses produces null correlations reaching |r| = 0.454**, which a parametric test on 1022 df would report as overwhelmingly significant. Any fixed threshold picked without measuring this would be either flaky or vacuous.

Every null CI is built from the same basis as the real one, so the null inherits the identical spatial autocorrelation. That is what makes it the correct reference distribution rather than merely a convenient one.

**B = 100**, putting the smallest achievable p-value at 1/(B+1) = 0.0099. The call is seeded, so this is a deterministic regression guard rather than live inference — that figure is the resolution of the procedure, not a result. What makes the test safe is the margin: measured across 10 different templates, the real CI beat the largest of 100 permutations by **0.26 to 0.48**, never less.

There is also a plain `expect_gt(observed, 0.5)`. That one is not a statistical test — it is a floor calibrated from the observed 0.71–0.84 range. The two are complementary: the permutation catches "is there any signal at all" without guessing a number, while the fixed threshold catches partial degradation that a max-null comparison could miss.

## Sensitivity, checked by mutation

Rather than trust that the test would catch a regression, I broke the wiring four ways:

| wiring | cor(CI, template) | caught? |
|---|---|---|
| correct pairing | 0.71 | — |
| response sign flipped | -0.74 | yes |
| responses reversed | -0.18 | yes |
| responses shifted one trial | 0.24 | yes |

All three mutations land far below the 0.5 threshold, and below the permutation null too.

## What it deliberately does not catch

Any transformation applied consistently inside `generateNoiseImage()` — a transposition, say — because the template is built through that same function and the error cancels. That is documented in the file header, and the oracle test in #131 covers it. This test covers the wiring around it.

## Cost

32px, `nscales = 2`, 300 trials, one stimulus set shared across the whole file: **15.9s** on `main` today. It drops by roughly half once #131 lands, since the bottleneck is `generateNoiseImage()`.

This is split out of #131 so it can land on `main` first; #131 will be rebased on top of it.