### PR TITLE
Record the 1.2.1 external check results, and run them earlier next time

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -92,7 +92,7 @@ they are the backlog proper for after CRAN, and are deliberately kept out of the
 | ~~12~~ | ~~Widen test coverage (scaling methods, z-maps, `participants`)~~ | **Done** — suite at 180 tests, 0 skips. It found three real `plotZmap()` bugs in code that read fine, one of which made `zmapdecoration = FALSE` entirely dead since R 4.2 | M |
 | ~~18~~ | ~~Codecov step fails for want of a token~~ | **Done** — `fail_ci_if_error: false`; a red `main` now means the package is broken | S |
 | ~~19~~ | ~~Close the 8 issues already fixed in `main`~~ | **Done** — 7 closed, #12 commented and left open as only partly fixed. ~22 remaining issues still unswept | S |
-| 20 | CRAN resubmission checklist | **Every box ticked**; `--as-cran` is 0 errors / 0 warnings / 2 expected NOTEs. Only the submission itself is left, and CRAN mails the maintainer to confirm it | M |
+| 20 | CRAN resubmission checklist | **Every box ticked**; `--as-cran` is 0 errors / 0 warnings / 2 expected NOTEs, and the external checks are in as of 2026-07-29 (win-builder 1 NOTE on both, R-hub OK on all three platforms). Only the submission itself is left, and CRAN mails the maintainer to confirm it | M |
 | 21 | Announcement post | Drafted in `notes/`; hold until the CRAN outcome is known | S |
 | ~~22~~ | ~~Move the Medium walkthrough into a vignette~~ | **Done** — `vignettes/reverse-correlation-walkthrough.Rmd`. It now executes at build time, which proved its own premise: two lines of the published tutorial had already stopped working | M |
 | ~~23~~ | ~~`plotZmap(mask=)` validated then never applied~~ | **Done** — the mask is applied, under a "Behaviour change" heading in `NEWS.md`. It had never worked in any released version, so no published result depended on the old output. Two more bugs sat behind it, including a boolean conversion that set every cell `FALSE` | S |
@@ -595,10 +595,10 @@ Best done as one batch after #131 merges, so #122 closes with it rather than by 
 > package returning from archival should not arrive already red. See `DECISIONS.md` → Testing
 > for the underlying rule.
 >
-> **The win-builder results in `cran-comments.md` are for the v1.2.0 tarball and were
-> deliberately not carried forward.** win-builder R-devel, win-builder R-release and R-hub all
-> need re-running against the 1.2.1 tarball; the three `<!-- TODO -->` markers there are what
-> is left before the submission.
+> **All three external checks have now run against the 1.2.1 tarball and are recorded in
+> `cran-comments.md`** (2026-07-29): win-builder R-devel and R-release both `1 NOTE` — the
+> incoming feasibility one — and R-hub `Status: OK` on Linux, Windows and macOS. **The only
+> thing left in this item is the submission itself.**
 
 **Current status — every box below is ticked.** The latest `--as-cran` run, on the
 `rcicr_1.2.1.tar.gz` built at the repo root from the `v1.2.1` tree (2026-07-28), gives
@@ -740,13 +740,14 @@ ships *in the package* and the link is courtesy to nine years of citations.
 
 #### Then, before hitting submit
 
-- [ ] Check on platforms this machine cannot provide: `devtools::check_win_devel()` and
-      `rhub::rhub_check()` (macOS, Windows, R-devel). CRAN tests those and we do not.
+- [x] **Check on platforms this machine cannot provide. Done 2026-07-29**, against the
+      1.2.1 tarball: win-builder R-devel (r90304 ucrt) and R-release (4.6.1), `1 NOTE` each;
+      R-hub Linux, Windows and macOS on R-devel, `Status: OK` on all three. CRAN tests those
+      platforms and we do not.
 - [x] **Write `cran-comments.md`. Done** — at the repo root, `.Rbuildignore`d. It states
       plainly that the 2021-06-08 archival was for an undeliverable maintainer address
       rather than any code or policy problem, that the address now works, and explains both
-      remaining NOTEs. Two `<!-- TODO -->` markers remain for the win-builder and R-hub
-      results, which cannot be filled in until those actually run.
+      remaining NOTEs. The win-builder and R-hub results are filled in as of 2026-07-29.
 - [ ] Submit at <https://cran.r-project.org/submit.html> (or `devtools::release()`).
       **Ron has to do this himself** — CRAN emails the maintainer address for
       confirmation, and that address working again is the entire point.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,11 +129,68 @@ R CMD build . && R CMD check --as-cran rcicr_*.tar.gz
   `DECISIONS.md` for why.
 - **`cran-comments.md`**: re-read every claim in it rather than trusting it. It has gone
   stale *within a single day* before, by describing a URL reference that another PR had
