### PR TITLE
Item 12: cover scaling, z-maps and participants; fix three plotZmap bugs

### DIFF
--- a/.session-log.md
+++ b/.session-log.md
@@ -791,4 +791,51 @@ components". Left deliberately: it is a release decision belonging with Ron's go
 4. Version → 1.1.0 + date `NEWS.md`, then win-builder + rhub. **Ron submits personally.**
 5. Item 21: post, after the CRAN outcome.
 
+## 2026-07-27, ~08:45 UTC — item 12 done; three new bugs found by writing the tests
+
+#134 merged (squash), `main` @ `171a3f8`. Then item 12 — and it paid for itself.
+
+### `test-scaling.R` (15 assertions)
+Each method tested against its defining property, not a stored number: `none` is the
+identity, `constant` is `(ci+k)/2k` and puts zero at mid grey, `matched` reproduces the
+base image's range, `independent` is `constant` with `k = max(abs(ci))` and touches
+exactly one boundary. Plus both warning paths.
+
+The one that matters most: **scaling changes only `$scaled`, never `$ci`.** Published
+numbers come from `$ci`; if a scaling method ever leaked into it, results would depend on
+a display choice.
+
+### `test-generateCI-paths.R` — three real bugs, all in `plotZmap()`
+Writing these found bugs in code nobody suspected:
+
+1. **`zmapdecoration = FALSE` was entirely dead on R >= 4.2.** The branch used
+   `if (bgimage != '')` on an image matrix — a length-`img_size²` condition. `generateCI()`
+   *always* passes a background image, so this path could never run. **Same root cause as
+   the known `mask` bug (item 6)**; the decorated branch nine lines above already used
+   `identical()`. Worth remembering: that class of bug was not a one-off.
+2. **`plot.new()` before `par(mar = c(0,0,0,0))`.** `plot.new()` rejects a device too small
+   for the current margins, so z-maps below ~100px died with `figure margins too large` —
+   and `generateCI()` sizes the device to `img_size`. Checked the visual consequence rather
+   than assuming: at 512px output is **identical** either way (canvas coverage 1.0 in both),
+   so this is purely an error fix, not a rendering change. My first guess — that images
+   were being inset — was wrong, and I verified before writing it down.
+3. **`zmaptargetpath` was accepted, documented, and never forwarded** to `plotZmap()`. Every
+   z-map went to `./zmaps` regardless.
+
+### Verification discipline
+Both new `plotZmap` regression tests were confirmed to fail without their fix, with exactly
+the expected errors (`the condition has length > 1`, `figure margins too large`).
+**Note the trap:** a plain `git stash` reverts the *tests* too, so the run passes
+vacuously. Use `git stash push -- R/` to revert only the source.
+
+### State
+**177 tests pass, 0 skipped, 14.6s.** Golden master green — no numeric output changed.
+`R CMD check --as-cran`: still 2 NOTEs, no new ones. Branch `test-coverage-item12`.
+
+### Next
+1. Merge the item-12 PR (**squash**).
+2. Item 22: Medium walkthrough → vignette.
+3. Version → 1.1.0 + date `NEWS.md`, then win-builder + rhub. **Ron submits personally.**
+4. Item 21: post, after the CRAN outcome.
+
 <!-- END LOG — append new sections above this line -->

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -328,21 +328,44 @@ Several related problems in one area:
       Verified: a mid-loop failure now leaks zero connections (issue #50).
 - [ ] Skip the cluster entirely when `ncores == 1`.
 
-### 12. Fill out the test suite
-A testthat suite now exists (84 tests) covering the pure functions, light I/O paths, and
-an end-to-end smoke test. Gaps worth closing:
+### 12. Fill out the test suite  ✅ **DONE**
+A testthat suite now exists (**177 tests**) covering the pure functions, light I/O paths,
+and an end-to-end smoke test. Every gap listed below is now closed — and closing the last
+two turned up three previously unknown bugs in `plotZmap()`, which is the argument for
+writing tests for code that "obviously works":
 
 - [x] **Lock in the InfoVal formula.** Done — pinned in `test-regression-baseline.R`.
       See the note under item #17 — the implementation is
       currently correct per the published erratum, but *nothing tests it*, so a future
       refactor could silently regress a published metric.
-- [ ] Cover the `scaling` methods (`none`/`constant`/`matched`/`independent`) — currently
-      only `independent` is meaningfully exercised, and scaling choice is the most
-      documented user-facing decision in the package.
+- [x] **Cover the `scaling` methods. Done** — `test-scaling.R`, 15 assertions. Each method
+      is tested against the property that defines it (`none` is the identity; `constant` is
+      `(ci + k)/2k` and centres zero at mid grey; `matched` reproduces the base image's
+      range; `independent` is `constant` with `k = max(abs(ci))` and touches exactly one
+      boundary), plus the warning paths for a too-small constant and an unrecognised
+      method. The load-bearing one is last: **scaling must change only `$scaled`, never
+      `$ci`** — published numbers come from `$ci`, so a leak there would make results
+      depend on a display choice.
 - [x] Cover `mask` handling in `generateCI()` — **done**, now that item 6 is fixed; see
       `test-fixed-bugs.R`.
-- [ ] Cover the `zmap = TRUE` paths (`quick` and `t.test`).
-- [ ] Cover `participants` (per-participant → group averaging).
+- [x] **Cover the `zmap = TRUE` paths. Done** — `test-generateCI-paths.R`. **Writing these
+      found three real bugs, all now fixed** (see `NEWS.md`):
+      1. `plotZmap()`'s undecorated branch used `if (bgimage != '')` on an image matrix —
+         a length-`img_size^2` condition, an error on R >= 4.2. `generateCI()` always
+         passes a background image, so `zmapdecoration = FALSE` was **entirely dead**.
+         Same root cause as item 6; the decorated branch already used `identical()`.
+      2. `plot.new()` ran *before* `par(mar = c(0,0,0,0))`, and it rejects a device too
+         small for the current margins — so z-maps below roughly 100px failed with
+         `figure margins too large`. Verified the ordering is the whole cause, and
+         verified rendered output at 512px is **unchanged**, so this is not a visual
+         change.
+      3. `zmaptargetpath` was documented and accepted but never forwarded to `plotZmap()`,
+         so every z-map went to `./zmaps` regardless.
+- [x] **Cover `participants`. Done** — asserts the group CI equals the mean of
+      independently computed per-participant CIs, that an **unbalanced** design makes
+      per-participant averaging diverge from trial pooling (the reason the argument
+      exists, and a check that the test is not vacuous), and that `save_individual_cis`
+      writes one PNG per participant.
 
 ### 18. The Codecov CI step fails without a repository token  ✅ **FIXED**
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,19 @@
 
 ## Bug fixes
 
+- `generateCI(zmap = TRUE, zmapdecoration = FALSE)` works at all. The undecorated
+  branch of `plotZmap()` tested its background image with `if (bgimage != '')`, a
+  condition of length `img_size^2`, which R >= 4.2 treats as an error rather than
+  silently taking the first element. `generateCI()` always supplies a background
+  image, so this path could never run. Same root cause as the `mask` bug above; the
+  decorated branch already used `identical()`.
+- `plotZmap(decoration = FALSE)` works on small images. `plot.new()` was called
+  before the margins were reset to zero, and it rejects a device too small to hold
+  the default margins, so any z-map below roughly 100 pixels failed with
+  `figure margins too large`. Rendered output at usual sizes is unchanged.
+- `generateCI(zmaptargetpath = ...)` is honoured. The argument was documented and
+  accepted but never forwarded to `plotZmap()`, so z-maps were always written to
+  `./zmaps` relative to the working directory regardless of what was requested.
 - `generateStimuli2IFC()` now validates that the base image matches `img_size`, with an
   error naming the file and both sizes, instead of failing inside a parallel worker with
   `non-conformable arrays` (#124).

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -320,10 +320,13 @@ generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
       # Create Z-map
       zmap <- sign(ci) * abs(qnorm(pmap/2))
     }
-    # Pass zmap object to plotZmap for plotting
+    # Pass zmap object to plotZmap for plotting. targetpath was previously not
+    # forwarded, so the documented zmaptargetpath argument was silently ignored
+    # and every z-map went to plotZmap()'s own default ('zmaps', relative to the
+    # working directory) no matter what the caller asked for.
     plotZmap(zmap = zmap, bgimage = combined, filename = baseimage,
              sigma = sigma, threshold = threshold, size = img_size,
-             decoration = zmapdecoration)
+             decoration = zmapdecoration, targetpath = zmaptargetpath)
   }
 
   # Return data

