### PR TITLE
Reopen development: bump to 1.2.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.2.0
+Version: 1.2.0.9000
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rcicr (development version)
+
 # rcicr 1.2.0 (2026-07-28)
 
 *Upgrading from the CRAN version?* The last release on CRAN was 0.3.4.1, before the package


### PR DESCRIPTION
Step 4 of `CONTRIBUTING.md`'s release checklist, after v1.2.0 went out as `526ced0` / tag `v1.2.0`.

- `DESCRIPTION` → `1.2.0.9000`
- `NEWS.md` gains a fresh `# rcicr (development version)` heading

## Why this is more than bookkeeping

Restoring the `.9000` suffix is what flips `.github/workflows/reproducibility.yaml` back to the everyday `--quick` battery. The job reads the version out of `DESCRIPTION` and treats the *absence* of the suffix as "this is a release", so the same edit that marks a release turns the full ~20-minute gate on, and this one turns it back off. Nothing to label and nothing to remember — which is the point of doing it that way.

## Checked

The empty development section still parses. R indexes only sections under a `#` heading it can read a version from, so `tools:::.build_news_db_from_package_NEWS_md("NEWS.md")` returns the same 10 rows (1.2.0 and 1.1.0) as before, with no error and no NOTE. The development section stays out of the news database until it is renamed at release — correct, not a problem.

No test pins a version literal: `test-smoke-pipeline.R` and `test-generateNoisePattern.R` both compare `generator_version` against `utils::packageVersion("rcicr")` at runtime.

The CRAN tarball is built from the `v1.2.0` tag, never from `main` HEAD, so `Version contains large components` cannot reach a submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)