### PR TITLE
Release 1.1.0: version bump, dated NEWS.md, last CRAN blocker closed

### DIFF
--- a/.session-log.md
+++ b/.session-log.md
@@ -895,4 +895,51 @@ further reading, not removed, so its inbound links survive.
 3. **Ron:** add a pointer to the vignette at the top of the Medium post.
 4. Item 21: post, after the CRAN outcome.
 
+## 2026-07-27, ~11:20 UTC — 1.1.0 cut; the last mechanical CRAN blocker is gone
+
+#136 merged (squash), `main` @ `e58a548`. Picked up mid-task after an interruption:
+`BACKLOG.md` had uncommitted bookkeeping from #133–#136 sitting in the working tree.
+
+### Two commits on `release-1.1.0` (PR #137)
+Kept separate on purpose, since one is bookkeeping and one is the release:
+1. The stale `BACKLOG.md` write-back — item 11 closed, item 12's 177 → 180, item 22's
+   plan text replaced by a pointer to its live checklist. Plus the
+   `detectCores()`/cgroup over-subscription behaviour recorded as a **known, deliberate
+   trade-off** — the point being that it now reads as a decision rather than as
+   something nobody noticed.
+2. `1.0.1.9000` → `1.1.0`, `NEWS.md` dated, `ChangeLog` and `cran-comments.md` updated.
+
+### The bump was never only mechanical
+- **`ChangeLog` needed an entry even though `NEWS.md` supersedes it.** Someone opening
+  `ChangeLog` first would otherwise conclude 1.0.1 is current. The entry is a pointer,
+  not a duplicate — two changelogs that both claim to be authoritative is worse than one
+  that defers.
+- **`cran-comments.md` had gone stale within the same day.** It said the Medium URL was
+  referenced "from `README.md` and the vignette", which item 22 made untrue: the check
+  output now reads `From: README.md` only. Checked the actual grep rather than trusting
+  the prose. It also now says the walkthrough *ships as a vignette*, which turns the
+  NOTE from "we like this link" into "the content is in the package; the link is
+  courtesy to nine years of citations, drop it if you like" — a much easier ask of a
+  reviewer.
+
+### Verification
+`--as-cran` with both `_R_CHECK_CRAN_INCOMING_*` set: **0/0/2 NOTEs.**
+`Version contains large components` is **gone** — confirmed by reading the incoming-
+feasibility block, not by assuming the bump worked. The two survivors are the
+archived/new-submission pair and the Medium 403. `devtools::test()`: **180 pass, 0 fail,
+0 skip**, golden master green, so no numeric output moved.
+
+### State
+PR #137 open. **Every mechanical CRAN blocker is now closed.** What is left in backlog
+item 1 is judgement, not work: the go/no-go, and the submission itself.
+
+### Next
+1. Merge #137 (**squash**).
+2. win-builder + R-hub — these **upload the tarball to third parties and email Ron**, so
+   they were left unrun pending his say-so. Two `<!-- TODO -->` markers in
+   `cran-comments.md` are waiting on the results.
+3. **Ron:** the CRAN submission, and a pointer at the top of the Medium post to
+   `vignette("reverse-correlation-walkthrough", package = "rcicr")`.
+4. Item 21: post, after the CRAN outcome.
+
 <!-- END LOG — append new sections above this line -->

--- a/.session-log.md
+++ b/.session-log.md
@@ -942,4 +942,50 @@ item 1 is judgement, not work: the go/no-go, and the submission itself.
    `vignette("reverse-correlation-walkthrough", package = "rcicr")`.
 4. Item 21: post, after the CRAN outcome.
 
