### PR TITLE
Release 1.2.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+Changes 1.2.1 [28-Jul-2026]
+
+* See NEWS.md for this release. It is the canonical changelog from 1.1.0 onward.
+* In brief: no user-facing changes. Nothing the package computes differs from 1.2.0.
+  The release exists because the 1.2.0 tree does not pass R CMD check on macOS —
+  a test in the suite asserted properties of a rendered PNG that belong to the
+  graphics device rather than to the drawing. No released function was affected.
+* R CMD check now runs on macOS and Windows as well as Linux on every change.
+
 Changes 1.2.0 [28-Jul-2026]
 
 * See NEWS.md for this release. It is the canonical changelog from 1.1.0 onward.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.2.0.9000
+Version: 1.2.1
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,39 @@
-# rcicr (development version)
+# rcicr 1.2.1 (2026-07-28)
+
+**No user-facing changes.** Nothing this package computes differs from 1.2.0 — no function,
+argument, return value or number has changed, and no analysis script needs revisiting.
+
+The release exists because the 1.2.0 source tree does not pass `R CMD check` on macOS. The
+fault was in the package's own test suite, not in the package: a test asserted properties of
+a rendered PNG that belong to the graphics device rather than to what was drawn, and those
+properties differ between macOS and Linux. No released function was ever affected. A package
+still has to pass its own checks on the platforms CRAN builds for, which is what this
+release restores.
+
+## Documentation
+
+- **`?plotZmap` and the README now describe what is and is not reproducible across operating
+  systems.** Classification images, scaling, informational value and the z-scores themselves
+  are ordinary R arithmetic and do not depend on your platform — as of this release that is
+  verified on Linux, macOS and Windows on every change, rather than assumed. The PNG written
+  by `plotZmap()` is the one exception: it is drawn through a graphics device, and devices
+  differ by platform in colour management and in whether they write an alpha channel, so the
+  same z-map produces visibly identical figures whose files are not byte-identical.
+
+  The practical advice, now stated in both places: **compare numbers, not rendered figures**,
+  when checking that an analysis reproduces. A z-map image that differs pixel-for-pixel on a
+  colleague's machine is not a different result. Every other PNG the package writes —
+  stimuli, classification images, autoscaled classification images — is written directly
+  from the pixel array and carries no such dependence.
+
+## Internal
+
+- `R CMD check` now runs on macOS and Windows as well as Linux, on every change. It
+  previously varied only the R version against a single platform, which is how the macOS
+  failure above went unnoticed.
+- The test suite pins z-map values as well as classification images, scaling and
+  informational value, so cross-platform agreement of the numbers is checked rather than
+  assumed.
 
 # rcicr 1.2.0 (2026-07-28)
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -19,27 +19,38 @@ found by a systematic source review, adds a test suite (previously there was non
 continuous integration, and removes 13 unused dependencies.
 
 **On the version number.** The archived CRAN version is 0.3.4.1 and this submission is
-1.2.0. Nothing is missing: 1.0.1 and 1.1.0 exist only as GitHub releases, made while the
-package was off CRAN, and 1.1.0 in particular was never published anywhere a user could
-install it from. `NEWS.md` carries their entries, so the record between 0.3.4.1 and 1.2.0
-is complete.
+1.2.1. Nothing is missing: 1.0.1, 1.1.0 and 1.2.0 exist only as GitHub releases, made while
+the package was off CRAN, and none of them was published anywhere a user could install it
+from with `install.packages()`. `NEWS.md` carries their entries, so the record between
+0.3.4.1 and 1.2.1 is complete.
+
+1.2.1 follows 1.2.0 by a short interval and contains no user-facing change. 1.2.0 did not
+pass `R CMD check` on macOS: a test in the package's own suite asserted properties of a
+rendered PNG that belong to the graphics device rather than to what was drawn, and those
+differ between macOS and Linux. No released function was affected and nothing the package
+computes changed, but the tree could not pass its own checks on a platform CRAN builds for,
+so it is not the tree we are asking you to accept.
 
 ## Test environments
 
 * local: Ubuntu 24.04, R 4.3.3 — `R CMD check --as-cran`, with
   `_R_CHECK_CRAN_INCOMING_=TRUE` and `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`
-* GitHub Actions: ubuntu-latest, R release and R devel
-* win-builder, R-devel — Windows Server 2022, R Under development (2026-07-26 r90304 ucrt):
-  **1 NOTE**, the CRAN incoming feasibility note below
-* win-builder, R-release — Windows Server 2022, R 4.6.1: **1 NOTE**, the same one
-* R-hub: Linux, Windows, macOS  <!-- TODO: run and record result -->
+* GitHub Actions: ubuntu-latest on R release and R devel, macos-latest on R release,
+  windows-latest on R release — all green
+* win-builder, R-devel  <!-- TODO: re-run against the 1.2.1 tarball and record result -->
+* win-builder, R-release  <!-- TODO: re-run against the 1.2.1 tarball and record result -->
+* R-hub: Linux, Windows, macOS  <!-- TODO: run against 1.2.1 and record result -->
+
+The win-builder results previously recorded here were for the **1.2.0** tarball (R-devel
+2026-07-26 r90304 ucrt and R 4.6.1, 1 NOTE each — the incoming feasibility note below).
+They are not carried forward: the submitted tarball has changed, so they are re-run rather
+than assumed still to hold.
 
 ## R CMD check results
 
 0 errors | 0 warnings | 2 notes
 
-Both win-builder runs reported **1 NOTE** — only the first of the two below. The second is
-local to our build machine.
+The second is local to our build machine; on win-builder only the first appeared.
 
 ### NOTE 1 — CRAN incoming feasibility
 


### PR DESCRIPTION
Step 1 of `CONTRIBUTING.md`'s release checklist. The four release edits, made together.

## Why 1.2.1 exists

**No user-facing change.** Nothing the package computes differs from 1.2.0 — no function, argument, return value or number, and no analysis script needs revisiting.

The 1.2.0 tree does not pass `R CMD check` on macOS. A test in the package's own suite asserted properties of a rendered PNG that belong to the graphics **device** rather than to what was drawn, and those differ between macOS and Linux. **No released function was ever affected.** But `tests/` is not in `.Rbuildignore`, so the tests ship and CRAN runs them, and a tree that cannot pass its own checks on a platform CRAN builds for is not one to submit. `BACKLOG.md` item 20 has carried that warning since the failure was found.

`NEWS.md` leads with "no user-facing changes" rather than warning people off 1.2.0, because 1.2.0 was a GitHub-only tag that nobody could `install.packages()` — there is no installed base to warn.

## The four edits

| file | change |
|---|---|
| `NEWS.md` | development heading → `# rcicr 1.2.1 (2026-07-28)` |
| `DESCRIPTION` | `1.2.0.9000` → `1.2.1` |
| `ChangeLog` | dated pointer entry deferring to `NEWS.md` |
| `cran-comments.md` | re-read rather than trusted — three stale claims, below |

Dropping the `.9000` is also what switches the reproducibility gate from the everyday `--quick` run to the **full battery**, which is why it has to happen before the PR is opened rather than after review.

## `cran-comments.md` had gone stale in three places

`CONTRIBUTING.md` says to re-read every claim in it rather than trust it. That earned itself again:

- The version paragraph said the submission was 1.2.0, and listed 1.0.1 and 1.1.0 as the GitHub-only releases. **1.2.0 has joined that list.**
- Test environments said `GitHub Actions: ubuntu-latest, R release and R devel`. It is now **four jobs across three platforms**.
- The recorded **win-builder results were for the 1.2.0 tarball**, and are *not* carried forward. The submitted tarball has changed, so both runs go back to `<!-- TODO -->` markers to be re-run against 1.2.1 rather than assumed still to hold. Same for the R-hub marker — the only R-hub run so far is the one that failed on macOS against 1.2.0.

## Verified locally

- **`NEWS.md` still parses.** `tools:::.build_news_db_from_package_NEWS_md()` returns 13 rows across 1.2.1, 1.2.0 and 1.1.0, none with an unreadable version. Section headings avoid version-shaped text, which would NOTE the whole file.
- **`R CMD build` + `R CMD check --no-manual` on the tarball: `Status: OK`**, with examples, tests and vignette re-building all actually executed. Tests inside the built package report `FAIL 0 | WARN 0 | SKIP 5 | PASS 223` — the 5 skips are the four `skip_on_cran()` guards plus the `tools/` test, correct for a built package rather than a checkout.

One warning worth recording so it is not mistaken for a package fault later: a first check run reported `checking R files for syntax errors ... WARNING`, which was the build container missing the `en_US.UTF-8` locale. Generating the locale and re-running gives `Status: OK`.

**Not verified locally:** `--as-cran`'s incoming feasibility checks need network access the build environment does not have, so the two expected NOTEs (archived/new submission, future file timestamps) are unconfirmed here. CI's full gate and the win-builder runs cover that.

## What to watch on this PR

The full battery runs here — both gate runs, against v1.0.1 and against v1.2.0 as the previous release — and takes ~20 minutes rather than the usual ~11.

This is also the first release PR since `macos-latest` and `windows-latest` joined the check matrix, so the merge box is the first confirmation that all four `R CMD check` jobs plus `compare` are enforced as required checks.

## After merge

Tag `v1.2.1` and push the tag (which re-runs the full gate against the released tree), create the GitHub release, then build **from the tag** for win-builder devel + release and an R-hub dispatch, recording those results in the TODO markers before submitting. The v1.2.1 tag will contain `rhub.yaml`, so R-hub can be dispatched against the tag directly — the throwaway branch that 1.2.0 needed is no longer necessary.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4j1pEStw2piD1FJXrBfEY)_