-  just removed, one step short of a CRAN reviewer reading it.
+  just removed, one step short of a CRAN reviewer reading it. Leave the test-environment
+  results for step 2; everything else is written now.
 
 Open the PR. The full battery runs on it, takes ~20 minutes, and is a required check.
 
-### 2. Merge and tag
+### 2. Run the external checks — on the release branch, before merging
+
+win-builder and R-hub run against the release branch, and their results go into
+`cran-comments.md` **in the same PR**, so the release commit carries its own evidence.
+
+```sh
+R CMD build .                                # at the repo root, never in a worktree
+R CMD check --as-cran rcicr_X.Y.Z.tar.gz
+curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-devel/
+curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-release/
+```
+
+Then trigger R-hub from the Actions tab against the release branch. Two NOTEs are expected
+locally and explained in `cran-comments.md` — CRAN incoming feasibility (new submission of
+an archived package) and future file timestamps (no network clock in a sandbox).
+
+This ordering works because **`cran-comments.md` is `.Rbuildignore`d and never reaches the
+tarball**, so writing the results into it cannot invalidate the checks those results
+describe — the tarball is unchanged. And `DESCRIPTION` on the release branch already carries
+the clean version, so the checks see the exact version string that will be submitted.
+
+Neither check is run casually: win-builder mails the maintainer, and both put the tarball in
+front of a third party.
+
+- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()` do the
+  same thing as the `curl` lines above. Each FTPs the tarball to `win-builder.r-project.org`
+  and mails a check log to the maintainer address within the hour; `226` means the transfer
+  completed. The server **will not overwrite an existing upload**: a second attempt at the
+  same filename fails with a bare `Failed FTP upload: 550`, which means "already queued", not
+  "rejected". Confirm with `curl --list-only ftp://win-builder.r-project.org/R-devel/` before
+  re-uploading, or you will conclude the upload failed when it succeeded. The mail carries a
+  result URL; `curl -s https://win-builder.r-project.org/<key>/00check.log` fetches the full
+  log, which beats transcribing the one-line summary. The pages expire after ~72 hours, so
+  `cran-comments.md` is the durable copy.
+- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
+  on this repository's own Actions rather than uploading anywhere. Trigger it from the
+  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
+  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
+  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
+  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
+  **default branch** before it can be triggered at all, and R-hub wants the file on the
+  default branch *and* on whichever branch is being checked.
+
+  To read the results, **download the artifacts — do not use `gh run view --log`**, which
+  truncates long jobs: at 1.2.1 the 38-minute macOS job returned 1548 lines ending four
+  minutes in, with no `Status:` line anywhere. `gh run download <run-id> -D <dir>` and read
+  `*/rcicr.Rcheck/00check.log`. Expect `Status: OK` where win-builder reports 1 NOTE — R-hub
+  does not run the CRAN incoming feasibility check, so that is agreement, not a discrepancy.
+
+  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
+  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
+  optional slot for your own PAT to reach private repositories — not a credential R-hub
+  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
+  any step. This package is public; an unset secret expands to an empty string and the jobs
+  run normally.
+
+### 3. Merge and tag
 
 ```sh
 gh pr merge <n> --squash --delete-branch
@@ -146,53 +203,35 @@ The tag push re-runs the full gate against the released tree, which is the copy 
 matters. Squash-merge, always: one commit per PR on `main`, and the squash message is where
 measurements and rejected alternatives have to live, because the branch commits disappear.
 
-### 3. Submit to CRAN
+**Confirm the squash did not change the tree** the external checks ran on:
 
 ```sh
