### PR TITLE
Item 22: port the walkthrough into an executing vignette

### DIFF
--- a/.session-log.md
+++ b/.session-log.md
@@ -864,26 +864,28 @@ Three things needed fixing during authoring, each caught by *looking at the outp
   span only ±1.65 and the **default `threshold = 3` returns a blank map**. Documented,
   because a user would read blank as "no signal" rather than "wrong ruler".
 
-### A fourth bug — and Ron was right to question it
-`autoscale()` replaced `$scaled` but left **`$combined` stale**, so the returned object's
-two fields described different images. Via `batchGenerateCI()` (which scales `'none'`
-then autoscales) `$combined` was an overlay of *unscaled* noise — nearly invisible — and
-disagreed with the `_autoscaled.png` the same call wrote to disk.
+### Not a fourth bug — `autoscale()`'s `$combined` is intentional
+I flagged `autoscale()` leaving `$combined` untouched as a fourth bug and changed it.
+**Ron overruled: it is intended.** `$combined` is meant to stay as the caller supplied it,
+so a combination made before autoscaling survives the call and existing scripts keep
+plotting the same image. `$scaled` is the field that carries the autoscaled result.
 
-Ron pushed back: "Not sure it's a bug or intentional." Fair, and unlike the three
-`plotZmap` bugs it is genuinely arguable — `autoscale()`'s own `@return` only ever
-promised `$scaled`, and its example input has no `$combined`. Against that,
-`batchGenerateCI()` *documents* `$combined` and autoscales by default. Read as an
-oversight at the seam between two functions.
+**The change was reverted.** `NEWS.md`'s "Behaviour change" section is gone, and the
+behaviour is now *documented* instead — in `?autoscale` (with the
+`(ci$scaled + ci$base) / 2` recipe for the overlay, which is exactly what
+`save_as_pngs = TRUE` writes) and in the vignette. Two tests pin it: one asserting
+`$combined` is left identical, one asserting the written PNG *is* built from the
+autoscaled noise. The first carries a note not to "fix" a failure by rewriting
+`$combined`.
 
-**Resolution: fixed, but filed under a separate "Behaviour change" heading in `NEWS.md`,
-not under bug fixes**, because it changes values returned to existing scripts. No
-statistical result moves — `$ci` is untouched and infoVal/z-maps/correlations all derive
-from it. The lesson: when a fix is arguable, the honest move is to document it as a
-change rather than quietly relabel it a bug.
+**Two lessons.** First, he was right to push back and I was right not to assert it as
+clear-cut — it was flagged as arguable and filed separately rather than slipped in with
+the three unambiguous `plotZmap` bugs, which is why reverting cost nothing. Second: the
+real user-facing problem was never the code, it was that nothing said which field to look
+at. Documentation plus a test was the correct fix all along.
 
 ### State
-**181 tests pass, 0 skips, 15.1s.** `--as-cran`: still 2 NOTEs. README and
+**180 tests pass, 0 skips, 14.5s.** `--as-cran`: still 2 NOTEs. README and
 `getting-started.Rmd` now point at the walkthrough first; the Medium link is demoted to
 further reading, not removed, so its inbound links survive.
 

--- a/.session-log.md
+++ b/.session-log.md
@@ -838,4 +838,59 @@ vacuously. Use `git stash push -- R/` to revert only the source.
 3. Version → 1.1.0 + date `NEWS.md`, then win-builder + rhub. **Ron submits personally.**
 4. Item 21: post, after the CRAN outcome.
 
+## 2026-07-27, ~09:30 UTC — item 22: walkthrough vignette; a fourth (arguable) bug
+
+#135 merged (squash), `main` @ `b7cb6d9`. Then item 22.
+
+### The premise proved itself immediately
+Fetched the Medium post to check coverage parity. **Two of its lines no longer work**:
+`autoscale(cis, saveasjpegs = TRUE)` — the argument is now `save_as_pngs` — and
+`install_github("rdotsch/rcicr", ref = "development")`, and there is no `development`
+branch. Exactly the silent drift item 22 predicted, found within minutes.
+
+### `vignettes/reverse-correlation-walkthrough.Rmd`
+Covers the post's ground plus what it lacked: what the four scaling methods do to an
+image, how to pick a z-map threshold, and a **simulated observer with a known template**
+so the vignette shows a recovered signal (r = 0.55) instead of a grey smudge. Builds in
+~7s; both vignettes together are 15s under `R CMD check`.
+
+Three things needed fixing during authoring, each caught by *looking at the output*:
+- The synthetic base was white noise, which drowned every figure. Replaced with a crude
+  Gaussian-blob face — legible, still obviously synthetic, no licence issue.
+- **`image()` auto-stretches its input to the palette**, so all four scaling methods
+  rendered identically and the comparison proved nothing. Fixed with explicit
+  `zlim = c(0, 1)`. Watch for this in any future figure meant to show absolute values.
+- `zmapmethod = "quick"` z-scores *across the pixels of one image*, so its values here
+  span only ±1.65 and the **default `threshold = 3` returns a blank map**. Documented,
+  because a user would read blank as "no signal" rather than "wrong ruler".
+
+### A fourth bug — and Ron was right to question it
+`autoscale()` replaced `$scaled` but left **`$combined` stale**, so the returned object's
+two fields described different images. Via `batchGenerateCI()` (which scales `'none'`
+then autoscales) `$combined` was an overlay of *unscaled* noise — nearly invisible — and
+disagreed with the `_autoscaled.png` the same call wrote to disk.
+
+Ron pushed back: "Not sure it's a bug or intentional." Fair, and unlike the three
+`plotZmap` bugs it is genuinely arguable — `autoscale()`'s own `@return` only ever
+promised `$scaled`, and its example input has no `$combined`. Against that,
+`batchGenerateCI()` *documents* `$combined` and autoscales by default. Read as an
+oversight at the seam between two functions.
+
+**Resolution: fixed, but filed under a separate "Behaviour change" heading in `NEWS.md`,
+not under bug fixes**, because it changes values returned to existing scripts. No
+statistical result moves — `$ci` is untouched and infoVal/z-maps/correlations all derive
+from it. The lesson: when a fix is arguable, the honest move is to document it as a
+change rather than quietly relabel it a bug.
+
+### State
+**181 tests pass, 0 skips, 15.1s.** `--as-cran`: still 2 NOTEs. README and
+`getting-started.Rmd` now point at the walkthrough first; the Medium link is demoted to
+further reading, not removed, so its inbound links survive.
+
+### Next
+1. Merge the item-22 PR (**squash**).
+2. Version → 1.1.0 + date `NEWS.md`, then win-builder + rhub. **Ron submits personally.**
+3. **Ron:** add a pointer to the vignette at the top of the Medium post.
+4. Item 21: post, after the CRAN outcome.
+
 <!-- END LOG — append new sections above this line -->

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -601,7 +601,39 @@ settled, so the post can say where the package actually lives instead of hedging
 are unchanged *and* that two fixes genuinely change infoVal. Flattening that to "nothing
 changed" would be both untrue and less useful to the researcher it is written for.
 
