### PR TITLE
Keep every argument across load() in the two functions that did not

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -129,6 +129,7 @@ scheduled at all — see "Beyond v1" at the end.
 | 33 | A decorated z-map below 256px dies with `figure margins too large` | **Open.** `zmapdecoration = TRUE` is the default, so `generateCI(zmap = TRUE)` on a 128px stimulus set fails from inside base R, naming neither `rcicr` nor the cause. Not a regression — 256px and up are fine. Needs a clear early error, or a documented fallback | S |
 | 37 | Error paths are largely untested | **Open, unblocked by the submission — do second.** 5 `expect_error()` + 4 `expect_warning()` against 27 `stop()` + 6 `warning()`. The untested ones include the likeliest user error of all (stimuli/responses length mismatch) and the four `.Rdata` guards that returning users hit. An unexercised guard is how items 6, 23 and 28 each stayed broken for years | M |
 | ~~38~~ | ~~Two error messages paste the base image matrix, not its label~~ | **Done** — both sites now name `baseimage`. The defect was worse than logged: `paste0()` is vectorized, so it built one complete message *per pixel*, and `stop()` concatenated them — 1,024 copies and 8,190 characters at 32px, ~7 MB at 512px. Only error text changed; the gate reports this tree still reproduces v1.2.1 | S |
+| ~~39~~ | ~~Two of the four `load(rdata)` sites did not guard their arguments~~ | **Done** — preventive, no live collision. `computeInfoVal2IFC()` restored 3 of its 5 arguments and `computeCumulativeCICorrelation()` none. The one that mattered: `target_ci` is read after a *second* `load()`, so a file carrying that name would have scored a different CI and returned a plausible number, not an error | S |
 
 Items 2, 3, 6 and 7 shared a shape worth remembering, because it will recur: **the
 package failed silently or misleadingly rather than telling the user what went wrong.**
@@ -1424,6 +1425,35 @@ its message to `stderr()` and then calls a bare `stop()`, so the condition carri
 message. That belongs to item 14, and its error path is one item 37 should cover.
 
 ---
+
+### 39. Two of the four `load(rdata)` sites did not guard their arguments **[verified] [own review]**  ✅ **FIXED**
+
+Found while sweeping for item 38, 2026-07-29. `load()` assigns straight into the calling
+function's frame, so an object in the `.Rdata` file replaces an argument of the same name.
+Of the four functions that read a stimulus set:
+
+| function | state before |
+|---|---|
+| `generateCI()` | guarded — all arguments kept via `mget(names(formals()))` |
+| `generateReferenceDistribution2IFC()` | guarded — each argument restored explicitly |
+| `computeInfoVal2IFC()` | **partial** — 3 of 5 arguments (`rdata`, `iter`, `response_seed`) |
+| `computeCumulativeCICorrelation()` | **none** |
+
+**There was no live bug.** The 15 names `generateStimuli2IFC()` saves do not intersect the
+unguarded arguments, checked rather than assumed. The fix is preventive, and the reason it is
+worth having is the direction the one real collision came from: item 32 was created by *adding
+a field to the file*, not by adding an argument, so an argument that is safe today stops being
+safe with nothing in the function changing.
+
+**The case worth naming** is `computeInfoVal2IFC(target_ci)`. It is read at the very end, to
+compute the CI norm, and after a **second** `load()` on the cache-writing path — so a file
+carrying that name would have scored somebody else's classification image and returned a
+plausible InfoVal rather than an error. Both loads now restore.
+
+Tested by planting the colliding names into a fixture `.Rdata` and asserting the caller's
+values survive; verified to fail without the fix (3 failures). Note the tests pass against
+unguarded code if the collision is *not* planted, which is why each one plants it explicitly.
+
 
 ## P3 — Features requested by users
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,23 @@
   are affected, and the condition that triggers the error is unchanged — if your analysis
   script runs today, it behaves identically.
 
+## Internal
+
+- **Every function that reads a stimulus set now keeps its arguments across the
+  `load()`.** `load()` assigns straight into the calling function's frame, so an object
+  stored in an `.Rdata` file silently replaces an argument of the same name. `generateCI()`
+  and `generateReferenceDistribution2IFC()` already guarded against this; `computeInfoVal2IFC()`
+  guarded three of its five arguments, and `computeCumulativeCICorrelation()` none.
+
+  **No file this package has ever written triggers the problem**, so no result changes and
+  no analysis needs revisiting — the guard is preventive. It is worth having because the one
+  collision that did occur (the z-map `sigma`, fixed in 1.2.0) was created by *adding a field
+  to the file*, not by adding an argument, so an argument that is safe today stops being safe
+  without anything in the function changing. The case now closed in `computeInfoVal2IFC()` is
+  the one that would have mattered most: `target_ci` is read at the very end to compute the
+  CI norm, and after a second `load()`, so a file carrying that name would have scored a
+  different classification image and returned a plausible number rather than an error.
+
 # rcicr 1.2.1 (2026-07-28)
 
 **No user-facing changes.** Nothing this package computes differs from 1.2.0 — no function,