-git switch --detach vX.Y.Z      # never build from main HEAD
+git diff <pr-head-sha> vX.Y.Z --stat    # must be empty
+```
+
+Empty output is what lets step 2's results stand for the tagged tree.
+
+### 4. Submit to CRAN
+
+```sh
+git switch --detach vX.Y.Z      # never build from main HEAD, never in a worktree
 R CMD build .
 R CMD check --as-cran rcicr_X.Y.Z.tar.gz
 git switch -                    # back to where you were
 ```
 
 Building from the tag is what keeps the development suffix out of the submitted version:
-`Version contains large components` is only a CRAN blocker if the *tarball* carries it. Two
-NOTEs are expected and explained in `cran-comments.md` — CRAN incoming feasibility (new
-submission of an archived package) and future file timestamps (no network clock in a
-sandbox).
+`Version contains large components` is only a CRAN blocker if the *tarball* carries it.
 
-Then run the two external checks and record their results in the `<!-- TODO -->` markers in
-`cran-comments.md`. Neither is run casually: win-builder mails the maintainer, and both put
-the tarball in front of a third party.
-
-- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()`, run
-  from a checkout of the tag. Each FTPs the tarball to `win-builder.r-project.org` and mails
-  a check log to the maintainer address within the hour. The server **will not overwrite an
-  existing upload**: a second attempt at the same filename fails with a bare
-  `Failed FTP upload: 550`, which means "already queued", not "rejected". Confirm with
-  `curl --list-only ftp://win-builder.r-project.org/R-devel/` before re-uploading, or you
-  will conclude the upload failed when it succeeded.
-- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
-  on this repository's own Actions rather than uploading anywhere. Trigger it from the
-  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
-  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
-  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
-  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
-  **default branch** before it can be triggered at all, and R-hub wants the file on the
-  default branch *and* on whichever branch is being checked.
-
-  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
-  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
-  optional slot for your own PAT to reach private repositories — not a credential R-hub
-  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
-  any step. This package is public; an unset secret expands to an empty string and the jobs
-  run normally.
+Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-comments.md`
+into the "Optional comment" field — that file is `.Rbuildignore`d and reaches CRAN only this
+way, never inside the tarball. `devtools::submit_cran()` does the same thing.
 
 **Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
 package archived over an undeliverable address, that confirmation *is* the point of the
 resubmission.
 
-### 4. Reopen development
+### 5. Reopen development
 
 Bump `DESCRIPTION` to `X.Y.Z.9000` and start a fresh `# rcicr (development version)` heading
 in `NEWS.md`. `main` is protected, so this goes through a small PR like anything else.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -405,6 +405,40 @@ the hard way that those entries do not cover:
   takes the other branch down with it. (`gh pr merge --delete-branch` has already removed the
   remote branch anyway.)
 
+### External checks run on the release branch; the tag and `.9000` still precede acceptance
+At 1.2.1 the order was: merge the release PR, tag, publish the GitHub release, bump to
+`.9000` — and only *then* run win-builder and R-hub. So the check results landed on a
+development tree, and the release commit and its tag recorded no evidence that the tree they
+name had passed anything. `usethis:::release_checklist()` puts `check_win_devel()` and
+"Update `cran-comments.md`" under **Prepare for release**, before the version is finalised,
+and leaves the tag (`use_github_release()`) and the `.9000` reopen (`use_dev_version()`)
+until after "Wait for CRAN… Accepted". The checks now run in step 2 of
+`CONTRIBUTING.md` → "Releasing", against the release branch.
+
+**The circularity that appears to force the old order is not real.** It looks as though
+results cannot be recorded in the commit they describe, because writing them changes the
+tree and so invalidates the tarball that was checked. But `cran-comments.md` is
+`.Rbuildignore`d and verifiably absent from the built tarball, so editing it produces the
+same tarball byte for byte. It is not a package artifact at all — it is the text pasted into
+the "Optional comment" field of the CRAN submission form.
+
+**What is deliberately *not* copied from usethis: tagging and reopening `.9000` still happen
+before CRAN accepts.** Two reasons. The `.9000` suffix is what selects `--quick` over the
+full ~20-minute battery, so holding `main` at a clean version across the weeks CRAN can take
+would run the full gate on every unrelated PR in that window. And a rejection means shipping
+X.Y.Z+1 anyway, leaving the tag naming a tree that was never on CRAN — already true of
+`v1.2.0`, so the repository tolerates that outcome cheaply.
+
+This variant is in one respect tighter than usethis's: that checklist runs win-builder while
+`DESCRIPTION` still carries `.9000` and never re-checks after `use_version()`, so the
+recorded results are for a different version string than the one submitted. Checking the
+release branch, where the version is already clean, avoids that.
+
+Not applied retroactively to 1.2.1. `cran-comments.md` never being in the tarball is exactly
+what makes a 1.2.2 unnecessary: the already-checked `rcicr_1.2.1.tar.gz` is what should be
+submitted, and re-cutting a release to carry updated comments would produce an identical
+tarball at the cost of a fresh round of external checks.
+
 ### GitHub releases carry notes only — the built tarball is not attached
 Asked and settled at the 1.2.1 release. A release page already offers "Source code (tar.gz)",
 which GitHub generates from the tag, and that is **not** the same artifact `R CMD build`

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -24,27 +24,21 @@ the package was off CRAN, and none of them was published anywhere a user could i
 from with `install.packages()`. `NEWS.md` carries their entries, so the record between
 0.3.4.1 and 1.2.1 is complete.
 
