### PR TITLE
Replace performative assertions with intent tests; log backlog items 23-25

### DIFF
--- a/.session-log.md
+++ b/.session-log.md
@@ -988,4 +988,97 @@ Docs-only change: `git diff --stat` is `BACKLOG.md` + this log, nothing under `R
 ### Next
 Unchanged: merge #137 (**squash**), then win-builder + R-hub, then **Ron submits to CRAN.**
 
+## 2026-07-27, ~14:00 UTC — #137 merged by Ron; test-intent audit; branch `test-intent-gaps`
+
+Resumed cold. **#137 was squash-merged by Ron at 13:42 UTC** (`a3904e8`, single parent —
+convention held). Both workflows green on `main` at that SHA. **v1.1.0 is on `main`.**
+Local `main` fast-forwarded; branch `test-intent-gaps` cut from `a3904e8`.
+
+Ron then asked whether the suite tests *intent* or is merely performative. Audited all 23
+test files rather than trusting the memory file.
+
+### Verdict: mostly intent-based, four gaps
+Strong: independent oracles (`generateNoiseImage` per-pixel mean; non-recycling check),
+algebraic identities (0°/90° transpose, π-shift negation, Gabor = sinusoid × Gaussian),
+scaling methods against their defining formulae, recovery, parallel equivalence, and the
+unbalanced-design case that keeps the participants/pooled equivalence non-vacuous.
+
+Gaps found, in severity order:
+1. **`batchGenerateCI` / `batchGenerateCI2IFC`** — titled "computes one CI per group" but
+   asserted only `length == 2`, field names and `dim`. **Grouping was never checked**: a
+   bug feeding all six trials to both groups, or swapping them, passed green. The list
+   keys (`base_pid_1`/`base_pid_2`, set at `R/batchGenerateCI.R:84`) were unasserted too.
+2. **`plotZmap`** — three of four assertions were `file.exists()`. A `plotZmap()` writing a
+   uniformly blank PNG passed all three. Same class as the logged `image()`/`zlim` lesson.
+3. **`generateReferenceDistribution2IFC`** — length + no-NAs only; satisfied by a vector of
+   zeros or of one repeated value, either of which breaks InfoVal (`mad()` divisor).
+4. **`computeInfoVal2IFC`'s oracle is a mirror** — the test recomputes
+   `(norm − median)/mad`, the same formula as the implementation, so it pins the
+   implementation rather than the published definition. **Left as-is** (deliberate): the
+   formula was hand-checked against the Schmitz erratum and the baseline pins the number.
+   Recorded here so a future session does not mistake it for an independent check.
+
+### Tests added (gaps 1–3)
+All three prototyped in the scratchpad first, confirming each new assertion actually
+discriminates — e.g. `cis[[1]]$ci` vs `direct2$ci` was verified to be FALSE before the
+test relied on it being TRUE for the right pairing.
+
+- `test-batchGenerateCI.R` / `test-batchGenerateCI2IFC.R`: each group's `$ci` must equal a
+  direct `generateCI()`/`generateCI2IFC()` on that subset; list keys asserted; the two
+  groups asserted *different* (catches "every group got the full frame"); plus an
+  **interleaved-`pid` fixture** so grouping-by-column is distinguishable from a positional
+  first-half/second-half split, with the positional answer asserted different so the check
+  is not vacuous. Compares `$ci`, not `$scaled`, because the default
+  `scaling = 'autoscale'` rewrites `$scaled` across the batch.
+- `test-plotZmap.R`: renders onto a **uniform** background so "nothing painted" equals
+  "output == background" — a comparison, not an eyeball. Covers sub- vs supra-threshold,
+  per-pixel thresholding (half the map above, half below, each half matched against a
+  full render), **negative** z-scores beyond threshold (pins the `abs()`; a
+  `zmap < threshold` rewrite would break it silently), and threshold monotonicity.
+- `test-generateReferenceDistribution2IFC.R`: norms strictly positive, genuinely varying
+  (`length(unique(.)) > 1`, `mad(.) > 0` — catches responses drawn once outside the loop),
+  and the distribution **fixed by the stimulus file, not the caller's RNG**.
+
+### The RNG finding, which was not what I expected
+I set out to test "same seed → same norms" and found something stronger: seeding 42 vs 99
+around two calls gives **byte-identical** norms. Cause: the function re-generates stimuli
+via `generateStimuli2IFC()`, which calls `set.seed(seed)` at `R/generateStimuli2IFC.R:53`
+using the seed from the `.Rdata` file — that reset governs the later `runif()` draws. So
+the reference distribution, and therefore InfoVal, is reproducible from the stimulus file
+alone regardless of ambient RNG state. That is a better property than the one I meant to
+pin, and it is now the test.
+
+### Two findings NOT fixed — both need Ron
+- **`plotZmap(mask = ...)` is dead code.** `R/plotZmap.R:34–69` validates the mask, checks
+  its dimensions, flattens identical colour channels and converts it to boolean — and then
+  **never applies it**. `mask` appears nowhere after line 69 (line 116 is only a comment).
+  The documented behaviour ("if a cell evaluates to TRUE, the corresponding zmap pixel will
+  be masked") does nothing. Narrow blast radius: `generateCI()` calls `plotZmap()` without
+  `mask` (`R/generateCI.R:327`) and masks the CI itself via `applyMask()`, so only direct
+  user calls are affected. **Not fixed, and no failing test added** — fixing it changes
+  rendered output for anyone currently passing `mask`, which is a behaviour change, and the
+  logged lesson from the `autoscale()`/`$combined` episode is to flag debatable fixes
+  rather than relabel them bugs. Ron's call. The existing test only covers the *error* path
+  for mismatched dimensions, which is why this survived.
+- **`generateReferenceDistribution2IFC()` leaves a stray `./stimuli` directory** in the
+  working directory (`tests/testthat/stimuli` after a suite run). Pre-existing, git-ignored
+  so it never showed in `git status`, and the function's own roxygen already notes it does
+  not forward `stimulus_path`. Cosmetic, but worth a `withr::local_dir()` in the tests or a
+  `stimulus_path` passthrough in the function.
+
+### State
+Branch `test-intent-gaps` off `a3904e8`. Three test files touched, **nothing under `R/`** —
+no behaviour change, so the golden master and `NEWS.md` are untouched by design. Baseline
+before the change: 180 pass / 0 fail / 0 skip in 15.4s. Package reinstalled to 1.1.0 first
+(the installed copy was a stale 1.0.1.9000, which the `generator_version` test would catch).
+
+### Next
+1. Confirm the new suite is green (run was in flight when the session ended) and push the
+   branch / open a PR — **squash** on merge.
+2. **Ron:** decide on the dead `plotZmap(mask=)` argument — fix and document under a
+   "Behaviour change" heading, or deprecate the argument.
+3. Then unchanged: win-builder + R-hub (two `<!-- TODO -->` markers in `cran-comments.md`,
+   deliberately unrun because they upload the tarball and email Ron), then **Ron submits to
+   CRAN**, then item 21.
+
 <!-- END LOG — append new sections above this line -->

--- a/.session-log.md
+++ b/.session-log.md
@@ -1072,11 +1072,28 @@ no behaviour change, so the golden master and `NEWS.md` are untouched by design.
 before the change: 180 pass / 0 fail / 0 skip in 15.4s. Package reinstalled to 1.1.0 first
 (the installed copy was a stale 1.0.1.9000, which the `generator_version` test would catch).
 
+### Backlog updated, and PR opened
+Suite came back **203 pass / 0 fail / 0 skip in 14.4s** (from 180); regression baseline
+green, so no researcher-visible change. Committed as `873eb9f`.
+
+The three findings are now **backlog items 23–25** (`f3e7e23`): 23 is the dead
+`plotZmap(mask=)` argument, filed under **P0** since it is silently-wrong documented
+behaviour and a sibling of item 6 — the same argument mishandled in the neighbouring
+function; 24 is the stray `./stimuli` directory; 25 is the mirrored InfoVal oracle, logged
+as a deliberate non-fix. The file header and the order-of-attack preamble both claimed no
+code work was left, which item 23 made untrue — both corrected, and the table now has three
+new rows.
+
+**PR [#138](https://github.com/rdotsch/rcicr/pull/138)** opened against `main`.
+`git diff --stat main...HEAD` checked before opening (the `cran-prep` lesson): six files,
+436 insertions, no artifacts. pre-commit.ci green; the three R workflows were still running
+when the session ended.
+
 ### Next
-1. Confirm the new suite is green (run was in flight when the session ended) and push the
-   branch / open a PR — **squash** on merge.
-2. **Ron:** decide on the dead `plotZmap(mask=)` argument — fix and document under a
-   "Behaviour change" heading, or deprecate the argument.
+1. **Check [#138](https://github.com/rdotsch/rcicr/pull/138) is green and merge it —
+   squash.**
+2. **Ron:** decide backlog item 23, the dead `plotZmap(mask=)` argument — fix and document
+   under a "Behaviour change" heading in `NEWS.md`, or deprecate the argument.
 3. Then unchanged: win-builder + R-hub (two `<!-- TODO -->` markers in `cran-comments.md`,
    deliberately unrun because they upload the tarball and email Ron), then **Ron submits to
    CRAN**, then item 21.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -70,6 +70,7 @@ they are the backlog proper for after CRAN, and are deliberately not in the tabl
 | 23 | `plotZmap(mask=)` validated then never applied | **Open, needs a decision.** A documented argument that silently does nothing; narrow blast radius (`generateCI()` never passes it), but fixing it changes rendered output, so it is a behaviour change rather than a plain bug fix | S |
 | 24 | `generateReferenceDistribution2IFC()` litters a `./stimuli` dir | Cosmetic; hidden until now because `stimuli` is git-ignored, so it never showed in `git status` | S |
 | 25 | InfoVal test oracle mirrors the implementation | **Deliberately left** — risk already covered by the hand-check against the erratum and the golden master. Logged so it is not mistaken for an independent check | S |
+| 26 | InfoVal's null is seeded by accident and cannot be varied | Behaviour is correct and worth keeping (MC error measured at ~0.04 infoVal units), but it is emergent rather than designed, and a stray edit to `set.seed()` in `generateStimuli2IFC()` would silently change every InfoVal | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -830,6 +831,55 @@ function's own roxygen already documents the behaviour as a caveat (with a
       rather than documenting the side effect.
 - [ ] Wrap the tests in `withr::local_dir()` so a suite run leaves no directory behind
       either way.
+
+### 26. InfoVal's null is seeded by accident, and cannot be varied **[verified] [own review]**
+Found 2026-07-27. `generateReferenceDistribution2IFC()` has no `seed` argument, yet its
+output is fully deterministic: it rebuilds the stimuli via `generateStimuli2IFC()`, which
+calls `set.seed(seed)` internally (`R/generateStimuli2IFC.R:53`) using the seed stored in
+the `.Rdata` file, and that reset lands *before* the `runif()` draws in the simulation
+loop. So the reference distribution — and every InfoVal computed from it — is fixed by the
+stimulus file alone.
+
+**Verified:** seeding 42 vs 99 around two calls gives byte-identical norms, and
+`ncores = 1` vs `ncores = 2` also agree, so the null is portable across machines. Both are
+now pinned by tests.
+
+**The behaviour is worth keeping** — reproducibility is this package's guiding constraint,
+and the Monte Carlo error it freezes in is small. Measured by splitting a 100,000-iteration
+run into ten independent 10,000-iteration batches (`img_size = 32`, `n_trials = 300`):
+
+| statistic | relative SD at `iter = 10000` |
+|---|---|
+| `median(reference_norms)` | 0.19% |
+| `mad(reference_norms)` | 1.26% |
+
+For a CI at infoVal ≈ 3 that is a spread of 2.95–3.06 (SD 0.036), i.e. below anything
+interpretable. The existing `iter >= 10000` warning is well calibrated.
+
+**The problem is that it is emergent, not designed.** Nobody chose to have the null inherit
+the stimulus seed; it is a side effect of the stimulus rebuild. Two consequences:
+
+- There is **no way to vary the null**, so a user cannot check the Monte Carlo error
+  themselves — measuring the table above required batching one long run.
+- Studies sharing `(seed, n_trials, img_size, nscales, noise_type)` share the *same draw*
+  of the null, not merely the same null distribution, so their InfoVal errors are perfectly
+  correlated rather than independent. For comparing InfoVals that is arguably a feature
+  (one ruler), and it is evidently the intent behind the `ref_lookup` table in
+  `computeInfoVal2IFC()` — but it means those errors cannot be treated as independent in a
+  meta-analysis.
+
+The real risk is silent breakage: anyone who moves or removes that `set.seed()`, or adds a
+seed argument to `generateStimuli2IFC()`, changes every InfoVal ever computed without
+touching `computeInfoVal2IFC()` at all.
+
+- [ ] Document the determinism as an intended **guarantee** in
+      `?generateReferenceDistribution2IFC`, and note that InfoVal is reproducible from the
+      stimulus file alone.
+- [ ] Consider an explicit `seed` argument defaulting to the current behaviour, so the null
+      *can* be varied deliberately. Purely additive — no change to the `.Rdata` contract or
+      to any existing call.
+- [ ] Add a comment at `R/generateStimuli2IFC.R:53` recording that the reference
+      distribution depends on that `set.seed()` call, so it is not moved casually.
 
 ### 25. `computeInfoVal2IFC`'s test oracle mirrors the implementation **[own review]**
 Found 2026-07-27 during the test-intent audit. `test-computeInfoVal2IFC.R:24` recomputes

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,8 +6,10 @@ breaking the API that researchers depend on**.
 **Compiled:** 2026-07-26, against `main` @ `b6ab269` (v1.0.1).
 **Last updated:** 2026-07-27 — P0 items 2–8, plus 9, 10, 11, 12, 16, 18, 19 and 22, fixed
 and released as **v1.1.0**; see `NEWS.md`. All mechanical CRAN blockers are closed; what
-remains in item 1 is the submission decision itself. Items 13–15 are the only substantive
-work left.
+remains in item 1 is the submission decision itself. **Items 23–25 were opened the same
+day** by a test-intent audit — 23 is a real bug in `plotZmap()` awaiting a
+fix-or-deprecate decision, 24 is cosmetic, 25 is a logged non-fix. Items 13–15 remain the
+only substantive untouched work.
 
 Sources: the GitHub issue tracker (45 open issues), the published literature, and a
 direct review of the codebase. Items marked **[verified]** were reproduced by running the
@@ -45,11 +47,12 @@ Legend: **[P0]** correctness/blocking · **[P1]** high value · **[P2]** worthwh
 
 **All seven P0 code bugs (items 2–8) are fixed, along with every P1 *code* item — the
 dependency, toolchain, parallelism, test-coverage and vignette work — all released as
-v1.1.0.** The three rows left below are not code: item 20's checklist is fully ticked, so
-what remains across 1, 20 and 21 is the go/no-go and the submission itself, which are the
-maintainer's to make. Items **13, 14 and 15** (modernize the R code, better errors, docs
-and onboarding) are the only substantive work still untouched — they are the backlog
-proper for after CRAN, and are deliberately not in the table above.
+v1.1.0.** Items 1, 20 and 21 are not code: item 20's checklist is fully ticked, so what
+remains across them is the go/no-go and the submission itself, which are the maintainer's
+to make. **Item 23 is the one open code bug** — a decision, not a diagnosis, since the
+cause is known and the fix changes rendered output. Items **13, 14 and 15** (modernize the
+R code, better errors, docs and onboarding) are the only substantive work still untouched —
+they are the backlog proper for after CRAN, and are deliberately not in the table above.
 
 | # | Item | Why | Size |
 |---|---|---|---|
@@ -64,6 +67,9 @@ proper for after CRAN, and are deliberately not in the table above.
 | 20 | CRAN resubmission checklist | **Every box ticked**; `--as-cran` is 0 errors / 0 warnings / 2 expected NOTEs. Only the submission itself is left, and CRAN mails the maintainer to confirm it | M |
 | 21 | Announcement post | Drafted in `notes/`; hold until the CRAN outcome is known | S |
 | ~~22~~ | ~~Move the Medium walkthrough into a vignette~~ | **Done** — `vignettes/reverse-correlation-walkthrough.Rmd`. It now executes at build time, which proved its own premise: two lines of the published tutorial had already stopped working | M |
+| 23 | `plotZmap(mask=)` validated then never applied | **Open, needs a decision.** A documented argument that silently does nothing; narrow blast radius (`generateCI()` never passes it), but fixing it changes rendered output, so it is a behaviour change rather than a plain bug fix | S |
+| 24 | `generateReferenceDistribution2IFC()` litters a `./stimuli` dir | Cosmetic; hidden until now because `stimuli` is git-ignored, so it never showed in `git status` | S |
+| 25 | InfoVal test oracle mirrors the implementation | **Deliberately left** — risk already covered by the hand-check against the erratum and the golden master. Logged so it is not mistaken for an independent check | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -244,6 +250,45 @@ package explicitly promises for old `.Rdata` files.
 
 - [x] Move the rename block above the validation.
 - [x] Test with a genuine pre-0.3.3-shaped `p`.
+
+### 23. `plotZmap(mask = ...)` is validated and then never applied **[verified] [own review]**
+Not in the issue tracker. Found 2026-07-27 while writing content tests for `plotZmap()`.
+
+`R/plotZmap.R:34–69` does real work on the `mask` argument: reads it from a PNG if given a
+path, checks it against the z-map's dimensions, verifies the values are 0/1 or TRUE/FALSE,
+collapses identical RGB channels to one layer, and converts the result to boolean. Then the
+function moves on to `zmap[abs(zmap) < threshold] <- NA` and **`mask` is never referenced
+again** — it appears nowhere after line 69 (the mention at line 116 is inside a comment).
+
+So the documented behaviour — *"If a cell evaluates to TRUE, the corresponding zmap pixel
+will be masked"* — does nothing at all. A user who passes a correct mask gets a z-map with
+no masking applied and no warning, which is the bad failure mode: the output looks
+plausible and is silently wrong about which regions carry signal.
+
+Blast radius is narrow. `generateCI()` calls `plotZmap()` **without** `mask`
+(`R/generateCI.R:327`) and masks the CI itself via `applyMask()` beforehand, so z-maps
+produced through the normal pipeline are unaffected. Only direct `plotZmap(mask = ...)`
+calls are hit.
+
+Why it survived the item-12 sweep: the only existing `mask` test asserts the *error* path
+for mismatched dimensions, which exercises lines 34–69 and stops there. The tests added
+alongside this entry check rendered content, but deliberately do not cover `mask` — see
+below.
+
+**This needs a decision before it is a code change.** Fixing it alters rendered output for
+anyone currently passing `mask`, which makes it a behaviour change rather than an
+unambiguous bug fix, and the standing lesson from the `autoscale()` / `$combined` episode
+is to flag those rather than relabel them. Hence no failing test was committed: a knowingly
+red test in the suite is worse than a backlog entry.
+
+- [ ] **Decide:** apply the mask (`zmap[mask] <- NA` after the threshold step), or formally
+      deprecate the argument if masking is considered `generateCI()`'s job alone.
+- [ ] If applied: document under a **"Behaviour change"** heading in `NEWS.md`, since
+      existing scripts passing `mask` will start producing different images.
+- [ ] Add the content test that is currently missing — a masked region must come back as
+      background, exactly as the sub-threshold test does.
+- [ ] Check the same argument in any sibling that accepts a mask; item 6 and this one are
+      the same argument mishandled in two different functions.
 
 ### Also found and fixed while working through the P0 items
 
@@ -767,6 +812,39 @@ The GitHub issues are dominated by confusing failure modes, not missing features
       (`rcicr_examples`).
 - [ ] Add a `CITATION.cff` so GitHub renders a "Cite this repository" button; keep it in
       sync with `inst/CITATION`.
+
+### 24. `generateReferenceDistribution2IFC()` writes a stray `./stimuli` directory **[verified] [own review]**
+Found 2026-07-27. The function re-generates the stimulus set by calling
+`generateStimuli2IFC()` (`R/generateReferenceDistribution.R:81`) **without forwarding a
+`stimulus_path`**, so that call falls back to its own default and creates a `stimuli`
+directory relative to whatever the working directory happens to be. Running the test suite
+leaves a `tests/testthat/stimuli/` behind.
+
+Harmless to results — `save_as_png = FALSE` and `save_rdata = FALSE` are passed, so the
+directory ends up empty — but it litters the user's working directory, and it was invisible
+here because `stimuli` is already in `.gitignore`, so it never appears in `git status`. The
+function's own roxygen already documents the behaviour as a caveat (with a
+`withr::with_dir()` workaround in the example), which is a note where a fix belongs.
+
+- [ ] Forward a `stimulus_path` (a `tempdir()` default is fine — nothing is written to it)
+      rather than documenting the side effect.
+- [ ] Wrap the tests in `withr::local_dir()` so a suite run leaves no directory behind
+      either way.
+
+### 25. `computeInfoVal2IFC`'s test oracle mirrors the implementation **[own review]**
+Found 2026-07-27 during the test-intent audit. `test-computeInfoVal2IFC.R:24` recomputes
+`(norm(ci, "f") - median(reference_norms)) / mad(reference_norms)` — the same expression as
+the implementation. It therefore pins the *implementation*, not the published definition: a
+formula that is wrong but consistently wrong in both places passes.
+
+Deliberately **not** changed. The formula was hand-checked against the Schmitz et al.
+erratum (item 17), and the golden master pins the resulting number, so the risk is already
+covered from two other directions. Recorded here so that a future reader does not mistake
+this test for the independent check it resembles — the genuinely independent oracle in the
+suite is the one in `test-generateNoiseImage.R`.
+
+- [ ] If ever revisited: assert against a worked example taken from the paper, or a
+      hand-computed case with a fixed 2×2 CI and a known reference vector.
 
 ### 16. Memory ceiling on large stimulus sets — concrete root cause found **[own review]**  ✅ **FIXED**
 Issue [#12](https://github.com/rdotsch/rcicr/issues/12) reports that large stimulus sets

--- a/tests/testthat/test-batchGenerateCI.R
+++ b/tests/testthat/test-batchGenerateCI.R
@@ -21,3 +21,78 @@ test_that("batchGenerateCI computes one CI per group", {
     expect_equal(dim(ci$ci), c(32, 32))
   }
 })
+
+test_that("each CI is built from exactly its own group's trials", {
+  # The shape test above passes for any function returning two 32x32 CIs -- it
+  # never checks that group 1's CI came from group 1's rows. This does: each
+  # element must equal a direct generateCI() on that subset alone. Compare $ci,
+  # not $scaled, because the default scaling = 'autoscale' rewrites $scaled
+  # across the batch; $ci is the field carrying the published numbers and is
+  # untouched by scaling (see test-scaling.R).
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  # Deliberately asymmetric: the two groups differ in both their stimuli and
+  # their response patterns, so a CI built from the wrong group's rows cannot
+  # coincide with the right answer.
+  df <- data.frame(pid = rep(1:2, each = 3), stim = 1:6, resp = c(1, 1, -1, -1, 1, 1))
+
+  cis <- suppressWarnings(
+    batchGenerateCI(
+      data = df, by = "pid", stimuli = "stim", responses = "resp",
+      baseimage = "base", rdata = rdata_path, save_as_png = FALSE
+    )
+  )
+
+  # The list is keyed <baseimage>_<by>_<unit>, which is what identifies whose CI
+  # is whose once these are written out or passed to autoscale().
+  expect_named(cis, c("base_pid_1", "base_pid_2"))
+
+  direct1 <- generateCI(
+    stimuli = df$stim[1:3], responses = df$resp[1:3], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  direct2 <- generateCI(
+    stimuli = df$stim[4:6], responses = df$resp[4:6], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+
+  expect_equal(cis[["base_pid_1"]]$ci, direct1$ci)
+  expect_equal(cis[["base_pid_2"]]$ci, direct2$ci)
+
+  # Guards against a subsetting bug that hands every group the full data frame:
+  # that would make both CIs identical while still satisfying the shape test.
+  expect_false(isTRUE(all.equal(cis[["base_pid_1"]]$ci, cis[["base_pid_2"]]$ci)))
+})
+
+test_that("grouping follows the `by` column, not row order", {
+  # With interleaved group labels, splitting the data positionally (first half /
+  # second half) gives a different answer than grouping by `pid`. A contiguous
+  # fixture cannot tell those two implementations apart.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  df <- data.frame(pid = rep(1:2, times = 3), stim = 1:6, resp = c(1, 1, -1, -1, 1, 1))
+
+  cis <- suppressWarnings(
+    batchGenerateCI(
+      data = df, by = "pid", stimuli = "stim", responses = "resp",
+      baseimage = "base", rdata = rdata_path, save_as_png = FALSE
+    )
+  )
+
+  rows <- df$pid == 1
+  direct <- generateCI(
+    stimuli = df$stim[rows], responses = df$resp[rows], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  expect_equal(cis[["base_pid_1"]]$ci, direct$ci)
+
+  # ...and the positional split gives a genuinely different CI, so the
+  # assertion above is not vacuous.
+  positional <- generateCI(
+    stimuli = df$stim[1:3], responses = df$resp[1:3], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  expect_false(isTRUE(all.equal(cis[["base_pid_1"]]$ci, positional$ci)))
+})

--- a/tests/testthat/test-batchGenerateCI2IFC.R
+++ b/tests/testthat/test-batchGenerateCI2IFC.R
@@ -18,3 +18,63 @@ test_that("batchGenerateCI2IFC computes one CI per group", {
     expect_equal(dim(ci$ci), c(32, 32))
   }
 })
+
+test_that("each CI is built from exactly its own group's trials", {
+  # Same gap as in test-batchGenerateCI.R: the shape test above never checks
+  # which rows fed which CI. batchGenerateCI2IFC() is a separate loop with its
+  # own subsetting, so it needs its own check rather than relying on the
+  # generateCI2IFC/generateCI wrapper equivalence test.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  df <- data.frame(pid = rep(1:2, each = 3), stim = 1:6, resp = c(1, 1, -1, -1, 1, 1))
+
+  cis <- suppressWarnings(
+    batchGenerateCI2IFC(
+      data = df, by = "pid", stimuli = "stim", responses = "resp",
+      baseimage = "base", rdata = rdata_path, save_as_png = FALSE
+    )
+  )
+
+  expect_named(cis, c("base_pid_1", "base_pid_2"))
+
+  direct1 <- generateCI2IFC(
+    stimuli = df$stim[1:3], responses = df$resp[1:3], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  direct2 <- generateCI2IFC(
+    stimuli = df$stim[4:6], responses = df$resp[4:6], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+
+  expect_equal(cis[["base_pid_1"]]$ci, direct1$ci)
+  expect_equal(cis[["base_pid_2"]]$ci, direct2$ci)
+  expect_false(isTRUE(all.equal(cis[["base_pid_1"]]$ci, cis[["base_pid_2"]]$ci)))
+})
+
+test_that("grouping follows the `by` column, not row order", {
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  df <- data.frame(pid = rep(1:2, times = 3), stim = 1:6, resp = c(1, 1, -1, -1, 1, 1))
+
+  cis <- suppressWarnings(
+    batchGenerateCI2IFC(
+      data = df, by = "pid", stimuli = "stim", responses = "resp",
+      baseimage = "base", rdata = rdata_path, save_as_png = FALSE
+    )
+  )
+
+  rows <- df$pid == 1
+  direct <- generateCI2IFC(
+    stimuli = df$stim[rows], responses = df$resp[rows], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  expect_equal(cis[["base_pid_1"]]$ci, direct$ci)
+
+  positional <- generateCI2IFC(
+    stimuli = df$stim[1:3], responses = df$resp[1:3], baseimage = "base",
+    rdata = rdata_path, save_as_png = FALSE, scaling = "none"
+  )
+  expect_false(isTRUE(all.equal(cis[["base_pid_1"]]$ci, positional$ci)))
+})

--- a/tests/testthat/test-generateReferenceDistribution2IFC.R
+++ b/tests/testthat/test-generateReferenceDistribution2IFC.R
@@ -19,3 +19,52 @@ test_that("generateReferenceDistribution2IFC saves a reference_norms vector of t
   expect_length(e$reference_norms, 3)
   expect_false(anyNA(e$reference_norms))
 })
+
+test_that("the reference norms are positive and actually vary across iterations", {
+  # Length and no-NAs (above) are satisfied by a vector of zeros, or by one
+  # where every iteration produced the same number. Both would be wrong in a
+  # way that matters: reference_norms is the null distribution InfoVal is
+  # scored against, and computeInfoVal2IFC() divides by its mad(), so a
+  # degenerate distribution yields Inf or NaN rather than an error.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  suppressWarnings(generateReferenceDistribution2IFC(rdata_path, iter = 8, ncores = 1))
+
+  e <- new.env()
+  load(rdata_path, envir = e)
+
+  # Each entry is a Frobenius norm of a non-degenerate CI, so strictly positive.
+  expect_true(all(e$reference_norms > 0))
+
+  # Responses are redrawn inside the loop, so the iterations must not collapse
+  # to one repeated value -- which is what drawing them once outside the loop
+  # would produce.
+  expect_gt(length(unique(e$reference_norms)), 1)
+  expect_gt(mad(e$reference_norms), 0)
+})
+
+test_that("the reference distribution is fixed by the stimulus file, not the caller's RNG state", {
+  # This is what makes InfoVal reproducible across sessions: the function
+  # re-generates the stimuli via generateStimuli2IFC(), which calls
+  # set.seed(seed) with the seed stored in the .Rdata file
+  # (R/generateStimuli2IFC.R:53). That reset governs the runif() draws in the
+  # simulation loop, so the same stimulus file gives the same reference
+  # distribution no matter what the ambient RNG was doing beforehand.
+  #
+  # Verified rather than assumed: seeding 42 vs 99 around the two calls below
+  # gives byte-identical norms.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  read_norms <- function(seed) {
+    withr::with_seed(seed, {
+      suppressWarnings(generateReferenceDistribution2IFC(rdata_path, iter = 8, ncores = 1))
+    })
+    e <- new.env()
+    load(rdata_path, envir = e)
+    e$reference_norms
+  }
+
+  expect_equal(read_norms(42), read_norms(99))
+})

--- a/tests/testthat/test-generateReferenceDistribution2IFC.R
+++ b/tests/testthat/test-generateReferenceDistribution2IFC.R
@@ -53,7 +53,14 @@ test_that("the reference distribution is fixed by the stimulus file, not the cal
   # distribution no matter what the ambient RNG was doing beforehand.
   #
   # Verified rather than assumed: seeding 42 vs 99 around the two calls below
-  # gives byte-identical norms.
+  # gives byte-identical norms, and ncores = 1 vs 2 also agree, so the null is
+  # portable across machines.
+  #
+  # Note this determinism is a *side effect* of the stimulus rebuild, not a
+  # designed guarantee -- there is no seed argument on this function. It is
+  # pinned here precisely because it is load-bearing but incidental: removing
+  # or moving that set.seed() would silently change every InfoVal ever
+  # computed. See BACKLOG.md item 26 for the design question.
   tmp <- withr::local_tempdir()
   rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
 

--- a/tests/testthat/test-plotZmap.R
+++ b/tests/testthat/test-plotZmap.R
@@ -42,6 +42,80 @@ test_that("decoration = FALSE works on a device too small for default margins", 
   expect_true(file.exists(file.path(tmp, "small.png")))
 })
 
+# The three tests above assert only that a file appeared, which was the right
+# bar for two hard-error regressions but says nothing about what was drawn: a
+# plotZmap() that wrote a blank image would pass all of them. These read the
+# PNG back and check the thresholding actually took effect. Rendering onto a
+# uniform background makes "nothing was painted" exactly equal to "the output
+# is the background", which is a comparison rather than an eyeball.
+render_zmap <- function(dir, zmap, name, threshold = 3) {
+  plotZmap(
+    zmap = zmap, bgimage = matrix(0.5, 8, 8), sigma = 3, threshold = threshold,
+    decoration = FALSE, targetpath = dir, filename = name, size = 64
+  )
+  png::readPNG(file.path(dir, paste0(name, ".png")))
+}
+
+test_that("sub-threshold z-scores are not painted and supra-threshold ones are", {
+  tmp <- withr::local_tempdir()
+
+  below <- render_zmap(tmp, matrix(1, 8, 8), "below")
+  above <- render_zmap(tmp, matrix(5, 8, 8), "above")
+
+  # Every cell is under threshold, so the z-map contributes nothing and the
+  # result is the bare background: a single grey value across the image.
+  expect_length(unique(as.vector(below)), 1)
+
+  # ...and when the z-map does clear the threshold, the output is no longer the
+  # background. Without this the assertion above is satisfied by a function
+  # that never draws anything at all.
+  expect_false(isTRUE(all.equal(above, below)))
+})
+
+test_that("the threshold is applied per pixel, not to the map as a whole", {
+  # Half the z-map above threshold, half below. The painted half must match a
+  # fully-painted render and the unpainted half must match a bare background,
+  # which pins *where* the thresholding lands rather than just that some of it
+  # happened.
+  tmp <- withr::local_tempdir()
+
+  split <- matrix(1, 8, 8)
+  split[, 1:4] <- 5
+
+  mixed <- render_zmap(tmp, split, "mixed")
+  above <- render_zmap(tmp, matrix(5, 8, 8), "all_above")
+  below <- render_zmap(tmp, matrix(1, 8, 8), "all_below")
+
+  expect_equal(mixed[, 1:32, ], above[, 1:32, ])
+  expect_equal(mixed[, 33:64, ], below[, 33:64, ])
+})
+
+test_that("z-scores beyond the negative threshold are painted too", {
+  # The threshold is applied to abs(zmap), so a strongly negative region is
+  # signal and must be drawn. A `zmap < threshold` implementation would drop
+  # it, and nothing else in the suite would notice.
+  tmp <- withr::local_tempdir()
+
+  negative <- render_zmap(tmp, matrix(-5, 8, 8), "negative")
+  below <- render_zmap(tmp, matrix(1, 8, 8), "neutral")
+
+  expect_false(isTRUE(all.equal(negative, below)))
+})
+
+test_that("raising the threshold removes regions from the z-map", {
+  # Monotonicity: the same z-map drawn at a stricter threshold must lose the
+  # region between the two thresholds and fall back to background there.
+  tmp <- withr::local_tempdir()
+  zmap <- matrix(4, 8, 8)
+
+  lenient <- render_zmap(tmp, zmap, "lenient", threshold = 3)
+  strict <- render_zmap(tmp, zmap, "strict", threshold = 10)
+  background <- render_zmap(tmp, matrix(0, 8, 8), "background", threshold = 3)
+
+  expect_false(isTRUE(all.equal(lenient, background)))
+  expect_equal(strict, background)
+})
+
 test_that("mismatched mask and zmap dimensions error", {
   tmp <- withr::local_tempdir()
 


### PR DESCRIPTION
Answers the question "are the tests testing intent, or just performative?" — asked before the CRAN submission, which seemed like the right time to check.

Audited all 23 test files. The suite is **mostly property-based** and holds up: independent oracles (`generateNoiseImage`'s per-pixel mean, plus a non-recycling check), algebraic identities (0°/90° transpose, π-shift negation, Gabor = sinusoid × Gaussian), each scaling method against its defining formula, template recovery, parallel equivalence, and an unbalanced-design case that keeps the participants/pooled equivalence non-vacuous.

Three files were the exception: they asserted **shape** where their titles claimed **behaviour**.

## What changed

**No `R/` changes.** These pin behaviour that is already correct. 180 → **203 passing, 0 skips, 14.4s**; the golden master is untouched, so researchers' numbers are unaffected.

### `batchGenerateCI` / `batchGenerateCI2IFC` — the real hole
Both tests were titled *"computes one CI per group"* and asserted only list length, field names and `dim`. **Grouping itself was never checked.** A bug handing every group the full data frame, or swapping the two groups, passed green.

Now each group's `$ci` is compared against a direct `generateCI()` on that subset alone, the list keys (`base_pid_1`/`base_pid_2`) are asserted, and the two groups are asserted *different* so the first check cannot pass vacuously. An **interleaved-`pid` fixture** distinguishes grouping-by-column from a positional first-half/second-half split — the contiguous fixture could not tell those two implementations apart — with the positional answer asserted different for the same reason.

Compares `$ci` rather than `$scaled`: the default `scaling = 'autoscale'` rewrites `$scaled` across the batch, and `$ci` is the field carrying published numbers.

### `plotZmap` — three of four assertions were `file.exists()`
A `plotZmap()` that wrote a uniformly blank PNG passed all of them. That was the right bar for two hard-error regressions, but it says nothing about what was drawn.

Rendering onto a **uniform background** makes "nothing was painted" exactly equal to "the output is the background" — so content becomes a comparison rather than an eyeball. Adds: sub- vs supra-threshold, per-pixel thresholding (half the map above, half below, each half matched against a full render), **negative** z-scores beyond threshold — pinning the `abs()`, which a `zmap < threshold` rewrite would break silently — and threshold monotonicity.

### `generateReferenceDistribution2IFC`
Length and no-NAs are satisfied by a vector of zeros, or by one where every iteration returned the same number. Both break InfoVal, which divides by `mad()`. Now asserts the norms are positive and genuinely vary — which catches responses drawn once outside the simulation loop.

**This one pins a stronger property than intended.** Seeding 42 vs 99 around two calls gives *byte-identical* norms: the function re-generates stimuli via `generateStimuli2IFC()`, whose `set.seed(seed)` at `R/generateStimuli2IFC.R:53` uses the seed from the `.Rdata` file, and that reset governs the later `runif()` draws. So the reference distribution — and therefore InfoVal — is reproducible from the stimulus file alone, whatever the caller's RNG was doing. Verified, not assumed, and now a test.

## Backlog items 23–25

**Item 23 is a real bug, filed rather than fixed.** `plotZmap()` validates its `mask` argument — reads it from a PNG, dimension-checks it, collapses identical RGB channels, converts to boolean — and then **never applies it**. `mask` appears nowhere after `R/plotZmap.R:69`. The documented behaviour does nothing, silently: the z-map renders and is simply wrong about which regions carry signal.

Narrow blast radius — `generateCI()` never passes `mask` to `plotZmap()` and masks the CI itself via `applyMask()` — but a fix changes rendered output for anyone currently passing it. That makes it a **behaviour change**, not an unambiguous bug fix, and the standing lesson from the `autoscale()`/`$combined` episode is to flag those rather than relabel them. No failing test was committed either: a knowingly red suite is worse than a backlog entry. Fix-or-deprecate is the maintainer's call.

Items 24 (a stray `./stimuli` directory, hidden because `stimuli` is git-ignored) and 25 (the `computeInfoVal2IFC` oracle recomputes the implementation's own formula, deliberately left alone) are logged with their reasoning.

## Method note

Every new discriminating assertion was prototyped first and confirmed to distinguish right from wrong pairings *before* being relied on — e.g. group 1's CI was verified **not** to equal group 2's direct result before the test asserted it equals group 1's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)