--- a/R/plotZmap.R
+++ b/R/plotZmap.R
@@ -95,13 +95,26 @@ plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, deco
     # Without decoration
   }
   if (!decoration) {
-    # Initialize plot without margins
-    plot.new()
+    # Initialize plot without margins. The order matters: plot.new() validates
+    # that the current margins fit inside the device, and the default margins
+    # (c(5.1, 4.1, 4.1, 2.1) *lines*) do not fit a small one. Setting them after
+    # plot.new(), as this did, meant any device below roughly 100 px failed with
+    # "figure margins too large" -- and generateCI() sizes the device to
+    # img_size, so small stimulus sets could not produce a z-map at all.
+    # Rendered output at usual sizes is unchanged: par(mar=) still takes effect
+    # before plot.window() either way.
     par(mar = c(0, 0, 0, 0))
+    plot.new()
     plot.window(xlim = c(0, 1), ylim = c(0, 1), xaxs = 'i', yaxs = 'i')
 
-    # If specified, add bgimage
-    if (bgimage != '') {
+    # If specified, add bgimage. Must be identical(), not !=: bgimage is normally
+    # an image matrix, so `bgimage != ''` is a condition of length img_size^2.
+    # R >= 4.2 makes that an error rather than silently using the first element,
+    # so this branch could not run at all with a background image -- which is
+    # every call from generateCI(), as it always passes the combined CI. The
+    # decoration = TRUE branch above already used identical(); this one was
+    # missed. Same root cause as the `mask` bug in BACKLOG.md item 6.
+    if (!identical(bgimage, '')) {
       rasterImage(bgimage, 0, 0, 1, 1)
     }
     # Add Z-map

--- a/tests/testthat/test-generateCI-paths.R
+++ b/tests/testthat/test-generateCI-paths.R
@@ -1,0 +1,138 @@
+# Coverage for the two branches of generateCI() that a plain call never reaches:
+# the `participants` two-step averaging, and the two z-map methods.
+#
+# Both were previously untested. Between them they account for most of the
+# conditional logic in generateCI(), including a second parallel loop.
+
+# --------------------------------------------------------------------------
+# participants: per-participant CIs, then average
+# --------------------------------------------------------------------------
+
+test_that("participants averages per-participant CIs rather than pooling trials", {
+  tmp <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+
+  responses <- rep(c(1, -1), 6)
+  pid <- rep(c("a", "b", "c"), each = 4)
+
+  group <- generateCI(
+    stimuli = 1:12, responses = responses, baseimage = "base", rdata = rdata,
+    participants = pid, save_as_png = FALSE, n_cores = 1
+  )
+
+  # Compute each participant's CI independently, then average by hand. The whole
+  # point of the `participants` argument is that this is *not* the same thing as
+  # pooling every trial, whenever participants contribute unequal trial counts.
+  per_pid <- lapply(split(seq_along(pid), pid), function(rows) {
+    generateCI(
+      stimuli = rows, responses = responses[rows], baseimage = "base",
+      rdata = rdata, save_as_png = FALSE, n_cores = 1
+    )$ci
+  })
+  by_hand <- Reduce(`+`, per_pid) / length(per_pid)
+
+  expect_equal(group$ci, by_hand)
+})
+
+test_that("participants and pooled trials diverge when the design is unbalanced", {
+  # Guards the reason the argument exists. With a balanced design the two routes
+  # coincide and this test would be vacuous, so the design here is deliberately
+  # lopsided: one participant contributes 8 trials, the other 2.
+  tmp <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 10, nscales = 1, seed = 1)
+
+  responses <- c(rep(1, 8), rep(-1, 2))
+  pid <- c(rep("a", 8), rep("b", 2))
+
+  by_participant <- generateCI(
+    stimuli = 1:10, responses = responses, baseimage = "base", rdata = rdata,
+    participants = pid, save_as_png = FALSE, n_cores = 1
+  )$ci
+
+  pooled <- generateCI(
+    stimuli = 1:10, responses = responses, baseimage = "base", rdata = rdata,
+    save_as_png = FALSE, n_cores = 1
+  )$ci
+
+  # Averaging participant CIs weights each person equally; pooling weights each
+  # trial equally. The heavy contributor dominates the pooled version.
+  expect_false(isTRUE(all.equal(by_participant, pooled)))
+})
+
+test_that("save_individual_cis writes one PNG per participant", {
+  tmp <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+
+  target <- file.path(tmp, "cis")
+  generateCI(
+    stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
+    rdata = rdata, participants = rep(c("a", "b", "c"), each = 4),
+    save_individual_cis = TRUE, save_as_png = FALSE, targetpath = target,
+    n_cores = 1
+  )
+
+  written <- list.files(file.path(target, "individual_cis"), pattern = "\\.png$")
+  expect_setequal(written, c("ci_a.png", "ci_b.png", "ci_c.png"))
+})
+
+# --------------------------------------------------------------------------
+# z-maps
+# --------------------------------------------------------------------------
+
+test_that("zmapmethod = 'quick' returns a thresholded z-map", {
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+
+  res <- generateCI(
+    stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
+    rdata = rdata, save_as_png = FALSE, zmap = TRUE, zmapmethod = "quick",
+    threshold = 1, zmapdecoration = FALSE, n_cores = 1
+  )
+
+  expect_true("zmap" %in% names(res))
+  expect_equal(dim(res$zmap), c(32, 32))
+
+  # Everything below the threshold is blanked, everything kept is above it.
+  kept <- res$zmap[!is.na(res$zmap)]
+  expect_true(length(kept) > 0)
+  expect_true(all(abs(kept) >= 1))
+})
+
+test_that("zmapmethod = 't.test' returns a z-map of per-pixel test statistics", {
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+
+  res <- generateCI(
+    stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
+    rdata = rdata, save_as_png = FALSE, zmap = TRUE, zmapmethod = "t.test",
+    zmapdecoration = FALSE, n_cores = 1
+  )
+
+  expect_equal(dim(res$zmap), c(32, 32))
+  expect_false(anyNA(res$zmap))
+
+  # This method is not thresholded, and its sign is taken from the CI itself.
+  expect_equal(sign(res$zmap), sign(res$ci))
+})
+
+test_that("a z-map is written where zmaptargetpath asks for it", {
+  # Regression test. zmaptargetpath was documented and accepted but never passed
+  # through to plotZmap(), so every z-map landed in ./zmaps relative to the
+  # working directory no matter what the caller asked for. Assert the intended
+  # behaviour, never the old one.
+  tmp <- withr::local_tempdir()
+  withr::local_dir(tmp)
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+
+  target <- file.path(tmp, "my_zmaps")
+  generateCI(
+    stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
+    rdata = rdata, save_as_png = FALSE, zmap = TRUE, threshold = 1,
+    zmaptargetpath = target, zmapdecoration = FALSE, n_cores = 1
+  )
+
+  expect_true(file.exists(file.path(target, "base.png")))
+  expect_false(dir.exists(file.path(tmp, "zmaps")))
+})

--- a/tests/testthat/test-plotZmap.R
+++ b/tests/testthat/test-plotZmap.R
@@ -10,6 +10,38 @@ test_that("plotZmap writes a PNG file", {
   expect_true(file.exists(file.path(tmp, "zmap.png")))
 })
 
+test_that("decoration = FALSE works with a background image", {
+  # Regression test. This branch used `if (bgimage != '')`, and bgimage is
+  # normally an image matrix, so the condition had length img_size^2 -- an error
+  # on R >= 4.2 rather than a silent first-element match. Every generateCI() call
+  # passes a background image, so the whole undecorated path was dead. Same root
+  # cause as the `mask` bug (BACKLOG.md item 6).
+  tmp <- withr::local_tempdir()
+
+  plotZmap(
+    zmap = matrix(5, 8, 8), bgimage = matrix(0.5, 8, 8), sigma = 3,
+    threshold = 3, decoration = FALSE, targetpath = tmp,
+    filename = "withbg", size = 200
+  )
+
+  expect_true(file.exists(file.path(tmp, "withbg.png")))
+})
+
+test_that("decoration = FALSE works on a device too small for default margins", {
+  # Regression test. plot.new() was called before par(mar = c(0,0,0,0)), and
+  # plot.new() rejects a device that cannot fit the current margins. Since
+  # generateCI() sizes the device to img_size, small stimulus sets could not
+  # produce a z-map at all ("figure margins too large").
+  tmp <- withr::local_tempdir()
+
+  plotZmap(
+    zmap = matrix(5, 8, 8), sigma = 3, threshold = 3, decoration = FALSE,
+    targetpath = tmp, filename = "small", size = 32
+  )
+
+  expect_true(file.exists(file.path(tmp, "small.png")))
+})
+
 test_that("mismatched mask and zmap dimensions error", {
   tmp <- withr::local_tempdir()
 

--- a/tests/testthat/test-scaling.R
+++ b/tests/testthat/test-scaling.R
@@ -1,0 +1,113 @@
+# Coverage for the four scaling methods of generateCI().
+#
+# Scaling is the most consequential user-facing choice in this package -- it
+# decides what a classification image actually looks like, and generateCI()'s
+# roxygen header spends most of its length on it. Each method is tested against
+# the mathematical property that defines it rather than against a stored number,
+# so these tests say what each method is *for* and stay meaningful if the
+# implementation is rewritten.
+#
+# The single most important property is the last one: scaling must never touch
+# `ci`. Published results are computed from `ci`; `scaled` exists for display.
+
+make_ci_fixture <- function(env = parent.frame()) {
+  tmp <- withr::local_tempdir(.local_envir = env)
+  rdata <- make_fixture_rdata(tmp, img_size = 32, n_trials = 12, nscales = 1, seed = 1)
+  list(tmp = tmp, rdata = rdata, responses = rep(c(1, -1), 6))
+}
+
+ci_with_scaling <- function(f, ...) {
+  generateCI(
+    stimuli = seq_along(f$responses), responses = f$responses,
+    baseimage = "base", rdata = f$rdata, save_as_png = FALSE, ...
+  )
+}
+
+test_that("scaling = 'none' leaves the CI untouched", {
+  f <- make_ci_fixture()
+  res <- ci_with_scaling(f, scaling = "none")
+
+  expect_identical(res$scaled, res$ci)
+})
+
+test_that("scaling = 'constant' applies (ci + k) / 2k and centres zero at 0.5", {
+  f <- make_ci_fixture()
+  k <- 0.5
+  res <- ci_with_scaling(f, scaling = "constant", scaling_constant = k)
+
+  expect_equal(res$scaled, (res$ci + k) / (2 * k))
+
+  # The defining property: a pixel the participants pushed neither way lands at
+  # mid grey, so the base image is unchanged there.
+  expect_equal(min(abs(res$scaled - 0.5)), min(abs(res$ci)) / (2 * k))
+})
+
+test_that("scaling = 'constant' warns when the constant is too small to avoid clipping", {
+  f <- make_ci_fixture()
+
+  # A constant well below the CI's own range forces values outside [0, 1], which
+  # png::writePNG() would silently clip. The user has to be told.
+  expect_warning(
+    ci_with_scaling(f, scaling = "constant", scaling_constant = 1e-4),
+    "exceed possible intensity range"
+  )
+})
+
+test_that("scaling = 'matched' matches the intensity range of the base image", {
+  f <- make_ci_fixture()
+  res <- ci_with_scaling(f, scaling = "matched")
+
+  expect_equal(range(res$scaled), range(res$base))
+})
+
+test_that("scaling = 'independent' uses the whole range without clipping", {
+  f <- make_ci_fixture()
+  res <- ci_with_scaling(f, scaling = "independent")
+
+  # Nothing clips...
+  expect_gte(min(res$scaled), 0)
+  expect_lte(max(res$scaled), 1)
+
+  # ...and the constant chosen is the smallest one that achieves that, so the
+  # extreme of whichever tail is larger in absolute value lands exactly on the
+  # boundary. Only one end is touched: the method is symmetric about 0.5, not
+  # a range stretch.
+  touches_boundary <- isTRUE(all.equal(max(res$scaled), 1)) ||
+    isTRUE(all.equal(min(res$scaled), 0))
+  expect_true(touches_boundary)
+
+  # Equivalently: it is 'constant' scaling with k = max(abs(ci)).
+  k <- max(abs(res$ci))
+  expect_equal(res$scaled, (res$ci + k) / (2 * k))
+})
+
+test_that("an unrecognised scaling method warns and falls back to none", {
+  f <- make_ci_fixture()
+
+  expect_warning(
+    res <- ci_with_scaling(f, scaling = "nonesuch"),
+    "not found"
+  )
+  expect_identical(res$scaled, res$ci)
+})
+
+test_that("scaling changes only $scaled, never $ci", {
+  # This is the reproducibility guarantee. Researchers compute infoVal, z-maps
+  # and correlations from $ci; $scaled exists so the CI can be written to a PNG.
+  # If a scaling method ever leaked into $ci, published numbers would depend on
+  # a display choice.
+  f <- make_ci_fixture()
+
+  methods <- list(
+    none = list(scaling = "none"),
+    constant = list(scaling = "constant", scaling_constant = 0.5),
+    matched = list(scaling = "matched"),
+    independent = list(scaling = "independent")
+  )
+
+  cis <- lapply(methods, function(args) do.call(ci_with_scaling, c(list(f), args))$ci)
+
+  for (method in names(cis)) {
+    expect_identical(cis[[method]], cis$none, info = method)
+  }
+})


### PR DESCRIPTION
Closes the last gaps in the test suite (**84 → 177 tests**). Writing the z-map tests
turned up **three bugs in `plotZmap()`** that no existing test touched — which is the
argument for testing code that "obviously works".

## Bugs found and fixed

**1. `generateCI(zmapdecoration = FALSE)` could never run on R ≥ 4.2.**
The undecorated branch tested its background with `if (bgimage != '')`. `bgimage` is an
image matrix, so the condition had length `img_size²` — an error since R 4.2 rather than a
silent first-element match. `generateCI()` *always* passes a background image, so the
entire path was dead.

This is the **same root cause as the known `mask` bug** (backlog item 6), and the decorated
branch nine lines above already used `identical()`. Worth noting: that class of bug was not
a one-off, and a grep for `if (<vector>)` patterns may be worth doing.

**2. `plot.new()` was called before `par(mar = c(0,0,0,0))`.**
`plot.new()` rejects a device too small to hold the current margins, so any z-map below
roughly 100px failed with `figure margins too large` — and `generateCI()` sizes the device
to `img_size`. The function's own comment says "Initialize plot without margins"; the reset
was one line too late.

I checked the visual consequence rather than assuming it. My first guess was that images
were being inset at normal sizes — **that was wrong**: at 512px canvas coverage is 1.0 both
ways, because `par(mar=)` still lands before `plot.window()`. So this fixes an error
without changing any image anyone has already produced.

**3. `zmaptargetpath` was accepted and documented but never forwarded** to `plotZmap()`,
so z-maps always went to `./zmaps` relative to the working directory.

## Tests added

**`test-scaling.R`** — each method tested against the property that defines it rather than
a stored number: `none` is the identity, `constant` is `(ci + k)/2k` and puts zero at mid
grey, `matched` reproduces the base image's range, `independent` is `constant` with
`k = max(abs(ci))` and touches exactly one boundary. Plus both warning paths.

The load-bearing assertion is the last one: **scaling changes only `$scaled`, never `$ci`.**
Researchers compute infoVal, z-maps and correlations from `$ci`, so a leak there would make
published numbers depend on a display choice.

**`test-generateCI-paths.R`** — both z-map methods and the `participants` two-step
averaging. The participants tests assert the group CI equals the mean of independently
computed per-participant CIs, and — so the test is not vacuous — that an **unbalanced**
design makes per-participant averaging genuinely diverge from trial pooling, which is the
reason the argument exists.

## Verification

Both new `plotZmap` regression tests were confirmed to fail without their fix, with exactly
the expected errors (`the condition has length > 1`, `figure margins too large`).

*Trap worth recording: a plain `git stash` reverts the tests too, so the run passes
vacuously. Use `git stash push -- R/` to revert only the source.*

**Reproducibility impact: none.** The golden master is unchanged; 177 tests pass with 0
skips in 14.6s. `R CMD check --as-cran` still reports the same 2 NOTEs, no new ones.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>