--- a/R/computeCumulativeCICorrelation.R
+++ b/R/computeCumulativeCICorrelation.R
@@ -45,8 +45,21 @@ computeCumulativeCICorrelation <- function(stimuli, responses, baseimage, rdata,
   stimuli <- unlist(stimuli, use.names = FALSE)
   responses <- unlist(responses, use.names = FALSE)
 
+  # load() assigns straight into this function's frame, so any object stored in
+  # the .Rdata file silently overwrites an argument of the same name - the same
+  # hazard handled in generateCI() and generateReferenceDistribution2IFC(). No
+  # field written today collides with these arguments, so this changes nothing
+  # now; it is here because the collision that actually bit us (item 32) was
+  # created from the .Rdata side, by adding a field, not by adding an argument.
+  #
+  # Captured after the unlist() above, so the coerced vectors are what gets
+  # restored rather than the original tibble columns.
+  .args <- mget(names(formals()), envir = environment())
+
   # Load parameter file (created when generating stimuli)
   load(rdata)
+
+  list2env(.args, envir = environment())
 
   # Check whether critical variables have been loaded
   if (!exists('s', envir=environment(), inherits=FALSE) & !exists('p', envir=environment(), inherits=FALSE) ) {

--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -85,12 +85,18 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
   # generateReferenceDistribution2IFC() - which saved its own `rdata` argument
   # into the file - would overwrite the path we were called with. This function
   # still uses `rdata` further down (to regenerate and re-load), so it would
-  # then operate on whatever path that file happened to record. Restore ours.
-  .args <- list(rdata = rdata, iter = iter, response_seed = response_seed)
+  # then operate on whatever path that file happened to record.
+  #
+  # Keep every argument rather than the three that were known to collide: the
+  # hazard has bitten from the .Rdata side twice now (item 32 added `sigma` to
+  # the file and captured generateCI()'s z-map argument), so the guard has to
+  # hold for fields that do not exist yet. `target_ci` is the one that would
+  # hurt most here - it is read at the very end to compute the CI norm, so a
+  # file carrying that name would silently score somebody else's classification
+  # image and return a plausible number rather than an error.
+  .args <- mget(names(formals()), envir = environment())
   load(rdata)
-  rdata         <- .args$rdata
-  iter          <- .args$iter
-  response_seed <- .args$response_seed
+  list2env(.args, envir = environment())
 
   # Asking for a specific response seed is asking for a specific reference
   # distribution, so it has to imply regeneration. Without this the argument
@@ -197,8 +203,13 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
 
       if (cache_ref_dist) {
 
-        # Re-load rdata file
+        # Re-load rdata file, to pick up the reference_norms just written to it.
+        # This load carries the same hazard as the one above and needs the same
+        # restore: `target_ci` is read after this point (line ~230, for the CI
+        # norm), so without it a file containing that name would replace the
+        # caller's classification image between here and the computation of it.
         load(rdata)
+        list2env(.args, envir = environment())
 
         # NB: write() defaults to file = "data", so omitting stdout() here did
         # not print this message - it silently created a file called "data" in

--- a/tests/testthat/test-load-argument-guards.R
+++ b/tests/testthat/test-load-argument-guards.R
@@ -1,0 +1,101 @@
+# Every function that reads a stimulus set does load(rdata), and load() assigns
+# straight into the calling function's frame -- so an object in the file silently
+# overwrites an argument of the same name.
+#
+# This has bitten twice, both times from the .Rdata side: a field was added to
+# the file and captured an argument that had been there all along (item 32 added
+# the noise `sigma` and took over generateCI()'s z-map blur `sigma`). No field
+# written today collides with the arguments below, so these tests pass against
+# the unguarded code too if the collision is not planted -- which is exactly why
+# each one plants it explicitly.
+
+# The leading dot matters: R partially matches named arguments to formals, so a
+# formal called `rdata_path` would swallow a planted `rdata = ...` by prefix and
+# make the helper try to open the decoy instead of the fixture.
+plant_in_rdata <- function(.path, ...) {
+  e <- new.env()
+  load(.path, envir = e)
+  objs <- list(...)
+  for (nm in names(objs)) assign(nm, objs[[nm]], envir = e)
+  save(list = ls(e), file = .path, envir = e)
+  invisible(.path)
+}
+
+test_that("computeInfoVal2IFC scores the caller's CI, not one found in the .Rdata", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  seed_reference_norms(rdata)
+
+  mine  <- list(ci = matrix(0.10, 32, 32))
+  decoy <- list(ci = matrix(0.90, 32, 32))
+
+  # target_ci is read at the very end, to compute the CI norm -- and it is read
+  # after a *second* load() on the cache-writing path, so both loads need the
+  # restore. A file carrying this name would return a plausible number for the
+  # wrong image rather than an error, which is the worst shape this can take.
+  plant_in_rdata(rdata, target_ci = decoy)
+
+  norms <- local({
+    e <- new.env()
+    load(rdata, envir = e)
+    e$reference_norms
+  })
+  expected_mine  <- (norm(matrix(mine$ci), "f")  - median(norms)) / mad(norms)
+  expected_decoy <- (norm(matrix(decoy$ci), "f") - median(norms)) / mad(norms)
+
+  val <- suppressWarnings(computeInfoVal2IFC(target_ci = mine, rdata = rdata))
+
+  expect_equal(val, expected_mine)
+
+  # Discriminating half: the two CIs must actually score differently, or the
+  # assertion above would hold whichever image were used.
+  expect_false(isTRUE(all.equal(expected_mine, expected_decoy)))
+  expect_false(isTRUE(all.equal(val, expected_decoy)))
+})
+
+test_that("computeInfoVal2IFC keeps its own rdata path across the load", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  seed_reference_norms(rdata)
+
+  # An older generateReferenceDistribution2IFC() saved its own `rdata` argument
+  # into the file, so this name really does occur in the wild.
+  plant_in_rdata(rdata, rdata = file.path(dir, "does-not-exist.Rdata"))
+
+  expect_no_error(
+    suppressWarnings(computeInfoVal2IFC(target_ci = list(ci = matrix(0.1, 32, 32)),
+                                        rdata = rdata))
+  )
+})
+
+test_that("computeCumulativeCICorrelation keeps its arguments across the load", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  responses <- rep(c(1, -1), 3)
+
+  reference <- suppressWarnings(computeCumulativeCICorrelation(
+    stimuli = 1:6, responses = responses, baseimage = "base", rdata = rdata
+  ))
+
+  # Plant collisions for three arguments at once: the step size, the label used
+  # to look up the parameters, and the stimulus indices themselves.
+  plant_in_rdata(rdata, step = 99L, baseimage = "not-a-real-label",
+                 stimuli = integer(0))
+
+  planted <- suppressWarnings(computeCumulativeCICorrelation(
+    stimuli = 1:6, responses = responses, baseimage = "base", rdata = rdata
+  ))
+
+  expect_equal(planted, reference)
+
+  # Without the guard, `baseimage` alone would take the lookup to a label that
+  # does not exist and error out, so this cannot pass vacuously.
+  expect_gt(length(reference), 0)
+})


