### PR TITLE
Tag-based releases: bump main to 1.1.0.9000, document the convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,33 @@ Version/date/dependency metadata lives in `DESCRIPTION`; user-facing changes sho
   rebase merges are still permitted in the repository settings, so it is on whoever
   merges to pick the right one.
 
+## Releases and versioning
+
+Trunk-based with tags — the standard R-package layout (what r-lib/tidyverse do). There is
+**no `develop` branch** and there should not be one: CRAN has no concept of it, this is a
+single-maintainer package, and it would add a permanent second merge direction for no gain.
+Feature branches → PR → squash onto `main`, and releases are marked by tags.
+
+- **`main` carries a `.9000` development version between releases.** Right after a release,
+  `DESCRIPTION` goes to `<released>.9000` (e.g. `1.1.0.9000`); the release commit drops it
+  to the clean number. `NEWS.md` accumulates entries under a
+  `# rcicr (development version)` heading, which gets renamed to `# rcicr X.Y.Z (date)` at
+  release time.
+- **Tag every release** — `git tag -a vX.Y.Z <release commit>` plus a GitHub release. This
+  was missing until 2026-07-27 and it cost real clarity: `main` had moved two PRs past the
+  1.1.0 that was awaiting CRAN submission, and nothing recorded which tree that was. `v1.1.0`
+  is tagged retroactively at `a3904e8`.
+- **Build the CRAN tarball from the tag, never from `main` HEAD.** This is also what keeps
+  the `.9000` suffix safe: `Version contains large components` is only a CRAN blocker if the
+  *submitted tarball* carries it, and a tarball built from the tag never does. Do not drop
+  the development-version convention to avoid that NOTE.
+- **Order `NEWS.md` entries largest-impact first** within each section — changes to numeric
+  output or return values, then behaviour changes, then bug fixes that only ever produced
+  errors, then message-only fixes. Someone who stops reading after three bullets should have
+  read the three that could change their results.
+- Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
+  clears the stale remote refs locally.
+
 ## Backlog
 
 `BACKLOG.md` is the prioritized modernization backlog — read it before starting substantial work, and update it when you close something out. It was compiled from the open GitHub issues, the published literature, and a direct source review, and it records:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.1.0
+Version: 1.1.0.9000
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:


### PR DESCRIPTION
Follow-up to the branching/versioning discussion. No code changes — `DESCRIPTION` and `CLAUDE.md` only.

## The gap

The repo had **zero tags and zero GitHub releases**. `main` had already moved two PRs past the 1.1.0 that is awaiting CRAN submission, and nothing recorded which tree that was — so "what exactly are we submitting?" had no answer.

Fixed outside this PR, since neither needs review:
- **`v1.1.0` tagged** retroactively at `a3904e8`, the release commit.
- **[GitHub release](https://github.com/rdotsch/rcicr/releases/tag/v1.1.0)** published, pointing at the `NEWS.md` "Reproducibility impact" section.

## This PR

- **`DESCRIPTION` back to `1.1.0.9000`.** `main` should not claim to be a version that has already shipped.
- **`CLAUDE.md` gains a "Releases and versioning" section** recording the convention so it isn't re-derived.

## Why the `.9000` suffix is safe again

`Version contains large components (1.0.1.9000)` was a real CRAN NOTE and the last mechanical blocker cleared before 1.1.0 — but it only bites because the *submitted tarball* carried the suffix. **Building the tarball from the tag means it never can.** So the development-version convention comes back rather than being permanently abandoned to dodge a NOTE.

## Why no `develop` branch

That would be GitFlow, and it's a poor fit: CRAN has no concept of it, this is a single-maintainer package, and it adds a permanent second merge direction to keep in sync for no gain. Trunk plus tags is both simpler and what r-lib/tidyverse actually do.

## Note on merge order

The `# rcicr (development version)` heading in `NEWS.md` that this pairs with is added in #139. The two don't conflict (different files) and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)