+## 2026-07-27, ~12:10 UTC — resume-doc audit; the backlog table had drifted
+
+Resumed cold and audited the four docs a future session reads first. `NEWS.md`,
+`ChangeLog`, `DESCRIPTION`, `cran-comments.md` and this log were all current. Two were not.
+
+### `BACKLOG.md`'s "Suggested order of attack" table was five rows wrong
+Items **9, 10, 12, 16 and 22** each carried ✅ FIXED/DONE in their own sections and shipped
+in 1.1.0, but the table above still listed them unstruck as work to do — contradicting the
+file's own header three lines earlier. This is the table the memory file points a cold
+session at as *the* to-do list, so the failure mode was concrete: a resumed session
+re-opens five finished items. Now struck, leaving exactly three live rows (1, 20, 21), none
+of which is code.
+
+Item 20 also contradicted itself: it said "Version contains large components" was "the one
+unticked box below" while that box was `[x]`. Its quoted `--as-cran` block is attributed to
+`main` @ `5428b79`, so it stays as dated evidence — but it is now labelled as the baseline
+run, and the two lines that read as current-state (`1.0.1.9000`, and the URL NOTE's
+`From: inst/doc/getting-started.html, README.md`, which item 22 narrowed to `README.md`)
+are called out as pre-1.1.0.
+
+### Two claims did not survive checking, which is the point of checking
+- Wrote "27-package dependency surface cut to **14**" from the item-9 prose. `DESCRIPTION`
+  says **15**. The round number was inferred (27 − 13) rather than counted; corrected to
+  the actual count.
+- Wrote "every P1 item is fixed". Items **20 and 21 are inside the P1 block** and are open.
+  Reworded to "every P1 *code* item", and the sentence now names 13–15 as the only
+  substantive work left, since "what is actually still open" is the one question this
+  section exists to answer.
+
+Both were mine, in a doc-accuracy commit, in the same edit that was fixing inaccurate docs.
+**Numbers copied from neighbouring prose are not verified numbers** — count them.
+
+### Memory file
+Was still at `main` @ `b7cb6d9` with "merge #136, then bump the version" as next steps,
+with no record that 1.1.0 exists. Now leads with the 1.1.0 status and the real next three
+(merge #137, win-builder/R-hub, Ron's submission); the old block is kept below it, marked
+historical. Also folded in the two catches from the bump — `ChangeLog` needing its own
+pointer entry, and `cran-comments.md` going stale within the same day.
+
+### State
+Docs-only change: `git diff --stat` is `BACKLOG.md` + this log, nothing under `R/`,
+`tests/`, `DESCRIPTION` or `NEWS.md`, so the suite is untouched at 180 pass / 0 skip.
+
+### Next
+Unchanged: merge #137 (**squash**), then win-builder + R-hub, then **Ron submits to CRAN.**
+
 <!-- END LOG — append new sections above this line -->

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,7 +4,9 @@ A prioritized backlog for bringing `rcicr` to a modern, maintainable state **wit
 breaking the API that researchers depend on**.
 
 **Compiled:** 2026-07-26, against `main` @ `b6ab269` (v1.0.1).
-**Last updated:** 2026-07-26 — P0 items 2–8 fixed (v1.0.1.9000); see `NEWS.md`.
+**Last updated:** 2026-07-27 — P0 items 2–8, plus 11, 12 and 22, fixed and released as
+**v1.1.0**; see `NEWS.md`. All mechanical CRAN blockers are closed; what remains in item 1
+is the submission decision itself.
 
 Sources: the GitHub issue tracker (45 open issues), the published literature, and a
 direct review of the codebase. Items marked **[verified]** were reproduced by running the
@@ -505,10 +507,14 @@ this NOTE previously also flagged is gone.
 
 #### Must do before submitting
 
-- [ ] **Bump the version to `1.1.0`.** *(left deliberately — it is a release decision,
-      not a mechanical fix, and it belongs with the CRAN go/no-go in item 1.)* `1.0.1.9000` trips "Version contains large
+- [x] **Bump the version to `1.1.0`. Done.** `1.0.1.9000` tripped "Version contains large
       components" — the `.9000` development suffix is not acceptable in a submission.
-      Date the `NEWS.md` heading at the same time.
+      `DESCRIPTION` now reads `1.1.0`, the `NEWS.md` heading is dated `2026-07-27`, and
+      `ChangeLog` gained a 1.1.0 entry pointing at `NEWS.md` as the canonical changelog
+      from this release onward. Minor rather than patch because some changes alter
+      behaviour; not major because the public API is untouched.
+      **This closes the last mechanical CRAN blocker** — what remains in this item is
+      the go/no-go and the submission itself, which are Ron's.
 - [x] **Fix the two flagged URLs — partly done.** The `codecov.io` one is **gone**: the
       badge rendered `unknown` (nothing has ever been uploaded, there being no token), so
       it was removed rather than repointed — a badge that reports nothing while looking

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -304,7 +304,7 @@ at which point five functions break at once.
       dropped from DESCRIPTION — citations were rendering as "Ron Dotsch ()." with an
       empty year.
 
-### 11. Make parallelism robust and user-controllable
+### 11. Make parallelism robust and user-controllable  ✅ **DONE**
 Several related problems in one area:
 
 - `generateReferenceDistribution2IFC()` **hardcodes** `ncores = parallel::detectCores() - 1`
@@ -326,10 +326,23 @@ Several related problems in one area:
       `stopClusterSafely()` helper is registered via `on.exit()` at all three cluster
       sites, so workers are released even when an error interrupts the `foreach` loop.
       Verified: a mid-loop failure now leaks zero connections (issue #50).
-- [ ] Skip the cluster entirely when `ncores == 1`.
+- [x] **Skip the cluster entirely when `ncores == 1`. Done** via `startBackend()` in
+      `R/zzz.R`, which registers `foreach::registerDoSEQ()` instead of building a
+      one-worker PSOCK cluster. No loop body changed. `devtools::test()` went 140.1s →
+      4.3s and `R CMD check`'s test phase `[8s/126s]` → `[8s/37s]`.
+      Output is bit-identical, verified rather than assumed: neither parallel loop draws
+      random numbers (parameters are drawn under `set.seed()` *before* the loop), so
+      there is no per-worker RNG stream to diverge. Pinned by
+      `tests/testthat/test-parallel-equivalence.R`.
+**Known limitation, not planned.** `detectCores()` still reports physical cores rather
+than a cgroup/container quota, so the default can over-subscribe on shared or HPC systems
+— exactly where big jobs run. `default_ncores()` caps at 2 only under `R CMD check`.
+Reading cgroup limits properly is platform-specific and not worth the complexity here;
+users on such systems should pass `ncores` explicitly. Recorded so it is a known
+trade-off rather than an oversight.
 
 ### 12. Fill out the test suite  ✅ **DONE**
-A testthat suite now exists (**177 tests**) covering the pure functions, light I/O paths,
+A testthat suite now exists (**180 tests**) covering the pure functions, light I/O paths,
 and an end-to-end smoke test. Every gap listed below is now closed — and closing the last
 two turned up three previously unknown bugs in `plotZmap()`, which is the argument for
 writing tests for code that "obviously works":
@@ -649,18 +662,11 @@ outside the repository. Three problems with that:
   so a broken example fails the build.
 - It is not available offline or via `vignette()`, which is where R users look first.
 
-- [ ] Port the walkthrough into a vignette (alongside `getting-started.Rmd`), with its
-      code chunks actually running so they stay honest.
-- [ ] **Keep the Medium post published**, updated with a pointer to the package docs. It
-      has nine years of inbound links and citations; deleting it would break them. This
-      is a *move of the canonical copy*, not a takedown.
-- [ ] Once the content lives here, the remaining `medium.com` references in `README.md`
-      and `vignettes/getting-started.Rmd` become "further reading" rather than the primary
-      source — and if they are dropped entirely at that point, the CRAN URL NOTE goes with
-      them.
-
-Worth doing before the CRAN submission if there is appetite, since it removes the one
-non-trivial NOTE. Not a blocker: the NOTE is explainable in `cran-comments.md`.
+The plan was: port the walkthrough into a vignette with its chunks actually running;
+keep the Medium post published (nine years of inbound links — a move of the canonical
+copy, not a takedown); and demote the remaining `medium.com` references in `README.md`
+and `vignettes/getting-started.Rmd` to further reading. All of that is done — see the
+checklist at the top of this item, which is the live one.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,9 +4,10 @@ A prioritized backlog for bringing `rcicr` to a modern, maintainable state **wit
 breaking the API that researchers depend on**.
 
 **Compiled:** 2026-07-26, against `main` @ `b6ab269` (v1.0.1).
-**Last updated:** 2026-07-27 — P0 items 2–8, plus 11, 12 and 22, fixed and released as
-**v1.1.0**; see `NEWS.md`. All mechanical CRAN blockers are closed; what remains in item 1
-is the submission decision itself.
+**Last updated:** 2026-07-27 — P0 items 2–8, plus 9, 10, 11, 12, 16, 18, 19 and 22, fixed
+and released as **v1.1.0**; see `NEWS.md`. All mechanical CRAN blockers are closed; what
+remains in item 1 is the submission decision itself. Items 13–15 are the only substantive
+work left.
 
 Sources: the GitHub issue tracker (45 open issues), the published literature, and a
 direct review of the codebase. Items marked **[verified]** were reproduced by running the
@@ -42,22 +43,27 @@ Legend: **[P0]** correctness/blocking · **[P1]** high value · **[P2]** worthwh
 
 ## Suggested order of attack
 
-**All seven P0 code bugs (items 2–8) are fixed.** What remains, in the order I would
-take it:
+**All seven P0 code bugs (items 2–8) are fixed, along with every P1 *code* item — the
+dependency, toolchain, parallelism, test-coverage and vignette work — all released as
+v1.1.0.** The three rows left below are not code: item 20's checklist is fully ticked, so
+what remains across 1, 20 and 21 is the go/no-go and the submission itself, which are the
+maintainer's to make. Items **13, 14 and 15** (modernize the R code, better errors, docs
+and onboarding) are the only substantive work still untouched — they are the backlog
+proper for after CRAN, and are deliberately not in the table above.
 
 | # | Item | Why | Size |
 |---|---|---|---|
-| 9 | Drop 13 unused `Imports` | Trivial deletion; removes install-failure risk and clears an `R CMD check` NOTE, which unblocks CRAN | S |
-| 16 | Pointless 1.5 GB array exported to every worker | Roughly a one-line fix; likely resolves most of issue #12 | S |
-| 10 | Replace deprecated `progress_estimated()` / `rbernoulli()` / `citEntry()` | Still work today, but warn on every run and will eventually break five functions at once | S |
+| ~~9~~ | ~~Drop 13 unused `Imports`~~ | **Done** — the 13 unused declarations are gone; `DESCRIPTION` now imports 15 packages. Removed the install-failure risk and the `R CMD check` NOTE that would have blocked resubmission | S |
+| ~~16~~ | ~~Pointless 1.5 GB array exported to every worker~~ | **Done** — the per-worker array copy is gone. Addresses, but does not fully close, issue #12: the `ncores == 1` path and `img_size` scaling remain, which is why #12 stays open | S |
+| ~~10~~ | ~~Replace deprecated `progress_estimated()` / `rbernoulli()` / `citEntry()`~~ | **Done.** The `rbernoulli()` replacement had to preserve the random *stream*, not just the distribution — it is `runif(n) > (1 - p)`, and the obvious `rbinom(n, 1, p)` would have silently changed every infoVal computed from a given seed | S |
 | 1 | CRAN archived | Highest reach of anything here, but a process/decision task rather than a code fix | M |
 | ~~11~~ | ~~Cluster cleanup (`on.exit`), serial fallback~~ | **Done.** `on.exit` cleanup in #130; the `ncores == 1` serial fast path landed via `startBackend()`. Test suite 140s → 4s, and serial/parallel output verified bit-identical | M |
-| 12 | Widen test coverage (scaling methods, z-maps, `participants`) | The suite covers the fixed bugs well; these paths are still untested | M |
+| ~~12~~ | ~~Widen test coverage (scaling methods, z-maps, `participants`)~~ | **Done** — suite at 180 tests, 0 skips. It found three real `plotZmap()` bugs in code that read fine, one of which made `zmapdecoration = FALSE` entirely dead since R 4.2 | M |
 | ~~18~~ | ~~Codecov step fails for want of a token~~ | **Done** — `fail_ci_if_error: false`; a red `main` now means the package is broken | S |
 | ~~19~~ | ~~Close the 8 issues already fixed in `main`~~ | **Done** — 7 closed, #12 commented and left open as only partly fixed. ~22 remaining issues still unswept | S |
-| 20 | CRAN resubmission checklist | Verified against a real `--as-cran` run; six concrete fixes then submit | M |
+| 20 | CRAN resubmission checklist | **Every box ticked**; `--as-cran` is 0 errors / 0 warnings / 2 expected NOTEs. Only the submission itself is left, and CRAN mails the maintainer to confirm it | M |
 | 21 | Announcement post | Drafted in `notes/`; hold until the CRAN outcome is known | S |
-| 22 | Move the Medium walkthrough into a vignette | Removes the last real CRAN NOTE, and makes the tutorial execute at build time so it cannot go stale | M |
+| ~~22~~ | ~~Move the Medium walkthrough into a vignette~~ | **Done** — `vignettes/reverse-correlation-walkthrough.Rmd`. It now executes at build time, which proved its own premise: two lines of the published tutorial had already stopped working | M |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -464,8 +470,17 @@ Best done as one batch after #131 merges, so #122 closes with it rather than by 
 
 ### 20. CRAN resubmission checklist  **[verified against `R CMD check --as-cran`]**
 
-**Current status — re-run 2026-07-27 against `main` @ `5428b79`, in a check environment
-that now genuinely matches CRAN's.** `texlive` and `tidy` are installed, and the run set
+**Current status — every box below is ticked.** The latest `--as-cran` run, on
+`release-1.1.0` after the version bump, gives **0 errors, 0 warnings, 2 NOTEs**, and
+`Version contains large components` is **gone** — confirmed by reading the incoming-
+feasibility block, not by assuming the bump worked. The two survivors are the
+archived/new-submission pair and the Medium 403, both expected and both explained in
+`cran-comments.md`. Nothing mechanical is left in this item; the go/no-go and the
+submission are Ron's.
+
+The run below is the earlier baseline, kept because it is what established the check
+environment. **Re-run 2026-07-27 against `main` @ `5428b79`, in a check environment that
+genuinely matches CRAN's.** `texlive` and `tidy` are installed, and the run set
 `_R_CHECK_CRAN_INCOMING_=TRUE` / `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`, so the incoming
 checks CRAN actually performs on submission ran for real.
 
@@ -500,10 +515,17 @@ Found the following (possibly) invalid URLs:
     From: inst/doc/getting-started.html, README.md
 ```
 
-Of these, only **"Version contains large components"** is an actual blocker, and it is the
-one unticked box below. "New submission" and "Package was archived" are expected for a
-reinstatement and are what `cran-comments.md` exists to explain. The `codecov.io` URL that
-this NOTE previously also flagged is gone.
+Of these, only **"Version contains large components"** was ever an actual blocker, and the
+1.1.0 bump closed it — see the first ticked box below; it no longer appears in the output.
+"New submission" and "Package was archived" are expected for a reinstatement and are what
+`cran-comments.md` exists to explain. The `codecov.io` URL that this NOTE previously also
+flagged is gone.
+
+Two details of the block above are pre-1.1.0 and should not be read as current. The
+version string is now `1.1.0`. And the URL NOTE now reads `From: README.md` only — item 22
+moved the walkthrough into a vignette, so `inst/doc/getting-started.html` no longer carries
+the Medium link. That narrowing is what lets `cran-comments.md` tell a reviewer the content
+ships *in the package* and the link is courtesy to nine years of citations.
 
 #### Must do before submitting
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+Changes 1.1.0 [27-Jul-2026]
+
+* See NEWS.md for this release. It is the canonical changelog from 1.1.0 onward,
+  and records the bug fixes, the removed dependencies, and — importantly — which
+  numeric results can and cannot differ from earlier versions.
+* In brief: many bug fixes (mask, zmaps, tibble columns, InfoVal reference
+  distributions), a test suite and CI where there were none, 13 unused
+  dependencies removed, and a reverse-correlation walkthrough vignette.
+
 Changes 1.0.1 [13-Jan-2023]
 
 * Replaced spatstat.core dependency (deprecated) with spatstat.explore

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.0.1.9000
+Version: 1.1.0
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,11 @@
-# rcicr 1.0.1.9000 (development version)
+# rcicr 1.1.0 (2026-07-27)
 
-> The `.9000` suffix marks an unreleased development version, per the usual R
-> convention. It will become a release number when these fixes ship — most
-> likely **1.1.0** rather than 1.0.2, since some of them change behaviour
-> (see below) rather than only repairing it. The public API is unchanged, so a
-> 2.0.0 is not warranted.
+> First release since 1.0.1, and the version submitted to CRAN to reinstate the
+> package after its 2021 archival. The minor bump rather than 1.0.2 is deliberate:
+> some of the changes below alter behaviour rather than only repairing it. The
+> public API is unchanged — no function, argument or argument meaning was removed
+> or redefined — so a 2.0.0 is not warranted. Anyone re-running an old analysis
+> script should read the "Reproducibility impact" section below.
 
 ## Bug fixes
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -42,15 +42,20 @@ Expected for a reinstatement; see the explanation above.
 ```
 Found the following (possibly) invalid URLs:
   URL: https://medium.com/@rondotsch/reverse-correlation-image-classification-using-r-a0701648fb0/
+    From: README.md
     Status: 403
 ```
 
 This URL is valid and resolves normally in a browser. `medium.com` returns 403 to
 requests originating from datacenter networks — this is a block by network origin rather
 than by user agent, so it reproduces from CI machines and not from an ordinary desktop.
-It is a tutorial walkthrough of the method that the package implements, and it is
-referenced from `README.md` and the vignette as a pointer for new users. We have kept it
-because it is genuinely useful to readers, but are happy to remove it if you prefer.
+
+It points to the original tutorial walkthrough of the method. That walkthrough has been
+ported into this release as the `reverse-correlation-walkthrough` vignette, so it is no
+longer the primary documentation. The single remaining reference, in `README.md`, is a
+"further reading" pointer to the historical copy, which has nine years of inbound links
+from published papers. We are happy to remove the link if you prefer — it is now a
+one-line change, since the content itself ships with the package.
 
 ### NOTE 2 — future file timestamps
 


### PR DESCRIPTION
Closes the last mechanical blocker on the CRAN resubmission. 

## What changed

**Version `1.0.1.9000` → `1.1.0`.** The `.9000` development suffix tripped
`Version contains large components` under `--as-cran`. That was the only genuine
blocker left; the NOTE line is gone.

Minor rather than patch because some changes this cycle alter behaviour rather than
only repairing it. Not major: no function, argument, or argument meaning was removed
or redefined, so old analysis scripts still parse and run.

- **`NEWS.md`** heading dated `2026-07-27`. The "unreleased development version"
  blockquote is replaced by a note on why the bump is minor, pointing anyone with
  published or in-progress results at the "Reproducibility impact" section.
- **`ChangeLog`** gains a 1.1.0 entry naming `NEWS.md` as the canonical changelog from
  this release onward, so a reader who opens `ChangeLog` first is not left thinking
  1.0.1 is current.
- **`cran-comments.md`**: the Medium-URL NOTE now explains that the walkthrough ships
  as a vignette in this release, so the link is further reading rather than the primary
  documentation and dropping it would cost one line. Corrected to say `README.md` only —
  it is no longer referenced from the vignettes, which the check output confirms.
- **`BACKLOG.md`**: bookkeeping that landed in #133–#136 but was never written back —
  item 11 closed, item 12's count 177 → 180, item 22's stale plan text replaced by a
  pointer to its live checklist. Also records the `detectCores()`/cgroup
  over-subscription behaviour as a known, deliberate trade-off rather than leaving it
  to be rediscovered as an oversight.

## Verification

`R CMD check --as-cran` with `_R_CHECK_CRAN_INCOMING_=TRUE` and
`_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`: **0 errors, 0 warnings, 2 NOTEs.** Both are
expected and explained in `cran-comments.md` — the archived-package/new-submission
pair, and the Medium 403 (`medium.com` blocks datacenter IPs; the URL resolves fine
in a browser).

`devtools::test()`: **180 pass, 0 fail, 0 skip.** The golden master in
`test-regression-baseline.R` is green, so no numeric output changed — this release is
safe for someone re-running an old script, subject to the documented
"Reproducibility impact" items.

## Still outstanding after this merges

- win-builder and R-hub runs — `cran-comments.md` has two `<!-- TODO -->` markers
  waiting on their results.
- the CRAN submission itself, and adding a pointer at the top of the Medium
  post to `vignette("reverse-correlation-walkthrough", package = "rcicr")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)