### PR DESCRIPTION
Backlog item 39, found while doing the `stop()`/`warning()` sweep item 38 asked for.

`load()` assigns straight into the calling function's frame, so an object stored in the `.Rdata` file silently replaces an argument of the same name. Of the four functions that read a stimulus set:

| function | state before |
|---|---|
| `generateCI()` | guarded — all arguments kept |
| `generateReferenceDistribution2IFC()` | guarded — each argument restored explicitly |
| `computeInfoVal2IFC()` | **partial** — 3 of 5 (`rdata`, `iter`, `response_seed`) |
| `computeCumulativeCICorrelation()` | **none** |

## There is no live bug

The 15 names `generateStimuli2IFC()` saves do not intersect the unguarded arguments — checked against the actual `save()` call, not assumed. Nothing this package has ever written can trigger it, and **no result changes**.

It is worth fixing anyway because of the direction the one real collision came from. Item 32 was created by adding a *field to the file*, not an argument to a function: the noise `sigma` took over `generateCI()`'s z-map blur `sigma`, and every z-map from a 1.1.0 stimulus set was smoothed with the wrong constant. An argument that is safe today stops being safe with nothing in the function changing, so the guard has to hold for fields that do not exist yet.

## The case worth naming

`computeInfoVal2IFC(target_ci)` is read at the very end, to compute the CI norm — and after a **second** `load()` on the cache-writing path, which had no restore at all. A file carrying that name would have scored somebody else's classification image and returned a **plausible InfoVal rather than an error**. Both loads now restore.

In `computeCumulativeCICorrelation()` the arguments are captured after the `unlist()` coercion, so the coerced vectors are what gets restored, not the original tibble columns.

## Tests

They plant the colliding names into a fixture `.Rdata` and assert the caller's values survive. Verified to fail without the guards (3 failures). Note they pass against unguarded code if the collision is *not* planted — which is exactly why each one plants it explicitly. Suite 285 → 288, 0 skipped.

## Note on merge order

This branches off `main`, so it **conflicts with #162** in `BACKLOG.md` and `NEWS.md` (both insert at the same spots; the shared `R/` file auto-merges). Merge #162 first and I will rebase this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)