### PR TITLE
Support pre-noise_type .Rdata files, fix the data-frame progress bar (#94, #82)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -919,6 +919,30 @@ suite is the one in `test-generateNoiseImage.R`.
 - [ ] If ever revisited: assert against a worked example taken from the paper, or a
       hand-computed case with a fixed 2×2 CI and a known reference vector.
 
+### 27. `return_as_dataframe = TRUE` silently drops all but the first base image **[verified] [own review]**
+Found 2026-07-27 while fixing issue [#82](https://github.com/rdotsch/rcicr/issues/82). The
+`return()` that hands back a trial's noise sits *inside* the per-base-image loop, so with
+several base images it fires on the first one and the rest never run. The returned data
+frame has one column per trial, not per trial × base image, so the shape cannot represent
+them anyway.
+
+With the default `use_same_parameters = TRUE` this is correct — every base image shares one
+parameter set, so one noise image per trial is all there is. With
+`use_same_parameters = FALSE` the caller silently receives only the first base image's
+noise.
+
+**InfoVal is not affected, checked rather than assumed.**
+`generateReferenceDistribution2IFC()` is the only in-package caller of this path. It does
+not pass `use_same_parameters`, so the rebuild always uses the default, and the first base
+image's parameters are drawn from the same leading block of the RNG stream either way —
+measured identical, max absolute difference 0 across both settings with two base images.
+
+- [ ] Document the restriction on `@param return_as_dataframe`: one noise image per trial,
+      meaningful only under `use_same_parameters = TRUE`.
+- [ ] Only if a user actually needs it: widen the returned frame to trial × base image.
+      That changes the return shape, so it needs a new argument rather than a redefinition
+      — the `.Rdata`/return contract is append-only.
+
 ### 16. Memory ceiling on large stimulus sets — concrete root cause found **[own review]**  ✅ **FIXED**
 Issue [#12](https://github.com/rdotsch/rcicr/issues/12) reports that large stimulus sets
 exhaust memory, with the suggested fix being "distribute stimulus matrices over multiple

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,20 @@
 
 ## Bug fixes
 
+- `computeInfoVal2IFC()` and `generateReferenceDistribution2IFC()` work on `.Rdata` files
+  written before `noise_type` was saved (#94). Such a file failed outright with
+  `object 'noise_type' not found`, and the workaround on record was to load the file and
+  assign the variable by hand. It now falls back to `sinusoid` with a loud warning, matching
+  how `nscales` is handled — a warning rather than a silent default, because guessing wrong
+  means the null is built on a different *kind* of noise than participants saw, and the
+  resulting InfoVal would be wrong. Files written by 1.1.0 or later already store the field
+  and are unaffected.
+
+- `generateStimuli2IFC(return_as_dataframe = TRUE)` shows its progress bar (#82). The
+  `return` handing back each trial's noise exits the entire loop body, so it jumped past the
+  progress-bar update and the bar sat at zero for the whole run — on the slowest path there
+  is, since `generateReferenceDistribution2IFC()` takes it for every InfoVal.
+
 - The `.Rdata` file written by `generateStimuli2IFC()` now records the rcicr version that
   actually wrote it (#29). `generator_version` was a hardcoded `'0.4.0'` string from 2016
   onwards, so every file produced by 0.4.0 through 1.1.0 claims to come from 0.4.0 —

--- a/R/generateReferenceDistribution.R
+++ b/R/generateReferenceDistribution.R
@@ -111,6 +111,21 @@ generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_
   if (!exists('sigma', envir=environment(), inherits=FALSE)) {
     sigma <- 25
   }
+  # Same story for noise_type, which older .Rdata files also lack. Without this
+  # the re-generation below failed outright with "object 'noise_type' not
+  # found" (issue #94) - the workaround on record was to load the file and
+  # assign noise_type by hand. It gets the same loud warning as nscales rather
+  # than the silent default given to sigma, because guessing wrong here means
+  # the null is built on a different *kind* of noise than participants saw.
+  if (!exists('noise_type', envir=environment(), inherits=FALSE)) {
+    noise_type <- 'sinusoid'
+    warning(paste0('This .Rdata file was written by a version of rcicr that ',
+                   'did not save `noise_type`, so the default (sinusoid) is ',
+                   'assumed for the reference distribution. If the stimuli ',
+                   'were generated with noise_type = "gabor", the resulting ',
+                   'infoVal will be wrong - regenerate the stimulus set with ',
+                   'this version of rcicr to fix this.'))
+  }
 
   # Re-generate stimuli based on rdata parameters in matrix form
   write("Re-generating stimuli based on rdata file, please wait...", stdout())

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -201,6 +201,13 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
 
       # Return CI
       if (return_as_dataframe) {
+        # Advance the bar here too. This return exits the entire foreach body,
+        # not just this loop, so the update below it never ran on this path and
+        # the bar sat at zero for the whole run (issue #82). It is duplicated
+        # rather than hoisted above the loop deliberately: `trial_noise` is
+        # reassigned per base face when use_same_parameters is FALSE, so moving
+        # this return would change *which* base face's noise is returned.
+        setTxtProgressBar(pb, trial)
         return(as.vector(trial_noise))
       }
     }

--- a/tests/testthat/test-generateReferenceDistribution2IFC.R
+++ b/tests/testthat/test-generateReferenceDistribution2IFC.R
@@ -44,6 +44,55 @@ test_that("the reference norms are positive and actually vary across iterations"
   expect_gt(mad(e$reference_norms), 0)
 })
 
+test_that("an .Rdata file predating noise_type still works, and says so", {
+  # Issue #94. Old files have no noise_type, and re-generating the stimuli from
+  # one failed outright with "object 'noise_type' not found". The workaround on
+  # record was to load the file and assign noise_type by hand.
+  tmp <- withr::local_tempdir()
+  rdata_path <- make_fixture_rdata(tmp, img_size = 32, n_trials = 6, nscales = 1, seed = 1)
+
+  # Age the fixture by removing the field, which is how a pre-0.3.x file looks.
+  e <- new.env()
+  load(rdata_path, envir = e)
+  rm("noise_type", envir = e)
+  save(list = ls(e), file = rdata_path, envir = e)
+
+  # Collected by hand rather than with expect_warning(): the iter < 10000
+  # warning fires too, and this needs to assert on one specific warning without
+  # swallowing or being tripped by the other.
+  collect_warnings <- function(expr) {
+    seen <- character()
+    withCallingHandlers(
+      expr,
+      warning = function(cond) {
+        seen <<- c(seen, conditionMessage(cond))
+        invokeRestart("muffleWarning")
+      }
+    )
+    seen
+  }
+
+  warnings_seen <- collect_warnings(
+    generateReferenceDistribution2IFC(rdata_path, iter = 3, ncores = 1))
+
+  expect_true(any(grepl("did not save `noise_type`", warnings_seen, fixed = TRUE)))
+
+  # It has to actually finish, not just warn on the way to the old error.
+  after <- new.env()
+  load(rdata_path, envir = after)
+  expect_length(after$reference_norms, 3)
+  expect_false(anyNA(after$reference_norms))
+
+  # And the warning must be specific to the missing field, or it is just noise
+  # on every call.
+  fresh <- make_fixture_rdata(withr::local_tempdir(), img_size = 32, n_trials = 6,
+                              nscales = 1, seed = 1)
+  expect_false(any(grepl(
+    "did not save `noise_type`",
+    collect_warnings(generateReferenceDistribution2IFC(fresh, iter = 3, ncores = 1)),
+    fixed = TRUE)))
+})
+
 test_that("the reference distribution is fixed by the stimulus file, not the caller's RNG state", {
   # This is what makes InfoVal reproducible across sessions: the function
   # re-generates the stimuli via generateStimuli2IFC(), which calls

--- a/tests/testthat/test-smoke-pipeline.R
+++ b/tests/testthat/test-smoke-pipeline.R
@@ -57,6 +57,37 @@ test_that("the .Rdata records the rcicr version that actually wrote it", {
   expect_false(identical(as.character(e$generator_version), "0.4.0"))
 })
 
+test_that("the progress bar advances even when returning a data frame", {
+  # Issue #82. The return that hands back the trial's noise exits the whole
+  # foreach body, so it used to jump straight past setTxtProgressBar() and the
+  # bar stayed at zero for the entire run -- on exactly the path that takes
+  # longest to sit through, since generateReferenceDistribution2IFC() uses it.
+  tmp <- withr::local_tempdir()
+  png_path <- file.path(tmp, "base.png")
+  make_square_png(png_path, size = 32)
+
+  run <- function(return_as_dataframe) {
+    # The result is assigned, not left to auto-print: with
+    # return_as_dataframe = TRUE the returned data frame would otherwise be
+    # printed into the capture and swamp the progress bar being measured.
+    capture.output(
+      result <- generateStimuli2IFC(
+        base_face_files = list(base = png_path),
+        n_trials = 5, img_size = 32, stimulus_path = tmp,
+        seed = 1, ncores = 1, nscales = 1,
+        save_as_png = FALSE, save_rdata = FALSE,
+        return_as_dataframe = return_as_dataframe
+      ),
+      type = "output"
+    )
+  }
+
+  # Compared against the normal path rather than asserted as "not empty", so
+  # this cannot pass on a bar that emits one stray character and then stalls.
+  expect_gt(sum(nchar(run(TRUE))), 0)
+  expect_equal(sum(nchar(run(TRUE))), sum(nchar(run(FALSE))))
+})
+
 test_that("full pipeline: generateStimuli2IFC -> generateCI produces a classification image", {
   tmp <- withr::local_tempdir()
   input_dir <- file.path(tmp, "input")


### PR DESCRIPTION
Closes #94. Closes #82.

Two small independent fixes that happen to meet at `generateStimuli2IFC()`'s `return_as_dataframe` path.

## #94 — old `.Rdata` files could not be used at all

Files written before `noise_type` was saved failed outright in `generateReferenceDistribution2IFC()` with `object 'noise_type' not found`, so `computeInfoVal2IFC()` was unusable on them. The workaround on record in the issue was to load the file and assign the variable by hand.

Now falls back to `sinusoid` with a **loud warning** — matching the treatment `nscales` got in 1.1.0, rather than the silent default given to `sigma`. The distinction matters: guessing wrong here means the null is built on a different *kind* of noise than participants saw, so the InfoVal is wrong rather than merely approximate. Files written by 1.1.0 or later store the field and are unaffected.

## #82 — progress bar frozen on the data-frame path

The `return` handing back each trial's noise exits the whole `foreach` body, not just the inner loop, so it jumped straight past `setTxtProgressBar()`. Measured: **0 progress characters emitted on that path against 800 on the normal one.** This is the slowest path there is — `generateReferenceDistribution2IFC()` takes it for every InfoVal — so the bar was missing exactly where someone is most likely to be waiting on it.

The advance is duplicated before the `return` rather than hoisted above the loop, deliberately: `trial_noise` is reassigned per base image when `use_same_parameters = FALSE`, so moving the `return` would change *which* base image's noise comes back.

## One thing found on the way, logged not fixed

Backlog item 27: `return_as_dataframe = TRUE` returns one noise image per trial regardless of how many base images were passed, so under `use_same_parameters = FALSE` the caller silently receives only the first. The returned frame's shape cannot represent more.

**InfoVal is not affected — checked, not assumed.** `generateReferenceDistribution2IFC()` is the only in-package caller, it does not pass `use_same_parameters`, and the first base image's parameters come off the same leading block of the RNG stream either way: measured identical across both settings with two base images, max absolute difference 0. Not fixed here because widening the returned frame changes its shape, which the append-only contract does not permit silently.

## Verification

Mutation-checked — removing the progress-bar advance fails 2 assertions; removing the `noise_type` fallback reproduces **the exact error string from #94's report**.

228 tests pass, 0 skips. `R CMD check --as-cran`: 0 errors, 0 warnings, 2 expected NOTEs. `test-regression-baseline.R` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