-1.2.1 follows 1.2.0 by a short interval and contains no user-facing change. 1.2.0 did not
-pass `R CMD check` on macOS: a test in the package's own suite asserted properties of a
-rendered PNG that belong to the graphics device rather than to what was drawn, and those
-differ between macOS and Linux. No released function was affected and nothing the package
-computes changed, but the tree could not pass its own checks on a platform CRAN builds for,
-so it is not the tree we are asking you to accept.
-
 ## Test environments
 
 * local: Ubuntu 24.04, R 4.3.3 — `R CMD check --as-cran`, with
   `_R_CHECK_CRAN_INCOMING_=TRUE` and `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`
 * GitHub Actions: ubuntu-latest on R release and R devel, macos-latest on R release,
   windows-latest on R release — all green
-* win-builder, R-devel  <!-- TODO: re-run against the 1.2.1 tarball and record result -->
-* win-builder, R-release  <!-- TODO: re-run against the 1.2.1 tarball and record result -->
-* R-hub: Linux, Windows, macOS  <!-- TODO: run against 1.2.1 and record result -->
+* win-builder, R-devel — R Under development (unstable) (2026-07-26 r90304 ucrt): 1 NOTE
+  (the incoming feasibility note below)
+* win-builder, R-release — R 4.6.1 (2026-06-24 ucrt): 1 NOTE (the same one)
+* R-hub, all on R-devel — Linux (x86_64-pc-linux-gnu, r90185), Windows
+  (x86_64-w64-mingw32, r90310 ucrt), macOS (x86_64-apple-darwin20, r90190): **Status: OK**
+  on all three, 0 errors, 0 warnings, 0 notes. R-hub does not run the CRAN incoming
+  feasibility check, which is why the note above does not appear there.
 
-The win-builder results previously recorded here were for the **1.2.0** tarball (R-devel
-2026-07-26 r90304 ucrt and R 4.6.1, 1 NOTE each — the incoming feasibility note below).
-They are not carried forward: the submitted tarball has changed, so they are re-run rather
-than assumed still to hold.
+All of the above were run against the tarball being submitted.
 
 ## R CMD check results
 


### PR DESCRIPTION
All three pre-submission checks returned green against the 1.2.1 tarball, so `cran-comments.md`'s three `<!-- TODO -->` markers are now filled in. The remaining changes are process, for the next release.

## The results

| Check | Platform / version | Result |
|---|---|---|
| win-builder R-devel | r90304 ucrt | 1 NOTE |
| win-builder R-release | 4.6.1 | 1 NOTE |
| R-hub | Linux r90185, Windows r90310 ucrt, macOS darwin20 r90190 (all R-devel) | **Status: OK** ×3 |

The NOTE is the CRAN incoming feasibility one already answered in `cran-comments.md`. R-hub reports 0 notes where win-builder reports 1 because it does not run the incoming feasibility check — agreement, not a discrepancy, and the file now says so.

## Dropping the 1.2.0 prose

The paragraph explaining why 1.2.1 followed 1.2.0 so closely is gone. 1.2.0 was never on CRAN, so a reviewer has no CRAN-visible history to reconcile, and the paragraph volunteered a macOS check failure in a tree they will never see. The version-jump paragraph (0.3.4.1 → 1.2.1) stays — that gap *is* visible to a reviewer.

## Running the checks earlier

`CONTRIBUTING.md` → "Releasing" gains a step 2: win-builder and R-hub run against the **release branch**, results recorded in the same PR, before merging. At 1.2.1 they ran after the tag and the `.9000` reopen, so the results landed on a development tree and the release commit recorded no evidence its own tree had passed anything. `usethis:::release_checklist()` puts both under "Prepare for release".

The obstacle this appears to hit — recording results changes the tree, invalidating the tarball they describe — **does not exist**: `cran-comments.md` is `.Rbuildignore`d and verifiably absent from the built tarball, so editing it leaves the tarball byte for byte identical. It is not a package artifact; it is the text pasted into the CRAN form's comment field.

**Not copied from usethis:** tagging and the `.9000` reopen still precede CRAN acceptance. The suffix selects `--quick` over the full ~20-minute battery, so holding `main` at a clean version for the weeks CRAN can take would run the full gate on every unrelated PR meanwhile.

**Not applied retroactively — no 1.2.2.** `cran-comments.md` never being in the tarball is exactly what makes one unnecessary: `rcicr_1.2.1.tar.gz` is already the right artifact and has been checked as such.

## Also

Two retrieval gotchas found doing this, now in `CONTRIBUTING.md`: `gh run view --log` truncates long jobs (the 38-minute macOS job returned 1548 lines with no `Status:` line — download the artifacts instead), and win-builder result pages expire after ~72 hours, which makes `cran-comments.md` the durable copy.

`BACKLOG.md` items 1 and 20 updated, including the summary table — the row that has drifted three times before.

Prose only; no file under `R/`, so the reproducibility gate should take its skip path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)