### PR TITLE
Make InfoVal's reference distribution deliberately seedable (item 26)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -70,7 +70,7 @@ they are the backlog proper for after CRAN, and are deliberately not in the tabl
 | 23 | `plotZmap(mask=)` validated then never applied | **Open, needs a decision.** A documented argument that silently does nothing; narrow blast radius (`generateCI()` never passes it), but fixing it changes rendered output, so it is a behaviour change rather than a plain bug fix | S |
 | 24 | `generateReferenceDistribution2IFC()` litters a `./stimuli` dir | Cosmetic; hidden until now because `stimuli` is git-ignored, so it never showed in `git status` | S |
 | 25 | InfoVal test oracle mirrors the implementation | **Deliberately left** — risk already covered by the hand-check against the erratum and the golden master. Logged so it is not mistaken for an independent check | S |
-| 26 | InfoVal's null is seeded by accident and cannot be varied | Behaviour is correct and worth keeping (MC error measured at ~0.04 infoVal units), but it is emergent rather than designed, and a stray edit to `set.seed()` in `generateStimuli2IFC()` would silently change every InfoVal | S |
+| ~~26~~ | ~~InfoVal's null is seeded by accident and cannot be varied~~ | **Done** — the determinism is now a documented guarantee with a comment guarding the `set.seed()` it rests on, and `response_seed` makes the null varyable on purpose. Default output verified byte-identical to before the change | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -872,14 +872,30 @@ The real risk is silent breakage: anyone who moves or removes that `set.seed()`,
 seed argument to `generateStimuli2IFC()`, changes every InfoVal ever computed without
 touching `computeInfoVal2IFC()` at all.
 
-- [ ] Document the determinism as an intended **guarantee** in
+**Done 2026-07-27.** All three boxes closed; default behaviour verified byte-identical
+against norms captured before the change.
+
+- [x] Document the determinism as an intended **guarantee** in
       `?generateReferenceDistribution2IFC`, and note that InfoVal is reproducible from the
       stimulus file alone.
-- [ ] Consider an explicit `seed` argument defaulting to the current behaviour, so the null
+- [x] Consider an explicit `seed` argument defaulting to the current behaviour, so the null
       *can* be varied deliberately. Purely additive — no change to the `.Rdata` contract or
-      to any existing call.
-- [ ] Add a comment at `R/generateStimuli2IFC.R:53` recording that the reference
+      to any existing call. Shipped as **`response_seed`**, not `seed`: `seed` is an object
+      in the `.Rdata` file, and since the function re-saves its own frame an argument of
+      that name would overwrite the stimulus seed *and be written back*, corrupting the
+      record of how the stimuli were generated. The seed is applied after the stimulus
+      rebuild, not forwarded into it — forwarding would rebuild a different stimulus set, so
+      the null would describe stimuli the participants never saw.
+- [x] Add a comment at `R/generateStimuli2IFC.R:53` recording that the reference
       distribution depends on that `set.seed()` call, so it is not moved casually.
+
+Also shipped: `save_rdata` and an invisible return on the generator, and a
+`reference_norms_seed` provenance field in the `.Rdata` (append-only) so a file carrying a
+varied null is distinguishable from one carrying the default.
+`computeInfoVal2IFC(response_seed = )` forces regeneration — without that it would have been
+silently ignored on every file that already had `reference_norms`, which is every file after
+the first call, the same shape as item 23's dead `mask` argument — and never caches its
+result.
 
 ### 25. `computeInfoVal2IFC`'s test oracle mirrors the implementation **[own review]**
 Found 2026-07-27 during the test-intent audit. `test-computeInfoVal2IFC.R:24` recomputes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,42 @@
