### PR TITLE
Record the real rcicr version in the generated .Rdata (#29)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -747,7 +747,7 @@ checklist at the top of this item, which is the live one.
 ## P2 — Usability and maintainability
 
 ### 13. Modernize the R code itself
-- [ ] **[own review]** Version metadata is inconsistent and stale. `generateStimuli2IFC()`
+- [x] **[own review]** Version metadata is inconsistent and stale. `generateStimuli2IFC()`
       hardcodes `generator_version <- '0.4.0'` (`R/generateStimuli2IFC.R:168`) into every
       `.Rdata` file, while `generateNoisePattern()` writes the real
       `utils::packageVersion('rcicr')`. So a file written today claims to come from 0.4.0
@@ -755,6 +755,13 @@ checklist at the top of this item, which is the live one.
       `pre_0.3.0`-style compatibility checks that key off it. Covers issue
       [#29](https://github.com/rdotsch/rcicr/issues/29). Replace the literal with
       `utils::packageVersion('rcicr')`, but keep *reading* tolerant of old values.
+      **Done 2026-07-27.** Nothing in the package reads the field, so "keep reads
+      tolerant" had no code to change — the tolerance requirement is instead recorded at
+      the write site and in `NEWS.md`, because it falls on *user* code: files in the wild
+      say `'0.4.0'` regardless of what wrote them, and the field is now a
+      `package_version` rather than a character string. The `pre_0.3.0` compatibility path
+      does not in fact key off this field — it detects the old `sinusoids`/`sinIdx` layout
+      structurally — which is just as well, given the field was lying.
 - [ ] **[own review]** The `matlab` package exports its own `sum()` with MATLAB semantics
       (column sums for a matrix, not a single total), which masks `base::sum()` wherever
       `@import matlab` is in effect — six files. Package code is currently safe (its only

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,21 @@
   files written by earlier versions simply lack it. A stimulus set carrying a deliberately
   varied null is no longer indistinguishable from one carrying the default.
 
+## Bug fixes
+
+- The `.Rdata` file written by `generateStimuli2IFC()` now records the rcicr version that
+  actually wrote it (#29). `generator_version` was a hardcoded `'0.4.0'` string from 2016
+  onwards, so every file produced by 0.4.0 through 1.1.0 claims to come from 0.4.0 —
+  useless for the provenance the field exists for, and it disagreed with
+  `p$generator_version`, which held the real version all along.
+
+  No result changes: nothing in the package has ever read this field. If your own code
+  does, note two things. Existing files cannot be trusted to say what wrote them, so treat
+  a stored `'0.4.0'` as "unknown, somewhere between 0.4.0 and 1.1.0" rather than as a
+  version. And the field is now a `package_version` object rather than a character string,
+  so compare with `utils::packageVersion()` or `numeric_version()`, never as text —
+  `'0.10.0' < '0.4.0'` is `TRUE` when compared as strings.
+
 ## Documentation
 
 - `?generateReferenceDistribution2IFC` now documents as a **guarantee** what was previously

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -214,7 +214,17 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
   cl <- NULL
 
   # Save all to image file (IMPORTANT, this file is necessary to analyze your data later and create classification images)
-  generator_version <- '0.4.0'
+  #
+  # This records which rcicr wrote the file. It was a hardcoded '0.4.0' string
+  # from 2016 until 1.1.0.9000, so *every* .Rdata written by 0.4.0 through 1.1.0
+  # claims to come from 0.4.0 no matter what actually wrote it. Anything reading
+  # this field must therefore treat '0.4.0' as "unknown, somewhere in that
+  # range" rather than as a real version, and must accept both a character
+  # string (old files) and the package_version object written here (new ones) --
+  # note that comparing versions as strings is wrong anyway, since '0.10.0' sorts
+  # below '0.4.0'. p$generator_version has always held the real version and is
+  # the more trustworthy of the two on any file that has it.
+  generator_version <- utils::packageVersion('rcicr')
 
   if (save_rdata) {
     # nscales and sigma are saved so that anything re-generating this stimulus

--- a/tests/testthat/test-smoke-pipeline.R
+++ b/tests/testthat/test-smoke-pipeline.R
@@ -35,6 +35,28 @@ test_that("generateStimuli2IFC produces stimuli, PNGs, and a loadable .Rdata end
   expect_equal(e$img_size, 32)
 })
 
+test_that("the .Rdata records the rcicr version that actually wrote it", {
+  # generator_version was a hardcoded '0.4.0' literal from 2016 until
+  # 1.1.0.9000, so it described no file written after 0.4.0 and was useless for
+  # the provenance purpose it exists for (issue #29). It must now agree with the
+  # installed version, and with p$generator_version, which was already correct --
+  # the two disagreeing is what made the field untrustworthy in the first place.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 4, nscales = 1, seed = 1)
+
+  e <- new.env()
+  load(rdata_path, envir = e)
+
+  installed <- as.character(utils::packageVersion("rcicr"))
+  expect_equal(as.character(e$generator_version), installed)
+  expect_equal(as.character(e$p$generator_version), installed)
+
+  # The specific failure being guarded against: any run reporting the frozen
+  # literal. Kept as its own assertion so a future re-freeze reads as such
+  # rather than as a stale-installed-package problem.
+  expect_false(identical(as.character(e$generator_version), "0.4.0"))
+})
+
 test_that("full pipeline: generateStimuli2IFC -> generateCI produces a classification image", {
   tmp <- withr::local_tempdir()
   input_dir <- file.path(tmp, "input")


### PR DESCRIPTION
Closes #29. Closes the first bullet of backlog item 13.

## What and why

`generateStimuli2IFC()` hardcoded `generator_version <- '0.4.0'` — a literal set in 2016 and never touched again. Every `.Rdata` file written by rcicr 0.4.0 through 1.1.0 therefore claims to come from 0.4.0, whatever actually wrote it. That is exactly backwards from the purpose of a provenance field, and it disagreed with `p$generator_version`, which has always written the real `utils::packageVersion('rcicr')`.

Issue #29 is a 2016 reminder to bump the literal before finalising 0.4.0. Bumping it by hand is what got us here; it now derives from `DESCRIPTION` and cannot go stale again.

## No result changes

Nothing in the package has ever *read* the top-level field, so the backlog's "keep reads tolerant of old values" had no code to change. The tolerance requirement falls on user code, and is recorded at the write site and in `NEWS.md` instead:

- **Old files cannot be trusted to say what wrote them.** A stored `'0.4.0'` means "unknown, somewhere between 0.4.0 and 1.1.0", not a version.
- **The field is now a `package_version`, not a character string.** Compare with `numeric_version()` semantics, never as text — `'0.10.0' < '0.4.0'` is `TRUE` when compared as strings, which is the trap a naive check would fall into once versions pass 0.9.

Worth noting for anyone auditing the backwards-compatibility paths: `pre_0.3.0` handling does **not** key off this field. It detects the old `sinusoids`/`sinIdx` layout structurally — just as well, given the field was lying.

## Verification

Mutation-checked: restoring the `'0.4.0'` literal fails the new test twice (once on the version equality, once on the explicit anti-freeze assertion, which is kept separate so a future re-freeze reads as such rather than as a stale installed package).

222 tests pass, 0 skips. `R CMD check --as-cran`: 0 errors, 0 warnings, 2 expected NOTEs. `test-regression-baseline.R` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)