### PR TITLE
Watch the GitHub Actions with Dependabot; record why not the R packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+# Covers GitHub Actions only. Dependabot has no CRAN ecosystem, so the R
+# dependencies in DESCRIPTION are not watched here and cannot be -- see
+# DECISIONS.md, "Dependabot watches the actions, not the R packages", for why
+# that gap is left open rather than filled with a scanner.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # One PR for all action updates rather than one each. Every PR to `main`
+    # runs R CMD check on four platforms plus the reproducibility gate, and
+    # `.github/workflows/` is deliberately not on the gate's inert allowlist,
+    # so an ungrouped week of updates would cost several full CI rounds to
+    # bump a few version tags.
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: "chore"

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1276,6 +1276,16 @@ removes four packages nothing else here needs:
 | `terra` | C++ against GDAL/GEOS/PROJ — the bulk of the build time |
 | `sp`, `Rcpp` | pulled in behind them; needed by no other `Imports` entry |
 
+**A second argument, found 2026-07-29 and not previously recorded: this is also the largest
+security surface in the tree.** Of the 53 non-base packages rcicr pulls in recursively, 29
+need compilation, and their vulnerabilities are not in R code — they belong to the C
+libraries underneath. `terra` binds **GDAL, GEOS and PROJ**, which carry by far the most CVE
+history of anything here, and they arrive solely so that three `raster::plot()` calls can
+draw a matrix. (`png` → libpng and `jpeg` → libjpeg are the other native bindings, and unlike
+this one they are load-bearing.) Since CRAN publishes no advisory database, shrinking the
+native surface is the only lever available — see `DECISIONS.md`, "Dependabot watches the
+actions, not the R packages".
+
 What has to be replaced is small but not nothing: `main`/`xlab` titling, `axes = F, box = F`,
 `add = TRUE` overlay onto a `rasterImage()` background, and the **colour-bar legend** that
 `raster::plot()` draws by default (the `legend = F` at line 147 is what makes the undecorated

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -346,6 +346,37 @@ obvious way to honour "never build from `main` HEAD") returned 2 NOTEs where the
 built at the repo root returned 1. Reproduced both ways before believing it: worktree tarball
 contains `rcicr/.git`, repo-root tarball contains no match.
 
+### Dependabot watches the actions, not the R packages
+`.github/dependabot.yml` covers `github-actions` and nothing else. That is not an oversight,
+and the asymmetry is the point.
+
+**The R dependencies cannot be watched, and pretending otherwise is worse than the gap.**
+Dependabot has no CRAN ecosystem, and **CRAN publishes no security advisory database** — there
+is no `npm audit` equivalent for R. The nearest thing is Sonatype's OSS Index via `oysteR`,
+which as of 2026-07-29 returns **401 to anonymous requests** and so needs an account to run at
+all. Weighed and rejected: a scanner whose CRAN coverage is thin reports "clean" because its
+database is empty, not because the tree is safe, and a green badge that means nothing is worse
+than a known gap. The realistic dependency failure — an import getting archived — is already
+caught by `R CMD check` on four platforms on every push.
+
+Where the actual CVE surface lives is worth stating, because it is not in R code at all: 29 of
+the 53 packages in the recursive tree need compilation, and their vulnerabilities belong to the
+C libraries they bind to — **libpng** (`png`), **libjpeg** (`jpeg`), **GDAL/GEOS/PROJ**
+(`terra` ← `raster`). Those are patched by the user's operating system, not by CRAN, and
+nothing this package does can affect them. Dropping `raster` (`BACKLOG.md` item 34) is the only
+lever that shrinks it.
+
+**The actions genuinely needed watching.** Thirteen third-party actions were in use, twelve on
+floating major tags (`@v2`, `@v6`) and exactly one — `codecov/codecov-action` — pinned to a
+full SHA, almost certainly a reaction to the Codecov uploader compromise. A floating tag means
+whoever controls that repository can change what runs in CI at any time; that is the
+supply-chain surface here with real incident history, and it is the one Dependabot supports.
+
+Updates are **grouped into a single PR** (`patterns: ["*"]`, limit 1). Every PR to `main` runs
+`R CMD check` on four platforms plus the reproducibility gate, and `.github/workflows/` is
+deliberately *not* on the gate's inert allowlist, so ungrouped updates would spend several full
+CI rounds bumping a handful of version tags.
+
 ### R-hub runs on `workflow_dispatch` only, never on push
 The R-hub v2 workflow is the stock file `rhub::rhub_setup()` writes, kept unmodified so it can
 be refreshed from upstream. It is left trigger-on-demand because R-hub answers a question that


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering `github-actions` only, and records in `DECISIONS.md` why the R dependencies are deliberately left out.

## Why the actions needed this

Thirteen third-party actions across the workflows. Twelve on floating major tags, exactly one pinned:

```
actions/checkout@v6                                    ← floating
r-lib/actions/setup-r-dependencies@v2                  ← floating
codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f   ← full SHA
```

Someone pinned codecov deliberately — almost certainly after the Codecov uploader compromise — and left the rest floating. A floating tag means whoever controls that repository can change what runs in CI at any time. That's the supply-chain surface here with actual incident history, and the one Dependabot supports.

**Grouped into a single PR** (`patterns: ["*"]`, `open-pull-requests-limit: 1`). Every PR to `main` runs `R CMD check` on four platforms plus the reproducibility gate, and `.github/workflows/` is deliberately *not* on the gate's inert allowlist — so ungrouped updates would spend several full CI rounds bumping a few version tags.

## Why not the R packages

Not an oversight, and `DECISIONS.md` now says so:

- **Dependabot has no CRAN ecosystem**, and **CRAN publishes no security advisory database**. There is no `npm audit` equivalent for R.
- `oysteR` + Sonatype OSS Index is the nearest thing, and it now returns **401 to anonymous requests** — verified today.
- **Considered and rejected:** a scanner whose CRAN coverage is thin reports "clean" because its database is empty, not because the tree is safe. A green badge that means nothing is worse than a known gap.
- The realistic dependency failure — an import getting archived — is already caught by `R CMD check` on four platforms every push.

## What the surface actually is

Measured while deciding this, and added to **item 34** as a second argument for dropping `raster`:

**29 of the 53** non-base packages in the recursive tree need compilation, and their vulnerabilities aren't in R code — they belong to the C libraries underneath. `terra` binds **GDAL, GEOS and PROJ**, the most CVE-bearing dependencies in the tree, and they arrive solely so three `raster::plot()` calls can draw a matrix. `png` → libpng and `jpeg` → libjpeg are the other native bindings; unlike that one, they're load-bearing.

So item 34 now has a security argument alongside the 30-minute install time.

## Notes

- `.github` is already `.Rbuildignore`d, so `dependabot.yml` cannot reach the tarball and needs no `.Rbuildignore` change.
- YAML validated locally.
- Nothing under `R/`, so the submission tarball is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)