-### 22. Move the Medium walkthrough into the package as a vignette
+### 22. Move the Medium walkthrough into the package as a vignette  ✅ **DONE**
+
+Ported as `vignettes/reverse-correlation-walkthrough.Rmd`. Covers the same ground as the
+Medium post — install, generate stimuli, analyse, batch, scaling, online tasks, citation —
+plus material the post did not have: what the four scaling methods actually do to an image,
+how to read a z-map threshold, and a simulated observer with a known template so the
+walkthrough shows a **recovered signal** (r = 0.55) rather than a grey smudge.
+
+Every chunk executes at build time. Vignette rebuild is 15s for both vignettes together;
+`--as-cran` still reports the same 2 NOTEs.
+
+**Porting it immediately proved the premise.** Two lines of the published tutorial no longer
+work against the current package: `autoscale(cis, saveasjpegs = TRUE)` (the argument is
+`save_as_pngs`) and `install_github("rdotsch/rcicr", ref = "development")` (no such branch).
+That is exactly the silent drift a vignette prevents, since a broken chunk now fails the
+build.
+
+Writing it also surfaced the `autoscale()` `$combined` staleness — the batch CIs rendered
+as a nearly invisible overlay, which is what led to the fix (see `NEWS.md`, "Behaviour
+change"). Documentation that runs is a test.
+
+- [x] Port the walkthrough into a vignette with executing chunks.
+- [x] README and `getting-started.Rmd` now point at the vignette first; the Medium link is
+      demoted to "further reading" rather than removed, so its inbound links keep working.
+- [ ] **Ron:** add a pointer at the top of the Medium post to
+      `vignette("reverse-correlation-walkthrough", package = "rcicr")`. Nothing in the repo
+      can do this.
+- [ ] The Medium URL still trips the CRAN URL NOTE (Medium blocks datacenter IPs). It is
+      explained in `cran-comments.md`. If a reviewer objects, dropping it is now a one-line
+      change in `README.md`, because the content no longer lives only there.
+
+#### Original entry
+
 
 The method walkthrough — the thing a new user is actually sent to read — lives at
 `https://medium.com/@rondotsch/reverse-correlation-image-classification-using-r-a0701648fb0/`,

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -618,9 +618,12 @@ work against the current package: `autoscale(cis, saveasjpegs = TRUE)` (the argu
 That is exactly the silent drift a vignette prevents, since a broken chunk now fails the
 build.
 
-Writing it also surfaced the `autoscale()` `$combined` staleness — the batch CIs rendered
-as a nearly invisible overlay, which is what led to the fix (see `NEWS.md`, "Behaviour
-change"). Documentation that runs is a test.
+Writing it also surfaced a real usability trap: after `batchGenerateCI()` the batch CIs
+rendered as a nearly invisible overlay, because `autoscale()` rewrites `$scaled` and leaves
+`$combined` alone. **That is intended** — Ron confirmed `$combined` is meant to survive the
+call untouched so existing scripts keep plotting the same image — so it is now *documented*
+in `?autoscale` and the vignette, and pinned by a test, rather than "fixed". An initial
+change that rewrote `$combined` was reverted. Documentation that runs is a test.
 
 - [x] Port the walkthrough into a vignette with executing chunks.
 - [x] README and `getting-started.Rmd` now point at the vignette first; the Medium link is

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,26 +6,6 @@
 > (see below) rather than only repairing it. The public API is unchanged, so a
 > 2.0.0 is not warranted.
 
-## Behaviour change
-
-- **`autoscale()` now refreshes `$combined` to match the `$scaled` image it computes.**
-  Previously it replaced `$scaled` and left `$combined` exactly as passed in, so the two
-  fields of the returned object described different images. This mattered most through
-  `batchGenerateCI()` / `batchGenerateCI2IFC()`, which scale with `'none'` before handing
-  over to `autoscale()`: their documented `$combined` was an overlay of the *unscaled*
-  noise, nearly invisible, and it disagreed with the `_autoscaled.png` that the very same
-  call had already written to disk.
-
-  Listed separately from the bug fixes below because it is genuinely arguable rather than
-  clear-cut: `autoscale()`'s own documentation only ever promised to update `$scaled`, and
-  its example input has no `$combined` at all. It reads as an oversight at the seam between
-  the two functions rather than a decision, and the new behaviour makes the returned object
-  agree with the file on disk — but if you plotted `$combined` after `autoscale()`, the
-  image you get now is different (and is the autoscaled one you almost certainly wanted).
-
-  **No statistical result changes.** `$ci` is untouched, and `computeInfoVal2IFC()`,
-  `plotZmap()` and any correlation between CIs all derive from `$ci`, not from `$combined`.
-
 ## Bug fixes
 
 - `generateCI(zmap = TRUE, zmapdecoration = FALSE)` works at all. The undecorated

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,26 @@
 > (see below) rather than only repairing it. The public API is unchanged, so a
 > 2.0.0 is not warranted.
 
+## Behaviour change
+
+- **`autoscale()` now refreshes `$combined` to match the `$scaled` image it computes.**
+  Previously it replaced `$scaled` and left `$combined` exactly as passed in, so the two
+  fields of the returned object described different images. This mattered most through
+  `batchGenerateCI()` / `batchGenerateCI2IFC()`, which scale with `'none'` before handing
+  over to `autoscale()`: their documented `$combined` was an overlay of the *unscaled*
+  noise, nearly invisible, and it disagreed with the `_autoscaled.png` that the very same
+  call had already written to disk.
+
+  Listed separately from the bug fixes below because it is genuinely arguable rather than
+  clear-cut: `autoscale()`'s own documentation only ever promised to update `$scaled`, and
+  its example input has no `$combined` at all. It reads as an oversight at the seam between
+  the two functions rather than a decision, and the new behaviour makes the returned object
+  agree with the file on disk — but if you plotted `$combined` after `autoscale()`, the
+  image you get now is different (and is the autoscaled one you almost certainly wanted).
+
+  **No statistical result changes.** `$ci` is untouched, and `computeInfoVal2IFC()`,
+  `plotZmap()` and any correlation between CIs all derive from `$ci`, not from `$combined`.
+
 ## Bug fixes
 
 - `generateCI(zmap = TRUE, zmapdecoration = FALSE)` works at all. The undecorated

--- a/R/autoscale.R
+++ b/R/autoscale.R
@@ -7,9 +7,20 @@
 #' @param save_as_pngs Boolean, when set to true, the autoscaled noise patterns will be combined with their respective base images and saved as PNGs (using the key of the list as name).
 #' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
 #' @return The input \code{cis} list, with the \code{$scaled} pixel matrix of each element
-#' replaced by its autoscaled version, and \code{$combined} refreshed to match (where a
-#' \code{$base} image is present). The scaling constant that was determined is printed to
-#' the console, not returned.
+#' replaced by its autoscaled version. The scaling constant that was determined is printed
+#' to the console, not returned.
+#'
+#' \strong{Look at \code{$scaled}, not \code{$combined}.} \code{$combined} is left exactly
+#' as it was passed in: autoscaling deliberately does not disturb it, so a combination made
+#' before this call survives unchanged. Only \code{$scaled} reflects the autoscaled result.
+#' If you want the autoscaled noise shown over the base image, build it yourself with
+#' \code{(ci$scaled + ci$base) / 2} — that is exactly what \code{save_as_pngs = TRUE}
+#' writes to disk.
+#'
+#' This matters most after \code{\link{batchGenerateCI}} or
+#' \code{\link{batchGenerateCI2IFC}}, which scale with \code{'none'} before handing over to
+#' this function: their \code{$combined} is therefore an overlay of the \emph{unscaled}
+#' noise and will look almost blank, while \code{$scaled} is the image you want.
 #' @examples
 #' cis <- list(
 #'   participant1 = list(ci = matrix(runif(64, -0.2, 0.2), 8, 8), base = matrix(0.5, 8, 8)),
@@ -37,23 +48,18 @@ autoscale <- function(cis, save_as_pngs=TRUE, targetpath='./cis') {
   for (ciname in names(cis)) {
     cis[[ciname]]$scaled <-  (cis[[ciname]]$ci + constant) / (2*constant)
 
-    # Refresh $combined to match the new $scaled. It used to be left untouched,
-    # so a CI that came from batchGenerateCI() (which scales with 'none' before
-    # handing over to autoscale) kept a $combined built from the *unscaled*
-    # noise -- a nearly invisible overlay -- while its $scaled was correct. The
-    # two fields silently disagreed, and anyone plotting the returned $combined
-    # got the un-autoscaled image. The PNGs written below were always right,
-    # which is why this went unnoticed.
-    if (!is.null(cis[[ciname]]$base)) {
-      cis[[ciname]]$combined <- (cis[[ciname]]$scaled + cis[[ciname]]$base) / 2
-    }
-
-    # Save to PNG if necessary
+    # Note that $combined is deliberately NOT updated here. It stays as the
+    # caller supplied it, so whatever combination was made before autoscaling
+    # survives this call unchanged. Use $scaled to see the autoscaled result;
+    # that is the field this function exists to produce, and it is what the
+    # PNG below is built from. Do not "fix" this by rewriting $combined -- it
+    # would silently change what existing analysis scripts plot.
     if (save_as_pngs) {
+      ci <- (cis[[ciname]]$scaled + cis[[ciname]]$base) / 2
+
       dir.create(targetpath, recursive=T, showWarnings = F)
 
-      png::writePNG(cis[[ciname]]$combined,
-                    paste0(targetpath, '/', ciname, '_autoscaled.png'))
+      png::writePNG(ci, paste0(targetpath, '/', ciname, '_autoscaled.png'))
     }
 
   }

--- a/R/autoscale.R
+++ b/R/autoscale.R
@@ -6,8 +6,10 @@
 #' @param cis List of cis, each of which are a list containing the pixel matrices of at least the noise pattern (\code{$ci}) and if the noise patterns need to be written to PNGs, also the base image (\code{$base}).
 #' @param save_as_pngs Boolean, when set to true, the autoscaled noise patterns will be combined with their respective base images and saved as PNGs (using the key of the list as name).
 #' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
-#' @return The input \code{cis} list, with a \code{$scaled} pixel matrix added to each element. The
-#' scaling constant that was determined is printed to the console, not returned.
+#' @return The input \code{cis} list, with the \code{$scaled} pixel matrix of each element
+#' replaced by its autoscaled version, and \code{$combined} refreshed to match (where a
+#' \code{$base} image is present). The scaling constant that was determined is printed to
+#' the console, not returned.
 #' @examples
 #' cis <- list(
 #'   participant1 = list(ci = matrix(runif(64, -0.2, 0.2), 8, 8), base = matrix(0.5, 8, 8)),
@@ -35,13 +37,23 @@ autoscale <- function(cis, save_as_pngs=TRUE, targetpath='./cis') {
   for (ciname in names(cis)) {
     cis[[ciname]]$scaled <-  (cis[[ciname]]$ci + constant) / (2*constant)
 
-    # Combine and save to PNG if necessary
-    if (save_as_pngs) {
-      ci <- (cis[[ciname]]$scaled + cis[[ciname]]$base) / 2
+    # Refresh $combined to match the new $scaled. It used to be left untouched,
+    # so a CI that came from batchGenerateCI() (which scales with 'none' before
+    # handing over to autoscale) kept a $combined built from the *unscaled*
+    # noise -- a nearly invisible overlay -- while its $scaled was correct. The
+    # two fields silently disagreed, and anyone plotting the returned $combined
+    # got the un-autoscaled image. The PNGs written below were always right,
+    # which is why this went unnoticed.
+    if (!is.null(cis[[ciname]]$base)) {
+      cis[[ciname]]$combined <- (cis[[ciname]]$scaled + cis[[ciname]]$base) / 2
+    }
 
+    # Save to PNG if necessary
+    if (save_as_pngs) {
       dir.create(targetpath, recursive=T, showWarnings = F)
 
-      png::writePNG(ci, paste0(targetpath, '/', ciname, '_autoscaled.png'))
+      png::writePNG(cis[[ciname]]$combined,
+                    paste0(targetpath, '/', ciname, '_autoscaled.png'))
     }
 
   }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ generateCI(
 )
 ```
 
-See [this Medium post](https://medium.com/@rondotsch/reverse-correlation-image-classification-using-r-a0701648fb0/) for a full walkthrough, and [rcicr_examples](https://github.com/rdotsch/rcicr_examples/) for example datasets and scripts.
+## Documentation
+
+Two vignettes ship with the package:
+
+``` r
+vignette("getting-started", package = "rcicr")  # shortest working example
+vignette("reverse-correlation-walkthrough", package = "rcicr")  # the full method
+```
+
+The walkthrough covers designing a study, generating stimuli, computing classification images for several participants, choosing a scaling method, and telling signal from noise. Its code runs when the package is built, so it cannot drift out of date.
+
+For example datasets and analysis scripts, see [rcicr_examples](https://github.com/rdotsch/rcicr_examples/). There is also an older [Medium post](https://medium.com/@rondotsch/reverse-correlation-image-classification-using-r-a0701648fb0/) covering similar ground; the vignette above supersedes it and is the version kept current with the code.
 
 ## Development
 

--- a/man/autoscale.Rd
+++ b/man/autoscale.Rd
@@ -15,9 +15,20 @@ autoscale(cis, save_as_pngs = TRUE, targetpath = "./cis")
 }
 \value{
 The input \code{cis} list, with the \code{$scaled} pixel matrix of each element
-replaced by its autoscaled version, and \code{$combined} refreshed to match (where a
-\code{$base} image is present). The scaling constant that was determined is printed to
-the console, not returned.
+replaced by its autoscaled version. The scaling constant that was determined is printed
+to the console, not returned.
+
+\strong{Look at \code{$scaled}, not \code{$combined}.} \code{$combined} is left exactly
+as it was passed in: autoscaling deliberately does not disturb it, so a combination made
+before this call survives unchanged. Only \code{$scaled} reflects the autoscaled result.
+If you want the autoscaled noise shown over the base image, build it yourself with
+\code{(ci$scaled + ci$base) / 2} — that is exactly what \code{save_as_pngs = TRUE}
+writes to disk.
+
+This matters most after \code{\link{batchGenerateCI}} or
+\code{\link{batchGenerateCI2IFC}}, which scale with \code{'none'} before handing over to
+this function: their \code{$combined} is therefore an overlay of the \emph{unscaled}
+noise and will look almost blank, while \code{$scaled} is the image you want.
 }
 \description{
 Determines optimal scaling constant for a list of CIs

--- a/man/autoscale.Rd
+++ b/man/autoscale.Rd
@@ -14,8 +14,10 @@ autoscale(cis, save_as_pngs = TRUE, targetpath = "./cis")
 \item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
 }
 \value{
-The input \code{cis} list, with a \code{$scaled} pixel matrix added to each element. The
-scaling constant that was determined is printed to the console, not returned.
+The input \code{cis} list, with the \code{$scaled} pixel matrix of each element
+replaced by its autoscaled version, and \code{$combined} refreshed to match (where a
+\code{$base} image is present). The scaling constant that was determined is printed to
+the console, not returned.
 }
 \description{
 Determines optimal scaling constant for a list of CIs

--- a/tests/testthat/test-autoscale.R
+++ b/tests/testthat/test-autoscale.R
@@ -13,33 +13,47 @@ test_that("autoscale picks the constant that covers the widest range across all 
   expect_equal(result$b$scaled, (cis$b$ci + constant) / (2 * constant))
 })
 
-test_that("autoscale refreshes $combined so it agrees with the new $scaled", {
-  # $combined used to be left at whatever the caller passed in, so after
-  # autoscale() the two fields described different images. batchGenerateCI()
-  # scales with 'none' before handing over, so its $combined was an overlay of
-  # the *unscaled* noise -- and it disagreed with the PNG the same call wrote.
+test_that("autoscale leaves $combined untouched and only rewrites $scaled", {
+  # This is intended behaviour, not an oversight, and the test exists to keep it
+  # that way. autoscale() rescales the noise; it does not re-derive the overlay.
+  # Whatever combination the caller made before this call survives it, so an
+  # existing analysis script that plots $combined keeps plotting the same image.
+  # $scaled is the field that carries the autoscaled result.
+  #
+  # If this test fails because someone made autoscale() rewrite $combined, that
+  # is a silent change to what published scripts render -- fix the code, not the
+  # assertion.
+  original_combined <- (matrix(c(-0.2, 0.1, 0, 0.05), 2, 2) + matrix(0.5, 2, 2)) / 2
   cis <- list(
     a = list(
       ci       = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2),
       base     = matrix(0.5, 2, 2),
-      scaled   = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2), # 'none' scaling
-      combined = (matrix(c(-0.2, 0.1, 0, 0.05), 2, 2) + matrix(0.5, 2, 2)) / 2
+      scaled   = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2), # as left by 'none' scaling
+      combined = original_combined
     )
   )
 
   result <- autoscale(cis, save_as_pngs = FALSE)
 
-  expect_equal(result$a$combined, (result$a$scaled + result$a$base) / 2)
-  expect_false(isTRUE(all.equal(result$a$combined, cis$a$combined)))
+  expect_identical(result$a$combined, original_combined)
+  expect_false(isTRUE(all.equal(result$a$scaled, cis$a$scaled)))
 })
 
-test_that("autoscale still works when there is no base image to combine with", {
-  # The documented example passes only $ci and $base; a caller may reasonably
-  # pass neither $combined nor $base, and that must not error.
-  cis <- list(a = list(ci = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2)))
+test_that("autoscale writes a PNG built from the autoscaled noise, not from $combined", {
+  # The file on disk is the autoscaled overlay even though the in-memory
+  # $combined is not: (scaled + base) / 2 is recomputed at save time. Anyone
+  # wanting that image in R should build it the same way.
+  tmp <- withr::local_tempdir()
+  cis <- list(
+    a = list(
+      ci       = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2),
+      base     = matrix(0.5, 2, 2),
+      combined = matrix(0, 2, 2) # deliberately wrong, must not be used
+    )
+  )
 
-  result <- autoscale(cis, save_as_pngs = FALSE)
+  result <- autoscale(cis, save_as_pngs = TRUE, targetpath = tmp)
 
-  expect_equal(result$a$scaled, (cis$a$ci + 0.2) / 0.4)
-  expect_null(result$a$combined)
+  written <- png::readPNG(file.path(tmp, "a_autoscaled.png"))
+  expect_equal(written, (result$a$scaled + result$a$base) / 2, tolerance = 1 / 255)
 })

--- a/tests/testthat/test-autoscale.R
+++ b/tests/testthat/test-autoscale.R
@@ -12,3 +12,34 @@ test_that("autoscale picks the constant that covers the widest range across all 
   expect_equal(result$a$scaled, (cis$a$ci + constant) / (2 * constant))
   expect_equal(result$b$scaled, (cis$b$ci + constant) / (2 * constant))
 })
+
+test_that("autoscale refreshes $combined so it agrees with the new $scaled", {
+  # $combined used to be left at whatever the caller passed in, so after
+  # autoscale() the two fields described different images. batchGenerateCI()
+  # scales with 'none' before handing over, so its $combined was an overlay of
+  # the *unscaled* noise -- and it disagreed with the PNG the same call wrote.
+  cis <- list(
+    a = list(
+      ci       = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2),
+      base     = matrix(0.5, 2, 2),
+      scaled   = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2), # 'none' scaling
+      combined = (matrix(c(-0.2, 0.1, 0, 0.05), 2, 2) + matrix(0.5, 2, 2)) / 2
+    )
+  )
+
+  result <- autoscale(cis, save_as_pngs = FALSE)
+
+  expect_equal(result$a$combined, (result$a$scaled + result$a$base) / 2)
+  expect_false(isTRUE(all.equal(result$a$combined, cis$a$combined)))
+})
+
+test_that("autoscale still works when there is no base image to combine with", {
+  # The documented example passes only $ci and $base; a caller may reasonably
+  # pass neither $combined nor $base, and that must not error.
+  cis <- list(a = list(ci = matrix(c(-0.2, 0.1, 0, 0.05), 2, 2)))
+
+  result <- autoscale(cis, save_as_pngs = FALSE)
+
+  expect_equal(result$a$scaled, (cis$a$ci + 0.2) / 0.4)
+  expect_null(result$a$combined)
+})

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -31,10 +31,10 @@ It works in two stages:
    classification image — visualizes which visual features were systematically
    associated with the participant's choices.
 
-This vignette walks through both stages using a tiny synthetic example. For a full
-walkthrough with a real face photo, see the
-[Medium post](https://medium.com/@rondotsch/reverse-correlation-image-classification-using-r-a0701648fb0/)
-linked from the README; for example datasets and analysis scripts, see
+This vignette walks through both stages using a tiny synthetic example. For the full
+treatment — several participants, scaling choices, z-maps and informational value —
+see `vignette("reverse-correlation-walkthrough", package = "rcicr")`. For example
+datasets and analysis scripts, see
 [rcicr_examples](https://github.com/rdotsch/rcicr_examples/).
 
 ```{r setup}

--- a/vignettes/reverse-correlation-walkthrough.Rmd
+++ b/vignettes/reverse-correlation-walkthrough.Rmd
@@ -1,0 +1,395 @@
+---
+title: "A reverse correlation walkthrough"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{A reverse correlation walkthrough}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.width = 3.2,
+  fig.height = 3.2,
+  dpi = 96
+)
+```
+
+This is the full walkthrough: designing a 2IFC reverse correlation study, generating
+stimuli, computing classification images for several participants, scaling them so
+they can be compared, and deciding whether what you are looking at is signal or noise.
+
+If you only want the shortest possible working example, read
+`vignette("getting-started", package = "rcicr")` instead.
+
+Every code chunk here runs when this vignette is built, so the code cannot silently
+drift out of date as the package changes. That matters: an earlier version of this
+walkthrough lived outside the package, and by the time it was brought in, two of its
+lines no longer worked — `autoscale()`'s argument had been renamed, and the install
+instruction pointed at a branch that no longer exists.
+
+```{r setup}
+library(rcicr)
+```
+
+One small helper, used throughout to display an image matrix:
+
+```{r show-helper}
+# zlim matters more than it looks. image() stretches whatever range it is given
+# across the full palette, so without a fixed zlim every linear rescaling of the
+# same image renders identically -- which would make the scaling comparison
+# below silently meaningless. Pass zlim = c(0, 1) whenever the point is what the
+# pixel values actually are; the default just stretches to the data's own range,
+# which is what you want when only the structure matters.
+show <- function(m, title, zlim = range(m, na.rm = TRUE)) {
+  op <- par(mar = c(0, 0, 1.4, 0))
+  on.exit(par(op))
+  # image() takes [x, y] with y increasing upwards, so a matrix indexed
+  # [row, col] has to be transposed and flipped to display the right way up.
+  image(t(m[nrow(m):1, ]), col = gray.colors(256), axes = FALSE, asp = 1,
+        main = title, zlim = zlim, useRaster = TRUE)
+}
+```
+
+## 1. Installing
+
+`rcicr` was archived on CRAN in 2021 (an undeliverable maintainer email address, not a
+problem with the package), so install it from GitHub:
+
+```{r install, eval = FALSE}
+# install.packages("remotes")
+remotes::install_github("rdotsch/rcicr")
+```
+
+## 2. What the method does
+
+On each trial a participant sees two images side by side. Both are the same base face,
+but one has random visual noise added and the other has *exactly the same noise
+subtracted*. The participant picks whichever looks more like some category — more
+trustworthy, more masculine, more like their own group.
+
+Neither image contains any real signal. But if a participant reliably picks the image
+whose noise happens to resemble their internal idea of "trustworthy", then averaging
+the noise from their chosen images — and subtracting the noise from the ones they
+rejected — makes that idea visible. That average is the **classification image**.
+
+## 3. Generating stimuli
+
+`generateStimuli2IFC()` needs one or more **square** base images. Here we draw a crude
+synthetic face so the vignette is self-contained and needs no image licence; in a real
+study you would pass paths to your face photos.
+
+```{r base-face, fig.width = 2.2, fig.height = 2.2}
+n <- 64
+rows <- matrix(seq(-1, 1, length.out = n), n, n)
+cols <- matrix(seq(-1, 1, length.out = n), n, n, byrow = TRUE)
+x <- cols
+y <- -rows # row indices grow downwards, so flip to make +y point up
+
+face <- exp(-(x^2 / 0.45 + y^2 / 0.75))                            # head
+face <- face - 0.55 * exp(-(((x + 0.3)^2 + (y - 0.25)^2) / 0.012)) # left eye
+face <- face - 0.55 * exp(-(((x - 0.3)^2 + (y - 0.25)^2) / 0.012)) # right eye
+face <- face - 0.35 * exp(-(x^2 / 0.10 + (y + 0.42)^2 / 0.006))    # mouth
+face <- (face - min(face)) / (max(face) - min(face))
+
+base_face <- tempfile(fileext = ".png")
+png::writePNG(face, base_face)
+
+show(face, "synthetic base face", zlim = c(0, 1))
+```
+
+The base image must be **square and already the size you want**: `rcicr` does not resize
+it, and will stop with an error if `img_size` disagrees.
+
+```{r generate-stimuli, results = "hide"}
+stimulus_path <- tempfile("stimuli")
+dir.create(stimulus_path)
+
+generateStimuli2IFC(
+  base_face_files = list(face = base_face),
+  n_trials        = 120,
+  img_size        = 64,
+  stimulus_path   = stimulus_path,
+  seed            = 1,
+  nscales         = 3,
+  ncores          = 1,
+  save_as_png     = FALSE # TRUE in a real study: this writes the actual stimuli
+)
+
+rdata_file <- list.files(stimulus_path, pattern = "\\.Rdata$", full.names = TRUE)[1]
+```
+
+**Real studies are much bigger than this.** The defaults — `n_trials = 770`,
+`img_size = 512`, `nscales = 5` — reflect published practice (Dotsch & Todorov, 2012).
+Everything here is shrunk so the vignette builds in seconds.
+
+With `save_as_png = TRUE` you get two PNGs per trial per base image: `..._ori.png` and
+`..._inv.png`. Those are what you show participants.
+
+### The `.Rdata` file is the important output
+
+That file records the random noise parameters behind every trial. **It is the only link
+between stimulus generation and analysis** — without it, the responses you collect are
+uninterpretable, because nothing else records which noise pattern trial 57 actually was.
+
+Back it up alongside your data. Every analysis function below takes it as `rdata`.
+
+## 4. Collecting responses
+
+Run the task however you like (see "Running the task online" below). What you need back,
+per trial, is:
+
+- the **stimulus number** — which trial of the generated set was shown, and
+- the **response** — `1` if the participant chose the original, `-1` if they chose the
+  inverted one.
+
+To make this walkthrough show a real result rather than a grey smudge, we simulate
+three participants who genuinely have an internal template and respond according to it,
+with different amounts of inconsistency.
+
+```{r simulate}
+e <- new.env()
+load(rdata_file, envir = e)
+params <- e$stimuli_params[["face"]]
+
+# The template is itself a noise image, so it is exactly expressible in the same
+# basis the stimuli are drawn from.
+set.seed(99)
+template <- generateNoiseImage(rnorm(max(e$p$patchIdx)), e$p)
+
+# Each trial's noise image, and how strongly it matches the template.
+stack <- vapply(seq_len(nrow(params)),
+                function(i) generateNoiseImage(params[i, ], e$p),
+                matrix(0, 64, 64))
+evidence <- apply(stack, 3, function(z) base::sum(z * template))
+evidence <- evidence / sd(evidence)
+
+# Three observers with the same template but increasing internal noise: the
+# third is much less consistent than the first.
+set.seed(7)
+simulate <- function(internal_noise) {
+  ifelse(evidence + rnorm(length(evidence), 0, internal_noise) > 0, 1, -1)
+}
+
+responses <- data.frame(
+  participant = rep(c("p01", "p02", "p03"), each = nrow(params)),
+  stimulus    = rep(seq_len(nrow(params)), 3),
+  response    = c(simulate(0.5), simulate(1.5), simulate(3))
+)
+
+head(responses)
+```
+
+Real data goes in exactly this shape: one row per trial per participant.
+
+## 5. Computing one classification image
+
+```{r one-ci}
+ci_p01 <- generateCI(
+  stimuli     = responses$stimulus[responses$participant == "p01"],
+  responses   = responses$response[responses$participant == "p01"],
+  baseimage   = "face",
+  rdata       = rdata_file,
+  save_as_png = FALSE
+)
+
+names(ci_p01)
+```
+
+The returned list has four parts, and the distinction between the first two matters:
+
+- **`ci`** — the raw classification image. **This is the data.** Compute statistics from
+  it.
+- **`scaled`** — `ci` rescaled into the 0–1 range a PNG can store. This is a *display*
+  transformation; which one you pick changes how the image looks, not what it means.
+- **`base`** — the base image.
+- **`combined`** — `scaled` overlaid on `base`. This is what gets written to disk.
+
+Did we recover the template the simulated observer was using?
+
+```{r show-recovery, fig.show = "hold", fig.width = 2.6, fig.height = 2.6}
+show(template, "true template")
+show(ci_p01$ci, "recovered CI")
+```
+
+```{r recovery-cor}
+cor(as.vector(ci_p01$ci), as.vector(template))
+```
+
+With real participants you have no template to compare against — that is the entire
+point of the technique. Section 8 covers how to tell signal from noise when you cannot
+peek at the answer.
+
+`generateCI2IFC()` does the same thing with an older argument list, kept so that
+analysis scripts written years ago still run. New code should use `generateCI()`.
+
+## 6. Scaling
+
+Scaling decides what the image looks like. `generateCI()` offers four methods, and the
+choice is a reporting decision, not a cosmetic one.
+
+```{r scaling-demo, fig.show = "hold", fig.width = 2.1, fig.height = 2.1}
+for (method in c("none", "constant", "matched", "independent")) {
+  res <- generateCI(
+    stimuli     = responses$stimulus[responses$participant == "p01"],
+    responses   = responses$response[responses$participant == "p01"],
+    baseimage   = "face", rdata = rdata_file, save_as_png = FALSE,
+    scaling     = method, scaling_constant = 0.5
+  )
+  # $scaled, not $combined, so the effect of scaling is visible rather than
+  # hidden under the base image -- and zlim fixed to the displayable range, so
+  # that what you see is the actual pixel values.
+  show(res$scaled, method, zlim = c(0, 1))
+}
+```
+
+Those four panels are the argument for taking scaling seriously.
+
+**`none`** leaves the raw CI, whose values straddle zero and span only about ±0.04.
+Nothing in that range is displayable: negative pixels fall outside 0–1 entirely (shown
+blank above) and positive ones are so close to zero they render as near-black. Written
+to a PNG, where out-of-range values are clipped rather than dropped, almost the whole
+image would be black. Scaling is not optional.
+
+**`constant`** with `scaling_constant = 0.5` gives a flat grey — the constant is more
+than ten times the CI's actual range, so every difference is compressed into a sliver of
+the palette. A constant has to be chosen with the data's range in mind; too large
+destroys the signal just as surely as too small clips it.
+
+**`matched`** and **`independent`** both use the available range and look similar here,
+because the base image happens to span nearly 0–1 already. On a real photograph with a
+narrower range they diverge.
+
+- **`independent`** (default) picks, for each image separately, the smallest constant
+  that avoids clipping. Every CI uses its full dynamic range — which means **two CIs
+  scaled this way are not comparable to each other**, because each got a different
+  constant.
+- **`constant`** divides by a fixed constant you choose, so several CIs stay on one
+  scale. Use this, or `autoscale()`, when comparing conditions.
+- **`matched`** matches the CI's intensity range to the base image's. Nonlinear.
+- **`none`** does nothing, leaving values outside 0–1 to be clipped on save.
+
+Whichever you choose, `ci$ci` is untouched. Statistics computed from it are unaffected
+by the display choice.
+
+## 7. Several participants at once
+
+`batchGenerateCI()` splits a data frame by a grouping column and computes one CI per
+group.
+
+```{r batch, results = "hide"}
+cis <- batchGenerateCI(
+  data        = responses,
+  by          = "participant",
+  stimuli     = "stimulus",
+  responses   = "response",
+  baseimage   = "face",
+  rdata       = rdata_file,
+  save_as_png = FALSE
+)
+```
+
+```{r batch-names}
+names(cis)
+```
+
+Use the same `by` mechanism for conditions rather than participants when that is the
+comparison you care about.
+
+Because each of those was scaled independently, they cannot be compared by eye yet.
+`autoscale()` finds one constant that works for all of them without clipping any:
+
+```{r autoscale, fig.show = "hold", fig.width = 2.1, fig.height = 2.1}
+scaled <- autoscale(cis, save_as_pngs = FALSE)
+
+for (nm in names(scaled)) {
+  show(scaled[[nm]]$combined, sub(".*_", "", nm), zlim = c(0, 1))
+}
+```
+
+`p01` should look cleanest and `p03` weakest — they share a template but differ in how
+consistently they applied it, which is what internal noise means in practice.
+
+Note the argument is `save_as_pngs`. Older tutorials show `saveasjpegs`, which no longer
+exists; this is precisely the drift that keeping the walkthrough inside the package
+prevents.
+
+## 8. Is there actually signal?
+
+Two tools, answering different questions.
+
+**`computeInfoVal2IFC()`** gives one number per CI: a z-score for how much stronger this
+CI is than one built from random responding. Values above about 1.96 indicate reliable
+signal.
+
+It needs a reference distribution simulated under the same task parameters, which takes
+a long time to build — so it is shown but not run here:
+
+```{r infoval, eval = FALSE}
+# Slow: simulates `iter` classification images from random responses. Do this once
+# per stimulus set; the result is cached back into the .Rdata file.
+generateReferenceDistribution2IFC(rdata_file, iter = 10000)
+
+computeInfoVal2IFC(target_ci = ci_p01, rdata = rdata_file)
+```
+
+**`plotZmap()`**, or `generateCI(zmap = TRUE)`, answers the spatial question instead:
+*which regions* of the image carry reliable signal.
+
+```{r zmap, results = "hide", fig.width = 3.2, fig.height = 3.2}
+zmap_dir <- tempfile("zmaps")
+
+ci_z <- generateCI(
+  stimuli     = responses$stimulus[responses$participant == "p01"],
+  responses   = responses$response[responses$participant == "p01"],
+  baseimage   = "face", rdata = rdata_file, save_as_png = FALSE,
+  zmap = TRUE, zmapmethod = "quick", threshold = 1.5,
+  zmaptargetpath = zmap_dir, zmapdecoration = FALSE
+)
+```
+
+```{r zmap-show}
+# Pixels that did not clear the threshold are set to NA.
+range(ci_z$zmap, na.rm = TRUE)
+mean(!is.na(ci_z$zmap)) # fraction of the image flagged
+```
+
+**Choose the threshold by looking at the range, not by habit.** `zmapmethod = "quick"`
+z-scores a blurred CI *across the pixels of that one image*, so its values are relative
+to the image's own spatial structure — they are not z-scores against a null distribution,
+and their spread shrinks as the image gets smaller or the blur gets wider. Here the whole
+map spans roughly ±1.7, so the default `threshold = 3` would have returned an entirely
+blank map. That is not evidence of no signal; it is the wrong ruler.
+
+`zmapmethod = "t.test"` is the inferential counterpart: a per-pixel t-test across trials,
+slower, but producing a statistic that does mean what it looks like. Neither method
+corrects for multiple comparisons across pixels, so treat both as exploratory.
+
+## 9. Running the task online
+
+`rcicr` generates stimuli and analyses responses; it does not run experiments. The
+stimulus PNGs are ordinary image files, so any platform that can show two images and
+record a choice will do — Qualtrics, jsPsych, Gorilla, PsychoPy, or a custom page.
+
+Two things to get right:
+
+1. **Record the stimulus number**, not the filename you happened to serve. The number is
+   what indexes into the `.Rdata` file.
+2. **Record which of the pair was chosen** as `1` (original) or `-1` (inverted), and be
+   certain which is which — a systematic flip inverts every classification image you
+   compute, and the result will look like a plausible mental representation of the
+   opposite trait.
+
+Worked examples and analysis scripts:
+<https://github.com/rdotsch/rcicr_examples/>
+
+## 10. Citing
+
+```{r citation, eval = FALSE}
+citation("rcicr")
+```
+
+If you use the technique, cite the method papers as well as the software — see the
+package's `CITATION` file and the README for the relevant references.

--- a/vignettes/reverse-correlation-walkthrough.Rmd
+++ b/vignettes/reverse-correlation-walkthrough.Rmd
@@ -305,15 +305,35 @@ Because each of those was scaled independently, they cannot be compared by eye y
 scaled <- autoscale(cis, save_as_pngs = FALSE)
 
 for (nm in names(scaled)) {
-  show(scaled[[nm]]$combined, sub(".*_", "", nm), zlim = c(0, 1))
+  # $scaled, not $combined -- see the note below.
+  show(scaled[[nm]]$scaled, sub(".*_", "", nm), zlim = c(0, 1))
 }
 ```
 
 `p01` should look cleanest and `p03` weakest — they share a template but differ in how
 consistently they applied it, which is what internal noise means in practice.
 
-Note the argument is `save_as_pngs`. Older tutorials show `saveasjpegs`, which no longer
-exists; this is precisely the drift that keeping the walkthrough inside the package
+### After `autoscale()`, look at `$scaled`
+
+`autoscale()` rewrites `$scaled` and **deliberately leaves `$combined` exactly as it
+was**. That is by design: a combination you made before autoscaling survives the call
+untouched, so an existing analysis script that plots `$combined` keeps producing the same
+image.
+
+It catches people out after `batchGenerateCI()`, though, because that function scales with
+`'none'` before handing over — so its `$combined` is an overlay of the *unscaled* noise and
+looks almost blank. If you want the autoscaled noise over the base image, build it
+yourself:
+
+```{r autoscale-combined, fig.width = 2.4, fig.height = 2.4}
+p01 <- scaled[["face_participant_p01"]]
+show((p01$scaled + p01$base) / 2, "p01 over base", zlim = c(0, 1))
+```
+
+That expression is exactly what `autoscale(save_as_pngs = TRUE)` writes to disk.
+
+Note also that the argument is `save_as_pngs`. Older tutorials show `saveasjpegs`, which no
+longer exists — precisely the drift that keeping this walkthrough inside the package
 prevents.
 
 ## 8. Is there actually signal?


### PR DESCRIPTION
## The `autoscale()` question — resolved, reverted

You confirmed the behaviour is **intended**: `$combined` stays as the caller supplied it,
so a combination made before autoscaling survives the call and existing scripts keep
plotting the same image. `$scaled` carries the autoscaled result.

**The change is reverted.** `R/autoscale.R` now differs from `main` only by comments — no
functional change, and the `NEWS.md` "Behaviour change" entry is gone. Nothing about the
returned object differs from previous releases.

What *was* a real problem is that nothing told users which field to look at. After
`batchGenerateCI()` — which scales with `'none'` before handing over — `$combined` is an
overlay of unscaled noise and looks almost blank, easy to mistake for a broken pipeline.
That is now **documented** in `?autoscale`, including the `(ci$scaled + ci$base) / 2`
recipe for building the overlay yourself, which is exactly what `save_as_pngs = TRUE`
writes to disk. The vignette shows the same.

Two tests pin it: one asserting `$combined` comes back identical, one asserting the written
PNG *is* built from the autoscaled noise. The first carries a note not to "fix" a failure
by rewriting `$combined`.

## The vignette

Covers the Medium post's ground — install, generate, analyse, batch, scaling, running
online, citation — plus what it lacked: what the four scaling methods do to an image, how
to choose a z-map threshold, and a simulated observer with a known template so the
walkthrough shows a **recovered signal (r = 0.55)** instead of a grey smudge.

### The premise proved itself within minutes

Two lines of the published tutorial no longer work against the current package:

- `autoscale(cis, saveasjpegs = TRUE)` — the argument is `save_as_pngs`
- `install_github("rdotsch/rcicr", ref = "development")` — no such branch

Exactly the drift item 22 predicted. Every chunk here executes at build time, so that class
of rot now fails the build instead of misleading a reader.

### Three things caught by looking at the output, not the code

- **`image()` auto-stretches its input to the palette**, so all four scaling methods
  rendered *identically* and the comparison proved nothing. Fixed with explicit
  `zlim = c(0, 1)`.
- **`zmapmethod = "quick"` z-scores across the pixels of one image**, so values here span
  only ±1.65 and the **default `threshold = 3` returns a blank map**. Documented, because a
  reader would take blank as "no signal" rather than "wrong ruler".
- The synthetic base was white noise, which drowned every figure. Replaced with a crude
  Gaussian-blob face — legible, still obviously synthetic, no image licence.

## Docs

`README.md` and `getting-started.Rmd` now point at the vignette first. The Medium link is
**demoted, not removed**, so its inbound links keep working; dropping it is a one-line
change if a reviewer objects to the 403.

**You'll want to add a pointer to the vignette at the top of the Medium post** — nothing in
the repo can do that.

## Checks

180 tests pass, 0 skips, 14.5s. Vignette rebuild 15s for both together.
`R CMD check --as-cran`: same 2 NOTEs, no new ones.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>