+# rcicr (development version)
+
+## New features
+
+- `generateReferenceDistribution2IFC()` and `computeInfoVal2IFC()` gained a
+  `response_seed` argument, so the null distribution InfoVal is scored against can be
+  varied deliberately. Until now there was no way to draw a second, independent null from
+  the same stimuli — which meant you could not check how much Monte Carlo error your choice
+  of `iter` was leaving in your InfoVal. `response_seed` seeds the simulated responses only;
+  the stimuli, and so the noise basis the null is built on, are untouched.
+
+  **Existing calls are unaffected.** The default (`NULL`) issues no `set.seed()` call at
+  all, so the reference distribution is byte-identical to what earlier versions produced.
+  Verified against norms generated before the change, not merely assumed.
+
+  In `computeInfoVal2IFC()`, passing `response_seed` forces the reference distribution to be
+  regenerated even when the `.Rdata` file already holds one, and the result is deliberately
+  *not* written back — a one-off check of the Monte Carlo error cannot silently become the
+  number every later analysis of that stimulus set reports.
+
+- `generateReferenceDistribution2IFC()` gained `save_rdata` (default `TRUE`, i.e. unchanged)
+  and now returns the reference distribution invisibly instead of returning nothing, so the
+  norms are reachable when you ask it not to write them to the `.Rdata` file.
+
+- The `.Rdata` file gained a `reference_norms_seed` field recording the `response_seed` the
+  stored `reference_norms` were generated with (`NULL` for the default). Purely additive;
+  files written by earlier versions simply lack it. A stimulus set carrying a deliberately
+  varied null is no longer indistinguishable from one carrying the default.
+
+## Documentation
+
+- `?generateReferenceDistribution2IFC` now documents as a **guarantee** what was previously
+  only true by accident: with the default `response_seed`, the reference distribution — and
+  therefore InfoVal — is reproducible from the stimulus `.Rdata` file alone, independent of
+  the calling session's random number state and of `ncores`. This held before, but nobody
+  had chosen it: it is a consequence of `generateStimuli2IFC()`'s internal `set.seed()`
+  landing before the simulation draws. That call now carries a comment saying what depends
+  on it, so it is not moved casually.
+
 # rcicr 1.1.0 (2026-07-27)
 
 > First release since 1.0.1, and the version submitted to CRAN to reinstate the

--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -26,6 +26,14 @@
 #' @param rdata String pointing to .RData file that was created when stimuli were generated. This file contains the contrast parameters of all generated stimuli and possibly its corresponding reference distribution generated with generateReferenceDistribution().
 #' @param iter Number of iterations for the simulation of the reference distribution (only used if reference distribution is not already pre-generated and present in rdata file)
 #' @param force_gen_ref_dist Boolean specifying whether to override the default behavior to use pre-computed values for the reference distribution for specific task parameters and instead force to recompute the reference distribution (default: FALSE).
+#' @param response_seed Optional seed for the simulated random responses used to build the
+#' reference distribution. The default (\code{NULL}) uses the reference distribution stored in
+#' the \code{rdata} file, or generates the reproducible default one described under
+#' Reproducibility in \code{\link{generateReferenceDistribution2IFC}}. Supplying a number
+#' forces a fresh reference distribution to be simulated from an independent draw, which is
+#' how you check how much Monte Carlo error \code{iter} leaves in this Informational Value.
+#' The result is deliberately \emph{not} written back to the \code{rdata} file, so a one-off
+#' check cannot change the number every later analysis of that stimulus set reports.
 #' @return Informational value (z-score)
 #' @examples
 #' \donttest{
@@ -65,7 +73,7 @@
 #' computeInfoVal2IFC(target_ci = target_ci, rdata = rdata_file)
 #' }
 
-computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dist = FALSE) {
+computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dist = FALSE, response_seed = NULL) {
 
   # RD: To supress notes from R CMD CHECK, but thise should not be necessary -- debug
   ref_seed <- NA
@@ -78,10 +86,22 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
   # into the file - would overwrite the path we were called with. This function
   # still uses `rdata` further down (to regenerate and re-load), so it would
   # then operate on whatever path that file happened to record. Restore ours.
-  .args <- list(rdata = rdata, iter = iter)
+  .args <- list(rdata = rdata, iter = iter, response_seed = response_seed)
   load(rdata)
-  rdata <- .args$rdata
-  iter  <- .args$iter
+  rdata         <- .args$rdata
+  iter          <- .args$iter
+  response_seed <- .args$response_seed
+
+  # Asking for a specific response seed is asking for a specific reference
+  # distribution, so it has to imply regeneration. Without this the argument
+  # would be silently ignored on every file that already has reference_norms -
+  # which is every file after the first call, since generating one writes it
+  # back. That is the same shape of bug as force_gen_ref_dist being ignored
+  # (see the comment further down) and the documented-but-unapplied `mask`
+  # argument of plotZmap(): accepted, documented, and doing nothing.
+  if (!is.null(response_seed)) {
+    force_gen_ref_dist <- TRUE
+  }
 
   # Check whether reference norms are present or can be looked up from table. If not, re-generate.
   if (!force_gen_ref_dist & !exists("reference_norms", envir=environment(), inherits=FALSE)) {
@@ -149,17 +169,35 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
     # ignored whenever reference_norms already existed in the .Rdata file.
     if (force_gen_ref_dist | !exists("reference_norms", envir=environment(), inherits=FALSE)) {
 
-      # Reference norms not present in rdata file (or regeneration forced)
-      generateReferenceDistribution2IFC(rdata, iter=iter)
+      # Reference norms not present in rdata file (or regeneration forced).
+      #
+      # A caller-supplied response_seed is a one-off check, not a redefinition
+      # of this stimulus set's null, so it is never cached: saving it would
+      # silently change what every later InfoVal computed from this file means,
+      # for anyone using it, with nothing in the call to say so.
+      cache_ref_dist <- is.null(response_seed)
 
-      # Re-load rdata file
-      load(rdata)
+      reference_norms <- generateReferenceDistribution2IFC(
+        rdata, iter=iter, response_seed=response_seed, save_rdata=cache_ref_dist)
 
-      # NB: write() defaults to file = "data", so omitting stdout() here did
-      # not print this message - it silently created a file called "data" in
-      # the working directory. Every other write() in the package passes
-      # stdout(); this one was missed.
-      write("Note that now that this simulated reference distribution has been saved to the .Rdata file, the next time you call computeInfoVal2IFC(), it will not need to be computed again.", stdout())
+      if (cache_ref_dist) {
+
+        # Re-load rdata file
+        load(rdata)
+
+        # NB: write() defaults to file = "data", so omitting stdout() here did
+        # not print this message - it silently created a file called "data" in
+        # the working directory. Every other write() in the package passes
+        # stdout(); this one was missed.
+        write("Note that now that this simulated reference distribution has been saved to the .Rdata file, the next time you call computeInfoVal2IFC(), it will not need to be computed again.", stdout())
+
+      } else {
+
+        write(paste0("Reference distribution simulated with response_seed = ", response_seed,
+                     ". This is an independent draw of the null, not the reference distribution ",
+                     "stored in the .Rdata file, and it has deliberately not been saved there."), stdout())
+
+      }
 
     } else {
 

--- a/R/generateReferenceDistribution.R
+++ b/R/generateReferenceDistribution.R
@@ -4,15 +4,43 @@
 #'
 #' In order to compute the Informational Value metric. Saves its results in the supplied rdata file for later reuse.
 #'
+#' @section Reproducibility:
+#' With the default \code{response_seed = NULL}, the reference distribution is determined by
+#' the stimulus \code{.Rdata} file alone. It does not depend on the ambient random number
+#' state of the calling session, and it does not depend on \code{ncores}. Two researchers
+#' who compute InfoVal from the same stimulus file therefore get the same number, and the
+#' same reference distribution, on different machines and in different sessions.
+#'
+#' This is a guarantee, not a coincidence, and it is relied upon: the function re-generates
+#' the stimuli through \code{\link{generateStimuli2IFC}}, whose internal \code{set.seed()}
+#' call uses the seed stored in the \code{.Rdata} file and lands before the random responses
+#' below are drawn.
+#'
+#' Pass an explicit \code{response_seed} to draw a *different* null from the same stimuli --
+#' for instance to check how much Monte Carlo error a given \code{iter} leaves in your
+#' InfoVal. This changes only the simulated responses; the stimuli themselves, and so the
+#' noise basis the null is built on, are unaffected.
+#'
 #' @export
 #' @importFrom stats runif
 #' @importFrom utils txtProgressBar setTxtProgressBar
 #' @param rdata String pointing to .RData file that was created when stimuli were generated. This file contains the contrast parameters of all generated stimuli.
 #' @param iter Number of iterations for the simulation (i.e., the number of norms generated with classification images based on random responding).
 #' @param ncores Number of CPU cores to use when re-generating the stimuli (default: \code{detectCores()-1}; 2 under \code{R CMD check}, per CRAN policy).
-#' @return Nothing. The reference distribution (\code{reference_norms}) is added to the supplied
-#' \code{rdata} file, so a later call to \code{\link{computeInfoVal2IFC}} using the same file can
-#' reuse it instead of re-simulating.
+#' @param response_seed Optional seed for the simulated random responses. The default
+#' (\code{NULL}) draws them from the state left by the stimulus re-generation, which is the
+#' reproducible behaviour described under Reproducibility. Supply a number to obtain an
+#' independent draw of the null from the same stimuli.
+#' @param save_rdata Boolean specifying whether the reference distribution should be written
+#' back into the \code{rdata} file (default \code{TRUE}). Set to \code{FALSE} to compute a
+#' distribution without changing what later calls to \code{\link{computeInfoVal2IFC}} will
+#' use -- worth doing whenever \code{response_seed} is set, so a one-off null does not become
+#' the file's permanent reference.
+#' @return The reference distribution, invisibly, as a numeric vector of \code{iter} norms.
+#' Unless \code{save_rdata = FALSE}, it is also added to the supplied \code{rdata} file as
+#' \code{reference_norms} (alongside \code{reference_norms_seed}, recording the
+#' \code{response_seed} it was generated with), so a later call to
+#' \code{\link{computeInfoVal2IFC}} using the same file can reuse it instead of re-simulating.
 #' @examples
 #' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
@@ -40,7 +68,7 @@
 #'   suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
 #' })
 #' }
-generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_ncores()) {
+generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_ncores(), response_seed=NULL, save_rdata=TRUE) {
 
   # load() assigns straight into this function's frame, so any object stored in
   # the .Rdata file silently overwrites an argument of the same name. This
@@ -49,14 +77,22 @@ generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_
   # call on the same file would ignore the ncores the caller passed and write
   # back to the path recorded during the first call. Keep private copies and
   # restore them after loading.
-  .args <- list(rdata = rdata, iter = iter, ncores = ncores)
+  #
+  # This is also why the response seed is called `response_seed` and not `seed`:
+  # `seed` is the stimulus seed stored in the file, so an argument of that name
+  # would overwrite it here and then be written back, corrupting the record of
+  # how the stimuli were generated.
+  .args <- list(rdata = rdata, iter = iter, ncores = ncores,
+                response_seed = response_seed, save_rdata = save_rdata)
 
   # Load parameter file (created when generating stimuli)
   load(rdata)
 
-  rdata  <- .args$rdata
-  iter   <- .args$iter
-  ncores <- .args$ncores
+  rdata         <- .args$rdata
+  iter          <- .args$iter
+  ncores        <- .args$ncores
+  response_seed <- .args$response_seed
+  save_rdata    <- .args$save_rdata
 
   # Recover the noise-basis parameters used for the real stimuli. These were
   # not saved before this version, so .Rdata files written by older rcicr lack
@@ -82,6 +118,19 @@ generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_
 
   # Simulate random responding in 2IFC task with ntrials trials across iter iterations
   write("Computing reference distribution, please wait...", stdout())
+
+  # Seed the *responses* only, and only when asked. This deliberately sits after
+  # the stimulus re-generation above rather than being passed into it: handing a
+  # different seed to generateStimuli2IFC() would rebuild a different stimulus
+  # set, so the null would describe stimuli the participants never saw. What
+  # varies here is the simulated responding, on the same stimuli.
+  #
+  # NULL means no set.seed() call at all, leaving the stream exactly as the
+  # stimulus re-generation left it - so the default path is byte-identical to
+  # what previous versions produced, not merely equivalent.
+  if (!is.null(response_seed)) {
+    set.seed(response_seed)
+  }
 
   if (iter < 10000) {
     warning("You should set iter >= 10000 for InfoVal statistic to be reliable")
@@ -111,19 +160,35 @@ generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_
       reference_norms[i] <- norm(ci, "f")
   }
 
-  # Save reference norms to rdata file
-  write("\nSaving simulated reference distribution to rdata file...", stdout())
   close(pb)
 
-  # Save everything that came from (or belongs in) the stimulus file, but none
-  # of this function's own arguments or scratch variables. Writing `rdata` and
-  # `ncores` back into the file is what causes the clobbering described at the
-  # top of this function, so they are excluded at the source rather than only
-  # worked around on read.
-  outfile <- rdata
-  internals <- c("stimuli", "responses", "pb", "ci", "i", ".args",
-                 "rdata", "iter", "ncores", "outfile", "internals")
-  save(list=setdiff(ls(all.names=TRUE), internals), file=outfile,
-       envir=environment())
+  if (save_rdata) {
+
+    # Save reference norms to rdata file
+    write("\nSaving simulated reference distribution to rdata file...", stdout())
+
+    # Record which seed produced these norms, so a file carrying a deliberately
+    # varied null is distinguishable from one carrying the default. NULL records
+    # the default stream. Files written before this version simply lack the
+    # field, which is why every read of it must be guarded with exists().
+    reference_norms_seed <- response_seed
+
+    # Save everything that came from (or belongs in) the stimulus file, but none
+    # of this function's own arguments or scratch variables. Writing `rdata` and
+    # `ncores` back into the file is what causes the clobbering described at the
+    # top of this function, so they are excluded at the source rather than only
+    # worked around on read. `response_seed` and `save_rdata` are excluded for
+    # the same reason - `reference_norms_seed` is the field that records the
+    # seed, and it is a description of the norms rather than an input.
+    outfile <- rdata
+    internals <- c("stimuli", "responses", "pb", "ci", "i", ".args",
+                   "rdata", "iter", "ncores", "response_seed", "save_rdata",
+                   "outfile", "internals")
+    save(list=setdiff(ls(all.names=TRUE), internals), file=outfile,
+         envir=environment())
+
+  }
+
+  invisible(reference_norms)
 
 }

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -50,6 +50,15 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
   # Initialize #
   p <- generateNoisePattern(img_size, noise_type=noise_type, nscales=nscales, sigma=sigma)
   dir.create(stimulus_path, recursive=T, showWarnings = F)
+
+  # More depends on this call than the stimuli. generateReferenceDistribution2IFC()
+  # re-generates stimuli through this function and then draws its simulated
+  # responses with runif(), *after* this set.seed() has run - which is what makes
+  # every Informational Value reproducible from the stimulus file alone, and is
+  # documented as a guarantee in ?generateReferenceDistribution2IFC.
+  #
+  # So moving or removing this line, or reseeding after it, changes every InfoVal
+  # ever computed with this package without touching computeInfoVal2IFC() at all.
   set.seed(seed)
 
   stimuli_params <- list()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -45,7 +45,7 @@ if (getRversion() >= "2.15.1")
   utils::globalVariables(
     c(
       # Suppress checking notes for variables loaded at runtime from .RData files
-      "p", "s", "base_faces", "stimuli_params", "img_size", "base_face_files", "n_trials", "seed", "noise_type", "reference_norms",
+      "p", "s", "base_faces", "stimuli_params", "img_size", "base_face_files", "n_trials", "seed", "noise_type", "reference_norms", "reference_norms_seed",
 
       # Suppress checking notes for variables in foreach loop (parallel runs)
       "obs"

--- a/man/computeInfoVal2IFC.Rd
+++ b/man/computeInfoVal2IFC.Rd
@@ -4,7 +4,13 @@
 \alias{computeInfoVal2IFC}
 \title{Computes Informational Value}
 \usage{
-computeInfoVal2IFC(target_ci, rdata, iter = 10000, force_gen_ref_dist = FALSE)
+computeInfoVal2IFC(
+  target_ci,
+  rdata,
+  iter = 10000,
+  force_gen_ref_dist = FALSE,
+  response_seed = NULL
+)
 }
 \arguments{
 \item{target_ci}{A classification image object (list-type) as returned by generateCI}
@@ -14,6 +20,15 @@ computeInfoVal2IFC(target_ci, rdata, iter = 10000, force_gen_ref_dist = FALSE)
 \item{iter}{Number of iterations for the simulation of the reference distribution (only used if reference distribution is not already pre-generated and present in rdata file)}
 
 \item{force_gen_ref_dist}{Boolean specifying whether to override the default behavior to use pre-computed values for the reference distribution for specific task parameters and instead force to recompute the reference distribution (default: FALSE).}
+
+\item{response_seed}{Optional seed for the simulated random responses used to build the
+reference distribution. The default (\code{NULL}) uses the reference distribution stored in
+the \code{rdata} file, or generates the reproducible default one described under
+Reproducibility in \code{\link{generateReferenceDistribution2IFC}}. Supplying a number
+forces a fresh reference distribution to be simulated from an independent draw, which is
+how you check how much Monte Carlo error \code{iter} leaves in this Informational Value.
+The result is deliberately \emph{not} written back to the \code{rdata} file, so a one-off
+check cannot change the number every later analysis of that stimulus set reports.}
 }
 \value{
 Informational value (z-score)

--- a/man/generateReferenceDistribution2IFC.Rd
+++ b/man/generateReferenceDistribution2IFC.Rd
@@ -7,7 +7,9 @@
 generateReferenceDistribution2IFC(
   rdata,
   iter = 10000,
-  ncores = default_ncores()
+  ncores = default_ncores(),
+  response_seed = NULL,
+  save_rdata = TRUE
 )
 }
 \arguments{
@@ -16,11 +18,24 @@ generateReferenceDistribution2IFC(
 \item{iter}{Number of iterations for the simulation (i.e., the number of norms generated with classification images based on random responding).}
 
 \item{ncores}{Number of CPU cores to use when re-generating the stimuli (default: \code{detectCores()-1}; 2 under \code{R CMD check}, per CRAN policy).}
+
+\item{response_seed}{Optional seed for the simulated random responses. The default
+(\code{NULL}) draws them from the state left by the stimulus re-generation, which is the
+reproducible behaviour described under Reproducibility. Supply a number to obtain an
+independent draw of the null from the same stimuli.}
+
+\item{save_rdata}{Boolean specifying whether the reference distribution should be written
+back into the \code{rdata} file (default \code{TRUE}). Set to \code{FALSE} to compute a
+distribution without changing what later calls to \code{\link{computeInfoVal2IFC}} will
+use -- worth doing whenever \code{response_seed} is set, so a one-off null does not become
+the file's permanent reference.}
 }
 \value{
-Nothing. The reference distribution (\code{reference_norms}) is added to the supplied
-\code{rdata} file, so a later call to \code{\link{computeInfoVal2IFC}} using the same file can
-reuse it instead of re-simulating.
+The reference distribution, invisibly, as a numeric vector of \code{iter} norms.
+Unless \code{save_rdata = FALSE}, it is also added to the supplied \code{rdata} file as
+\code{reference_norms} (alongside \code{reference_norms_seed}, recording the
+\code{response_seed} it was generated with), so a later call to
+\code{\link{computeInfoVal2IFC}} using the same file can reuse it instead of re-simulating.
 }
 \description{
 Generates reference distribution of norms for a particular set of task parameters.
@@ -28,6 +43,25 @@ Generates reference distribution of norms for a particular set of task parameter
 \details{
 In order to compute the Informational Value metric. Saves its results in the supplied rdata file for later reuse.
 }
+\section{Reproducibility}{
+
+With the default \code{response_seed = NULL}, the reference distribution is determined by
+the stimulus \code{.Rdata} file alone. It does not depend on the ambient random number
+state of the calling session, and it does not depend on \code{ncores}. Two researchers
+who compute InfoVal from the same stimulus file therefore get the same number, and the
+same reference distribution, on different machines and in different sessions.
+
+This is a guarantee, not a coincidence, and it is relied upon: the function re-generates
+the stimuli through \code{\link{generateStimuli2IFC}}, whose internal \code{set.seed()}
+call uses the seed stored in the \code{.Rdata} file and lands before the random responses
+below are drawn.
+
+Pass an explicit \code{response_seed} to draw a *different* null from the same stimuli --
+for instance to check how much Monte Carlo error a given \code{iter} leaves in your
+InfoVal. This changes only the simulated responses; the stimuli themselves, and so the
+noise basis the null is built on, are unaffected.
+}
+
 \examples{
 \donttest{
 # a synthetic square grayscale image stands in for a real base face photo

--- a/tests/testthat/test-computeInfoVal2IFC.R
+++ b/tests/testthat/test-computeInfoVal2IFC.R
@@ -24,3 +24,36 @@ test_that("computeInfoVal2IFC uses a pre-seeded reference distribution and never
   expected <- (norm(matrix(target_ci$ci), "f") - median(e$reference_norms)) / mad(e$reference_norms)
   expect_equal(iv, expected)
 })
+
+test_that("response_seed regenerates the null even when the .Rdata already has one, and never caches it", {
+  # The trap this guards. computeInfoVal2IFC() only calls the generator when
+  # reference_norms is absent or force_gen_ref_dist is TRUE -- and the first
+  # call writes reference_norms into the file. So a response_seed that was
+  # merely passed through would be accepted, documented, and silently ignored on
+  # every call after the first. That is the same shape as force_gen_ref_dist
+  # being ignored in this exact branch, and as plotZmap()'s documented-but-
+  # unapplied `mask`. Asserting the seeded result *differs* from the cached one
+  # is what makes this test non-vacuous.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+  seed_reference_norms(rdata_path, n = 50, seed = 1)
+
+  cached <- new.env()
+  load(rdata_path, envir = cached)
+
+  target_ci <- list(ci = matrix(withr::with_seed(2, rnorm(32 * 32)), 32, 32))
+
+  iv_cached <- computeInfoVal2IFC(target_ci = target_ci, rdata = rdata_path)
+  iv_seeded <- suppressWarnings(computeInfoVal2IFC(
+    target_ci = target_ci, rdata = rdata_path, iter = 8, response_seed = 99))
+
+  expect_false(identical(iv_cached, iv_seeded))
+
+  # The one-off check must not have become this stimulus set's reference
+  # distribution: the file's norms are untouched, and a later default call
+  # returns exactly what it did before.
+  after <- new.env()
+  load(rdata_path, envir = after)
+  expect_identical(after$reference_norms, cached$reference_norms)
+  expect_equal(computeInfoVal2IFC(target_ci = target_ci, rdata = rdata_path), iv_cached)
+})

--- a/tests/testthat/test-generateReferenceDistribution2IFC.R
+++ b/tests/testthat/test-generateReferenceDistribution2IFC.R
@@ -56,11 +56,13 @@ test_that("the reference distribution is fixed by the stimulus file, not the cal
   # gives byte-identical norms, and ncores = 1 vs 2 also agree, so the null is
   # portable across machines.
   #
-  # Note this determinism is a *side effect* of the stimulus rebuild, not a
-  # designed guarantee -- there is no seed argument on this function. It is
-  # pinned here precisely because it is load-bearing but incidental: removing
-  # or moving that set.seed() would silently change every InfoVal ever
-  # computed. See BACKLOG.md item 26 for the design question.
+  # This determinism began as a *side effect* of the stimulus rebuild rather
+  # than a designed guarantee. Backlog item 26 resolved that: it is now
+  # documented as a guarantee under ?generateReferenceDistribution2IFC, the
+  # set.seed() call it rests on carries a comment saying so, and the deliberate
+  # way to vary the null is the response_seed argument tested below. This test
+  # is the guarantee's guard -- removing or moving that set.seed() would
+  # silently change every InfoVal ever computed.
   tmp <- withr::local_tempdir()
   rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
 
@@ -74,4 +76,123 @@ test_that("the reference distribution is fixed by the stimulus file, not the cal
   }
 
   expect_equal(read_norms(42), read_norms(99))
+})
+
+test_that("response_seed varies the null reproducibly, and NULL leaves the default alone", {
+  # The point of the argument is to let a user draw an independent null from the
+  # same stimuli -- e.g. to measure how much Monte Carlo error a given iter
+  # leaves in their InfoVal. Two claims have to hold together: the same seed
+  # must reproduce, and different seeds must actually differ. Without the
+  # second, the first is satisfied by an argument that is ignored entirely.
+  tmp <- withr::local_tempdir()
+  pristine <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  # Each run gets its own copy, since a run with save_rdata = TRUE rewrites the file.
+  norms_for <- function(tag, ...) {
+    path <- file.path(tmp, paste0(tag, ".Rdata"))
+    file.copy(pristine, path, overwrite = TRUE)
+    suppressWarnings(generateReferenceDistribution2IFC(path, iter = 8, ncores = 1, ...))
+  }
+
+  expect_equal(norms_for("s99a", response_seed = 99), norms_for("s99b", response_seed = 99))
+  expect_false(identical(norms_for("s99a2", response_seed = 99),
+                         norms_for("s1234", response_seed = 1234)))
+
+  # And a seeded null is not just the default null relabelled.
+  expect_false(identical(norms_for("seeded", response_seed = 99), norms_for("default")))
+})
+
+test_that("response_seed reaches the responses, and never the stimulus rebuild", {
+  # This is the whole semantic distinction, and the reason the seed is not
+  # simply forwarded to generateStimuli2IFC(): handing that function a different
+  # seed would rebuild a *different stimulus set*, so the null would describe
+  # stimuli the participants never saw.
+  #
+  # It has to be tested on the call itself. Comparing p/stimuli_params in the
+  # .Rdata before and after is vacuous -- the rebuild runs with
+  # save_rdata = FALSE and never writes stimuli back, so the file is unchanged
+  # whichever seed the rebuild received. A mutant forwarding response_seed to
+  # generateStimuli2IFC() passed that version of this test.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  # Grab the real function before mocking, so the mock can delegate to it.
+  real_generate <- get("generateStimuli2IFC", envir = asNamespace("rcicr"))
+  seen_seed <- NULL
+
+  testthat::local_mocked_bindings(
+    generateStimuli2IFC = function(..., seed) {
+      seen_seed <<- seed
+      real_generate(..., seed = seed)
+    },
+    .package = "rcicr"
+  )
+
+  suppressWarnings(generateReferenceDistribution2IFC(
+    rdata_path, iter = 8, ncores = 1, response_seed = 99))
+
+  # The stimulus seed stored in the file, not the response seed we passed.
+  stored <- new.env()
+  load(rdata_path, envir = stored)
+  expect_equal(seen_seed, stored$seed)
+  expect_false(identical(seen_seed, 99))
+})
+
+test_that("save_rdata = FALSE returns the norms without touching the file", {
+  # Needed so a one-off check of the null cannot become the stimulus set's
+  # permanent reference distribution. The norms are only reachable through the
+  # return value in that case, which is why the function returns them at all.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  norms <- suppressWarnings(generateReferenceDistribution2IFC(
+    rdata_path, iter = 8, ncores = 1, response_seed = 99, save_rdata = FALSE))
+
+  expect_length(norms, 8)
+  expect_true(all(norms > 0))
+
+  e <- new.env()
+  load(rdata_path, envir = e)
+  expect_false(exists("reference_norms", envir = e, inherits = FALSE))
+
+  # Discriminating case: the same call with save_rdata = TRUE does write it,
+  # so the assertion above is about the flag and not about the call failing.
+  suppressWarnings(generateReferenceDistribution2IFC(
+    rdata_path, iter = 8, ncores = 1, response_seed = 99, save_rdata = TRUE))
+  e2 <- new.env()
+  load(rdata_path, envir = e2)
+  expect_equal(e2$reference_norms, norms)
+})
+
+test_that("the saved file records which seed produced its norms, and no arguments", {
+  # Provenance: a file carrying a deliberately varied null must be
+  # distinguishable from one carrying the default, otherwise the two are
+  # indistinguishable to anyone who picks the file up later.
+  #
+  # The second half guards the clobbering trap documented at the top of
+  # generateReferenceDistribution2IFC(): an argument left in the frame at save
+  # time becomes an *input* to the next call's load(). That is what happened to
+  # `rdata` and `ncores`, and is why the seed is recorded under a different name
+  # (reference_norms_seed) than the argument that sets it (response_seed).
+  tmp <- withr::local_tempdir()
+  pristine <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  read_after <- function(tag, ...) {
+    path <- file.path(tmp, paste0(tag, ".Rdata"))
+    file.copy(pristine, path, overwrite = TRUE)
+    suppressWarnings(generateReferenceDistribution2IFC(path, iter = 8, ncores = 1, ...))
+    e <- new.env()
+    load(path, envir = e)
+    e
+  }
+
+  default_run <- read_after("default")
+  expect_true(exists("reference_norms_seed", envir = default_run, inherits = FALSE))
+  expect_null(default_run$reference_norms_seed)
+
+  seeded_run <- read_after("seeded", response_seed = 99)
+  expect_equal(seeded_run$reference_norms_seed, 99)
+
+  expect_false(any(c("response_seed", "save_rdata", "rdata", "ncores", "iter") %in%
+                     ls(seeded_run, all.names = TRUE)))
 })


### PR DESCRIPTION
Closes backlog item 26.

## What and why

The reference distribution InfoVal is scored against has always been fully deterministic — but nobody chose that. `generateReferenceDistribution2IFC()` rebuilds the stimuli through `generateStimuli2IFC()`, whose internal `set.seed(seed)` uses the seed stored in the `.Rdata` file and lands *before* the simulation loop's `runif()` draws.

That behaviour is worth keeping: it is what makes InfoVal reproducible from a stimulus file alone, and the Monte Carlo error it freezes in is immaterial (relative SD 0.19% on the median, 1.26% on the mad at `iter = 10000`; a CI at infoVal ≈ 3 spans 2.95–3.06). But it was emergent, undocumented, and left **no way to draw a second null** — so a user could not check how much Monte Carlo error their choice of `iter` was leaving behind. Measuring the numbers above required batching one long run by hand.

## Changes

- **`response_seed`** on `generateReferenceDistribution2IFC()` and `computeInfoVal2IFC()`, seeding the simulated *responses*. Applied after the stimulus rebuild rather than forwarded into it — forwarding would rebuild a different stimulus set, so the null would describe stimuli the participants never saw.
- **The determinism is now a documented guarantee** in `?generateReferenceDistribution2IFC`, and the `set.seed()` call it rests on carries a comment recording what depends on it.
- **`save_rdata`**, an invisible return of the norms, and a **`reference_norms_seed`** provenance field in the `.Rdata` (append-only) so a file carrying a varied null is distinguishable from one carrying the default.

## Existing results are unaffected

`response_seed = NULL` issues no `set.seed()` call at all, so the default path is **byte-identical**, verified against reference norms captured before any code change rather than assumed. The golden master is green and `NEWS.md` needs no "Reproducibility impact" entry.

## Two design points worth the reviewer's attention

**Named `response_seed`, not `seed`.** `seed` is an object in the `.Rdata` file. Since the function re-saves its own frame, an argument of that name would overwrite the stimulus seed *and be written back*, corrupting the record of how the stimuli were generated — the clobbering that already caught `rdata` and `ncores`, one step worse.

**`computeInfoVal2IFC(response_seed=)` forces regeneration and never caches.** The generator writes `reference_norms` into the file, so without the forced regeneration the argument would be silently ignored on every call after the first — the same shape as `force_gen_ref_dist` being ignored in that exact branch, and as `plotZmap()`'s documented-but-unapplied `mask` (item 23). And caching a one-off Monte Carlo check would silently redefine what every later InfoVal from that stimulus set means.

## Verification

Mutation-checked rather than assumed — each of these is caught by a failing test:

| mutation | caught |
|---|---|
| drop the forced regeneration | 1 failure |
| leave `response_seed` in the saved frame | 1 failure |
| forward the seed to the stimulus rebuild | 2 failures |
| cache the varied null | 2 failures |

The third one **was not caught at first.** The test compared `p`/`stimuli_params` in the file before and after, which is vacuous: the rebuild runs with `save_rdata = FALSE` and never writes stimuli back, so the file is unchanged whichever seed the rebuild received. It now asserts what `generateStimuli2IFC()` is actually called with. Same performative-assertion trap as #138, found because the mutant survived.

219 tests pass, 0 skips, ~17s (from 203). `R CMD check --as-cran`: 0 errors, 0 warnings, 2 expected NOTEs.

## Note before merging

`main` now moves past the 1.1.0 that is awaiting CRAN submission. **The submission tarball should be built from the 1.1.0 release point, not `main` HEAD.** `DESCRIPTION` is deliberately left at `1.1.0` here — see the branching/versioning discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)