### PR TITLE
Add the R-hub v2 workflow (workflow_dispatch only)

### DIFF
--- a/.github/workflows/rhub.yaml
+++ b/.github/workflows/rhub.yaml
@@ -1,0 +1,99 @@
+# R-hub's generic GitHub Actions workflow file. It's canonical location is at
+# https://github.com/r-hub/actions/blob/v1/workflows/rhub.yaml
+# You can update this file to a newer version using the rhub2 package:
+#
+# rhub::rhub_setup()
+#
+# It is unlikely that you need to modify this file manually.
+
+name: R-hub
+run-name: >-
+  ${{ github.event.inputs.id || format('Manual run by @{0}', github.triggering_actor) }}:
+  ${{ github.event.inputs.name || github.event.inputs.config }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: >-
+          Comma-separated list of R-hub platforms to use.
+          Full list: https://r-hub.github.io/containers/
+        type: string
+        default: 'linux,windows,macos'
+      name:
+        description: 'Run name. You can leave this empty.'
+        type: string
+      id:
+        description: 'Unique ID. You can leave this empty.'
+        type: string
+
+jobs:
+
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      containers: ${{ steps.rhub-setup.outputs.containers }}
+      platforms: ${{ steps.rhub-setup.outputs.platforms }}
+
+    steps:
+    # NO NEED TO CHECKOUT HERE
+    - uses: r-hub/actions/setup@v1
+      with:
+        config: ${{ github.event.inputs.config }}
+      id: rhub-setup
+
+  linux-containers:
+    needs: setup
+    if: ${{ needs.setup.outputs.containers != '[]' }}
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.containers) }}
+    container:
+      image: ${{ matrix.config.container }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+
+  other-platforms:
+    needs: setup
+    if: ${{ needs.setup.outputs.platforms != '[]' }}
+    runs-on: ${{ matrix.config.os }}
+    name: ${{ matrix.config.label }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config: ${{ fromJson(needs.setup.outputs.platforms) }}
+
+    steps:
+      - uses: r-hub/actions/checkout@v1
+      - uses: r-hub/actions/setup-r@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/platform-info@v1
+        with:
+          token: ${{ secrets.RHUB_TOKEN }}
+          job-config: ${{ matrix.config.job-config }}
+      - uses: r-hub/actions/setup-deps@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}
+      - uses: r-hub/actions/run-check@v1
+        with:
+          job-config: ${{ matrix.config.job-config }}
+          token: ${{ secrets.RHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,9 +176,17 @@ the tarball in front of a third party.
   on this repository's own Actions rather than uploading anywhere. Trigger it from the
   Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
   `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
-  scope — `rhub::rhub_doctor()` reports whether yours has it. Because the workflow is
-  `workflow_dispatch`-only, it must be merged to the **default branch** before it can be
-  triggered at all.
+  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
+  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
+  **default branch** before it can be triggered at all, and R-hub wants the file on the
+  default branch *and* on whichever branch is being checked.
+
+  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
+  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
+  optional slot for your own PAT to reach private repositories — not a credential R-hub
+  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
+  any step. This package is public; an unset secret expands to an empty string and the jobs
+  run normally.
 
 **Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
 package archived over an undeliverable address, that confirmation *is* the point of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,9 +161,24 @@ NOTEs are expected and explained in `cran-comments.md` — CRAN incoming feasibi
 submission of an archived package) and future file timestamps (no network clock in a
 sandbox).
 
-Then run `devtools::check_win_devel()` and `rhub::rhub_check()`, and record their results in
-the two `<!-- TODO -->` markers in `cran-comments.md`. These upload the tarball to third
-parties and email the maintainer, which is why they are not run casually.
+Then run the two external checks and record their results in the `<!-- TODO -->` markers in
+`cran-comments.md`. Neither is run casually: win-builder mails the maintainer, and both put
+the tarball in front of a third party.
+
+- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()`, run
+  from a checkout of the tag. Each FTPs the tarball to `win-builder.r-project.org` and mails
+  a check log to the maintainer address within the hour. The server **will not overwrite an
+  existing upload**: a second attempt at the same filename fails with a bare
+  `Failed FTP upload: 550`, which means "already queued", not "rejected". Confirm with
+  `curl --list-only ftp://win-builder.r-project.org/R-devel/` before re-uploading, or you
+  will conclude the upload failed when it succeeded.
+- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
+  on this repository's own Actions rather than uploading anywhere. Trigger it from the
+  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
+  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
+  scope — `rhub::rhub_doctor()` reports whether yours has it. Because the workflow is
+  `workflow_dispatch`-only, it must be merged to the **default branch** before it can be
+  triggered at all.
 
 **Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
 package archived over an undeliverable address, that confirmation *is* the point of the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -293,6 +293,19 @@ The mechanics are in `CLAUDE.md` and `CONTRIBUTING.md`. What is easy to reintrod
 RStudio-template leftover, so it never shipped to CI or to other contributors at all. Do not
 re-add it.
 
+### R-hub runs on `workflow_dispatch` only, never on push
+The R-hub v2 workflow is the stock file `rhub::rhub_setup()` writes, kept unmodified so it can
+be refreshed from upstream. It is left trigger-on-demand because R-hub answers a question that
+only arises at release time — does this build on Windows, macOS and the odd CRAN compiler
+flags — and the everyday answer is already covered by `R-CMD-check.yaml` on release and devel.
+Running it per-PR would spend a matrix of platforms on a question nobody asked yet, and it
+would compete with the ~11-minute reproducibility gate that *is* required on every code PR.
+
+The cost of `workflow_dispatch`-only is that the workflow is invisible until it reaches the
+**default branch** — GitHub offers no "Run workflow" button for a file that exists only on a
+feature branch. So it merges to `main` ahead of the release it is meant to check, not
+alongside it.
+
 ### The 75,000-line artifact commit
 One branch carried ~75,000 lines of committed `R CMD check` artifacts across three commits,
 unnoticed because only the diffs of edited files were ever read — hence the `git diff --stat


### PR DESCRIPTION
Adds `.github/workflows/rhub.yaml` — the stock file `rhub::rhub_setup()` writes, unmodified so it can be refreshed from upstream. This is the R-hub half of the two pre-submission checks `CONTRIBUTING.md` asks for at release time; win-builder is the other half and does not live in the repo.

**Why `workflow_dispatch`-only.** R-hub answers a release-time question — does this build on Windows, macOS and CRAN's compiler flags — that `R-CMD-check.yaml` already covers day to day on release and devel. A per-PR platform matrix would spend a lot of CI on a question nobody has asked yet, and compete with the ~11-minute reproducibility gate that *is* required on every code PR.

**Why it merges now rather than with the release.** GitHub shows no "Run workflow" button for a workflow that exists only on a feature branch, so `workflow_dispatch` is invisible until the file is on the default branch. It has to land before it can be triggered even once.

No `.Rbuildignore` entry is needed — `^\.github$` already covers it.

### Docs

`CONTRIBUTING.md`'s release checklist gains what the two external checks actually cost:

- **R-hub** — trigger from the Actions tab (needs only repository access). `rhub::rhub_check()` does the same over the API but wants a GitHub PAT with the `repo` scope; `rhub::rhub_doctor()` reports whether yours has it. The token in the dev container does not.
- **win-builder** — the server will not overwrite a queued upload, so a second attempt at the same filename fails with a bare `Failed FTP upload: 550`. That reads as a failure and means *already queued*. Verified the hard way: a 1.2.0 tarball that had uploaded fine minutes earlier produced exactly that error on a retry. Check `curl --list-only ftp://win-builder.r-project.org/R-devel/` before concluding anything failed.

`DECISIONS.md` records the trigger choice under "Packaging, CI and tooling".

### Status of the checks themselves

Both win-builder uploads for 1.2.0 are already queued (R-devel 14:18 UTC, R-release 14:28 UTC), built from the `v1.2.0` tag. Results go to the maintainer address by email; the `<!-- TODO -->` markers in `cran-comments.md` stay open until those and an R-hub run come back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)