### PR TITLE
Test the error paths

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -11,13 +11,25 @@ breaking the API that researchers depend on**.
 > CRAN incoming feasibility one; R-hub `Status: OK` on Linux, Windows and macOS). **Item 1 now
 > waits on CRAN's reply, not on us.**
 >
-> **Code work is unblocked again.** Items **37** and **38** were opened by a final review the
-> same day and held unfixed only because touching `R/` would have invalidated the tarball the
-> external checks had already run against; the tarball is now sent, so that reason is gone and
-> they are the natural first pair — 37's tests are what would have caught 38. **Item 21 stays
-> held** until CRAN actually accepts, since it announces availability.
+> **CRAN's auto-check came back the same day: 1 NOTE on Windows and Debian both**, the
+> expected incoming-feasibility one, plus `No strong reverse dependencies`. It is now pending
+> **manual inspection, within 10 working days**. That is not acceptance.
 >
-> Open items are **1, 20, 21, 24, 25, 27, 30, 31, 33, 34, 37, 38** in the table below, plus
+> **Code work is unblocked, and items 37, 38 and 39 are done** — the three the submission
+> released. They were held only because touching `R/` would have invalidated the tarball the
+> external checks had run against; the tarball is sent, so nothing here can change what CRAN
+> received. **Two things stay held** for reasons that survive the submission: **item 21**
+> announces availability, which is not yet true, and **item 34** should not land while 1.2.1
+> is in the queue — if CRAN asks for a change, the answer wants to be a minimal 1.2.2, not one
+> that also swapped the plotting backend under three rendered outputs.
+>
+> **While 1.2.1 is in the queue, keep `main` releasable.** The real risk is not a bad merge
+> but time pressure: a CRAN request often carries an implicit deadline, and half-finished work
+> on `main` is what stops you answering one. If a resubmission is needed, branch
+> `release-1.2.2` from `main` when it is clean, or from the **`v1.2.1` tag** when it is not —
+> the tag exists for exactly that. There is still no `develop` branch and should not be one.
+>
+> Open items are **1, 20, 21, 24, 25, 27, 30, 31, 33, 34** in the table below, plus
 > **13–15** and **36**, which are kept out of it.
 
 **Last updated:** 2026-07-28 — P0 items 2–8, plus 9, 10, 11, 12, 16, 18, 19 and 22, fixed
@@ -93,9 +105,10 @@ v1.1.0.** Items 1, 20 and 21 are not code: item 20's checklist is fully ticked a
 was submitted on 2026-07-29**, so item 1 now waits on CRAN's reply and item 21 waits on the
 outcome. **Item 23 is fixed** — the `plotZmap()` mask is applied, under a "Behaviour change"
 heading in `NEWS.md` — as is **item 32**, the `.Rdata` field that was capturing
-`generateCI()`'s z-map `sigma`, caught by the release gate on its first full run. **Start
-with items 38 then 37**, which the submission has just unblocked. The rest of the table is
-triage: items 27, 30, 31 and 33. Items **13, 14 and 15** (modernize the
+`generateCI()`'s z-map `sigma`, caught by the release gate on its first full run. **Items 37,
+38 and 39 are all fixed** — the submission unblocked them, and they went in that order: the
+error message, the `load()` guards it exposed, then the tests that would have caught both.
+The rest of the table is triage: items 27, 30, 31, 33 and 34. Items **13, 14 and 15** (modernize the
 R code, better errors, docs and onboarding) are the only substantive work still untouched —
 they are the backlog proper for after CRAN, and are deliberately kept out of the table.
 **Item 36** (tidyverse style as a v2 breaking change) is out of the table too, and is not
@@ -127,7 +140,7 @@ scheduled at all — see "Beyond v1" at the end.
 | ~~35~~ | ~~`test-plotZmap.R:68` fails on macOS — blocked the CRAN submission~~ | **Done** — released as 1.2.1. The second distinct value was macOS quartz writing an **alpha channel** where cairo writes RGB, not an antialiasing artifact, so every option drafted before a macOS run was wrong. The count now ignores the alpha plane, and the value it compares is an ordering rather than a constant — the first fix pinned the background grey and macOS failed that too, at 0.573 vs 0.502. CI gained macOS and Windows runners, and the z-map is now pinned by the golden master on all three | S |
 | 34 | `raster` costs 4 packages and a C++ toolchain for 3 plotting calls | **Open, post-CRAN.** `raster` → `terra` → GDAL/GEOS/PROJ is why R-hub's Linux and macOS jobs spent 30+ minutes installing dependencies while Windows, on binaries, took minutes. Used only by three `raster::plot()` calls in `plotZmap.R`. The release gate compares the z-map *matrix*, so it cannot catch a rendering regression here | M |
 | 33 | A decorated z-map below 256px dies with `figure margins too large` | **Open.** `zmapdecoration = TRUE` is the default, so `generateCI(zmap = TRUE)` on a 128px stimulus set fails from inside base R, naming neither `rcicr` nor the cause. Not a regression — 256px and up are fine. Needs a clear early error, or a documented fallback | S |
-| 37 | Error paths are largely untested | **Open, unblocked by the submission — do second.** 5 `expect_error()` + 4 `expect_warning()` against 27 `stop()` + 6 `warning()`. The untested ones include the likeliest user error of all (stimuli/responses length mismatch) and the four `.Rdata` guards that returning users hit. An unexercised guard is how items 6, 23 and 28 each stayed broken for years | M |
+| ~~37~~ | ~~Error paths are largely untested~~ | **Done** — `test-error-paths.R`, suite 291 → 323. Covers the length mismatch, every `.Rdata` "did not contain X" guard in both functions, all four mask-import failures, unreadable and non-square base images, and the `targetci` path that was never exercised. Each was confirmed to fire *its own* guard rather than an incidental error | M |
 | ~~38~~ | ~~Two error messages paste the base image matrix, not its label~~ | **Done** — both sites now name `baseimage`. The defect was worse than logged: `paste0()` is vectorized, so it built one complete message *per pixel*, and `stop()` concatenated them — 1,024 copies and 8,190 characters at 32px, ~7 MB at 512px. Only error text changed; the gate reports this tree still reproduces v1.2.1 | S |
 | ~~39~~ | ~~Two of the four `load(rdata)` sites did not guard their arguments~~ | **Done** — preventive, no live collision. `computeInfoVal2IFC()` restored 3 of its 5 arguments and `computeCumulativeCICorrelation()` none. The one that mattered: `target_ci` is read after a *second* `load()`, so a file carrying that name would have scored a different CI and returned a plausible number, not an error | S |
 
@@ -1352,7 +1365,7 @@ then give it the same care item 23 got.
 
 ---
 
-### 37. Error paths are largely untested **[verified] [own review]**
+### 37. Error paths are largely untested **[verified] [own review]**  ✅ **FIXED**
 
 Found in the pre-submission review, 2026-07-29. The suite is strong on *intent* for the
 numeric paths — properties rather than stored numbers, grouping actually checked, both
@@ -1423,6 +1436,25 @@ re-check only when a new message interpolates something.
 One unrelated oddity noted in passing, not fixed here: `generateStimuli2IFC.R:68-69` writes
 its message to `stderr()` and then calls a bare `stop()`, so the condition carries an empty
 message. That belongs to item 14, and its error path is one item 37 should cover.
+
+
+✅ **FIXED** in `tests/testthat/test-error-paths.R`. Suite **291 → 323**, 0 skipped. Every
+box above is covered, plus the `base_face_files`-not-a-list guard found during the item 38
+sweep.
+
+**How these were verified, since the usual method does not apply.** This item adds no `R/`
+change, so `git stash push -- R/` proves nothing. The real risk for a test of an error path
+is that it passes on a *different* error than the guard it names. Each of the 13 was
+therefore run directly and its `conditionMessage()` read, confirming it fires its own guard
+— and every assertion matches a distinctive fragment of that message rather than merely
+expecting "an error".
+
+**Two things worth keeping.** `generateStimuli2IFC.R:68-69` writes its explanation to
+`stderr()` and then calls a **bare `stop()`**, so the condition carries an empty message and
+no regexp can match it; the test asserts only that it errors, and giving it a real message
+belongs to item 14. And the assertions deliberately match short fragments (`"same length"`,
+`"did not contain"`, `"other than 0 or 1"`) rather than whole sentences, precisely so item 14
+can rewrite the wording without rewriting the suite.
 
 ---
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,15 @@
 
 ## Internal
 
+- **The failure paths are tested.** The suite had 9 assertions covering 33 `stop()` and
+  `warning()` calls, so most of the package's error messages had never been run. They now
+  are: the stimuli/responses length mismatch, every "this `.Rdata` file did not contain X"
+  guard in `generateCI()` and `computeCumulativeCICorrelation()`, all four mask-import
+  failures, and base images that are unreadable or not square. No behaviour changed — this
+  is coverage of messages that were already there. It matters because an unexercised guard
+  is indistinguishable from one that works, which is how three separate bugs in this package
+  stayed live for years, the most recent being the one fixed just above.
+
 - **Every function that reads a stimulus set now keeps its arguments across the
   `load()`.** `load()` assigns straight into the calling function's frame, so an object
   stored in an `.Rdata` file silently replaces an argument of the same name. `generateCI()`

--- a/tests/testthat/helper-fixtures.R
+++ b/tests/testthat/helper-fixtures.R
@@ -40,3 +40,26 @@ seed_reference_norms <- function(rdata_path, n = 50, seed = 1) {
   save(list = ls(e), file = rdata_path, envir = e)
   invisible(rdata_path)
 }
+
+# Rewrites an existing .Rdata fixture: adds or replaces the objects passed via
+# `...`, and drops the names listed in `.remove`. Both directions are needed --
+# the load()-collision guards are reached by *adding* a colliding name, and the
+# "file did not contain X" guards by *removing* one.
+#
+# The leading dot on `.path` matters. R partially matches named arguments to
+# formals, so a formal called `rdata_path` would swallow a planted
+# `rdata = <decoy>` by prefix and make the helper open the decoy instead of the
+# fixture. That cost a confusing test failure once already.
+mutate_rdata <- function(.path, ..., .remove = character()) {
+  e <- new.env()
+  load(.path, envir = e)
+
+  objs <- list(...)
+  for (nm in names(objs)) assign(nm, objs[[nm]], envir = e)
+
+  present <- intersect(.remove, ls(e))
+  if (length(present)) rm(list = present, envir = e)
+
+  save(list = ls(e), file = .path, envir = e)
+  invisible(.path)
+}

--- a/tests/testthat/test-error-paths.R
+++ b/tests/testthat/test-error-paths.R
@@ -1,0 +1,309 @@
+# Backlog item 37. The suite was strong on the numeric paths and thin on the
+# failure side: 9 assertions against 33 stop()/warning() calls. An unexercised
+# guard is indistinguishable from one that works, which is how items 6, 23 and
+# 28 each stayed broken for years -- and item 38 was a guard nothing ran that
+# pasted 8,190 characters of pixel values into its own message.
+#
+# Two conventions here, both deliberate:
+#
+#  * Match a short load-bearing fragment of each message, never the whole
+#    sentence. Item 14 will rewrite this wording, and tests that pin it turn
+#    that into a slog.
+#  * Assert nothing platform-dependent. These tests ship in the tarball and run
+#    on CRAN's check farm. Our own message text is stable; locale-formatted
+#    numbers, paths and anything read back from a graphics device are not.
+
+# --------------------------------------------------------------------------
+# generateCI(): the argument the user is most likely to get wrong
+# --------------------------------------------------------------------------
+
+test_that("generateCI rejects stimuli and responses of different lengths", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  err <- expect_error(
+    generateCI(stimuli = 1:6, responses = c(1, -1, 1), baseimage = "base",
+               rdata = rdata, save_as_png = FALSE),
+    "same length"
+  )
+
+  # Reporting both lengths is what makes this message actionable -- knowing
+  # they differ is not enough to find which vector is wrong.
+  msg <- conditionMessage(err)
+  expect_match(msg, "6")
+  expect_match(msg, "3")
+
+  # And it fires before the file is read, so a mismatch is reported even when
+  # the rdata path is nonsense.
+  expect_error(
+    generateCI(stimuli = 1:6, responses = c(1, -1, 1), baseimage = "base",
+               rdata = file.path(dir, "no-such-file.Rdata"), save_as_png = FALSE),
+    "same length"
+  )
+})
+
+# --------------------------------------------------------------------------
+# generateCI(): the four ".Rdata did not contain X" guards
+#
+# These are the returning-user path the CRAN reinstatement is for: a stimulus
+# set generated years ago, by a version that saved a different set of names.
+# Reached by removing the name from a good fixture rather than by hand-building
+# a broken one, so the file stays realistic in every other respect.
+# --------------------------------------------------------------------------
+
+test_that("generateCI reports which variable an .Rdata file is missing", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+
+  expect_missing <- function(removed, pattern) {
+    d <- withr::local_tempdir()
+    rdata <- make_fixture_rdata(d)
+    mutate_rdata(rdata, .remove = removed)
+    expect_error(
+      generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3), baseimage = "base",
+                 rdata = rdata, save_as_png = FALSE),
+      pattern
+    )
+  }
+
+  # The noise basis. The guard is `!exists('s') & !exists('p')`, so both names
+  # have to go -- the fixture carries p, and s only exists in pre-0.3.3 files.
+  expect_missing(c("s", "p"), "did not contain s or p")
+
+  expect_missing("base_faces", "did not contain base_faces")
+  expect_missing("stimuli_params", "did not contain stimuli_params")
+
+  # img_size is not a formal of generateCI(), so it can only come from the file
+  # -- unlike sigma, which is both, and which is what item 32 turned on.
+  expect_missing("img_size", "did not contain img_size")
+})
+
+test_that("generateCI names the unknown base image and lists the ones it has", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  err <- expect_error(
+    generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+               baseimage = "no-such-label", rdata = rdata, save_as_png = FALSE),
+    "no-such-label"
+  )
+
+  # Listing what the file does contain is the difference between a dead end and
+  # a one-line fix, since the label is a key the user chose at generation time.
+  expect_match(conditionMessage(err), "base")
+})
+
+# --------------------------------------------------------------------------
+# computeCumulativeCICorrelation(): the same guards, none of them covered
+# --------------------------------------------------------------------------
+
+test_that("computeCumulativeCICorrelation reports which variable is missing", {
+  skip_if_not_installed("withr")
+
+  expect_missing <- function(removed, pattern) {
+    d <- withr::local_tempdir()
+    rdata <- make_fixture_rdata(d)
+    mutate_rdata(rdata, .remove = removed)
+    expect_error(
+      computeCumulativeCICorrelation(stimuli = 1:6, responses = rep(c(1, -1), 3),
+                                     baseimage = "base", rdata = rdata),
+      pattern
+    )
+  }
+
+  expect_missing(c("s", "p"), "did not contain s or p")
+  expect_missing("base_faces", "did not contain base_faces")
+  expect_missing("stimuli_params", "did not contain stimuli_params")
+})
+
+test_that("computeCumulativeCICorrelation names the unknown base image", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  expect_error(
+    computeCumulativeCICorrelation(stimuli = 1:6, responses = rep(c(1, -1), 3),
+                                   baseimage = "no-such-label", rdata = rdata),
+    "no-such-label"
+  )
+})
+
+# --------------------------------------------------------------------------
+# applyMask(): all four import failures
+#
+# plotZmap() has one of these covered; generateCI() has none -- and generateCI()
+# is the copy that has always been live. Called directly, as test-plotZmap.R
+# already does, because reaching them through generateCI() would test the
+# wiring rather than the guard.
+# --------------------------------------------------------------------------
+
+test_that("applyMask rejects a mask that is neither a string nor a matrix", {
+  expect_error(rcicr:::applyMask(matrix(1, 8, 8), mask = TRUE, img_size = 8),
+               "neither a string nor a matrix")
+  expect_error(rcicr:::applyMask(matrix(1, 8, 8), mask = list(), img_size = 8),
+               "neither a string nor a matrix")
+
+  # A vector is a double but has no dim, so it takes the same branch.
+  expect_error(rcicr:::applyMask(matrix(1, 8, 8), mask = rep(0, 64), img_size = 8),
+               "neither a string nor a matrix")
+})
+
+test_that("applyMask rejects a mask of the wrong size and says both sizes", {
+  err <- expect_error(
+    rcicr:::applyMask(matrix(1, 8, 8), mask = matrix(0, 4, 4), img_size = 8),
+    "same dimensions"
+  )
+
+  msg <- conditionMessage(err)
+  expect_match(msg, "8")
+  expect_match(msg, "4")
+})
+
+test_that("applyMask rejects a mask that is not binary", {
+  mask <- matrix(0, 8, 8)
+  mask[1, 1] <- 0.5
+
+  expect_error(rcicr:::applyMask(matrix(1, 8, 8), mask = mask, img_size = 8),
+               "other than 0 or 1")
+})
+
+test_that("applyMask rejects a PNG whose colour channels genuinely differ", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  path <- file.path(dir, "rgb.png")
+
+  # Three channels that are not identical, so the greyscale conversion cannot
+  # apply. The neighbouring case -- greyscale stored as RGB -- must still work,
+  # and is asserted below, because this stop() once ran unconditionally and
+  # rejected convertible images too.
+  rgb <- array(0, dim = c(8, 8, 3))
+  rgb[, , 1] <- 1
+  png::writePNG(rgb, path)
+
+  expect_error(rcicr:::applyMask(matrix(1, 8, 8), mask = path, img_size = 8),
+               "not a greyscale image")
+
+  grey_as_rgb <- array(0, dim = c(8, 8, 3))
+  png::writePNG(grey_as_rgb, file.path(dir, "grey.png"))
+  expect_no_error(
+    rcicr:::applyMask(matrix(1, 8, 8), mask = file.path(dir, "grey.png"),
+                      img_size = 8)
+  )
+})
+
+# --------------------------------------------------------------------------
+# generateStimuli2IFC(): base image import
+# --------------------------------------------------------------------------
+
+test_that("generateStimuli2IFC rejects a base image that is not a PNG or JPEG", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  path <- file.path(dir, "base.txt")
+  writeLines("not an image", path)
+
+  expect_error(
+    generateStimuli2IFC(base_face_files = list(base = path), n_trials = 2,
+                        img_size = 32, stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE),
+    "PNG or JPEG"
+  )
+})
+
+test_that("generateStimuli2IFC rejects a non-square base image and reports its size", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  path <- file.path(dir, "oblong.png")
+  png::writePNG(matrix(0.5, 16, 32), path)
+
+  err <- expect_error(
+    generateStimuli2IFC(base_face_files = list(base = path), n_trials = 2,
+                        img_size = 32, stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE),
+    "not square"
+  )
+
+  # A different branch from the img_size mismatch covered in test-fixed-bugs.R:
+  # this one fires whatever img_size was asked for.
+  msg <- conditionMessage(err)
+  expect_match(msg, "16")
+  expect_match(msg, "32")
+})
+
+test_that("generateStimuli2IFC rejects base_face_files that is not a list", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  png <- make_square_png(file.path(dir, "base.png"), size = 32)
+
+  # This one calls stop() with no arguments after writing its explanation to
+  # stderr(), so the condition carries an *empty* message and no regexp can
+  # match it. Asserting only that it errors is the most this path allows;
+  # giving it a real message belongs to item 14.
+  expect_error(
+    suppressWarnings(
+      generateStimuli2IFC(base_face_files = png, n_trials = 2, img_size = 32,
+                          stimulus_path = dir, ncores = 1,
+                          save_as_png = FALSE, save_rdata = FALSE)
+    )
+  )
+})
+
+# --------------------------------------------------------------------------
+# computeCumulativeCICorrelation(targetci = ...): never exercised
+#
+# The existing test covers only the no-targetci route, where the last
+# correlation is 1 by construction -- true whatever the function does with the
+# argument. Supplying a target CI is what the function is actually for.
+# --------------------------------------------------------------------------
+
+test_that("computeCumulativeCICorrelation correlates against a supplied target CI", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  stimuli <- 1:6
+  responses <- rep(c(1, -1), 3)
+
+  self <- suppressWarnings(computeCumulativeCICorrelation(
+    stimuli = stimuli, responses = responses, baseimage = "base", rdata = rdata
+  ))
+
+  # The self-referential run ends at 1: the cumulative CI over every trial is
+  # the final CI. That is the assertion the old test rested on.
+  expect_equal(self[length(self)], 1)
+
+  # A different target must not. Build one from the same stimulus set with the
+  # responses reversed, so it is a real classification image rather than noise.
+  target_ci <- suppressWarnings(generateCI(
+    stimuli = stimuli, responses = rev(responses), baseimage = "base",
+    rdata = rdata, save_as_png = FALSE
+  ))
+
+  against_target <- suppressWarnings(computeCumulativeCICorrelation(
+    stimuli = stimuli, responses = responses, baseimage = "base", rdata = rdata,
+    targetci = target_ci
+  ))
+
+  expect_length(against_target, length(self))
+  expect_false(isTRUE(all.equal(against_target[length(against_target)], 1)))
+
+  # And the value is the correlation with the supplied CI, not merely "not 1".
+  full_ci <- suppressWarnings(generateCI(
+    stimuli = stimuli, responses = responses, baseimage = "base",
+    rdata = rdata, save_as_png = FALSE
+  ))
+  expect_equal(
+    against_target[length(against_target)],
+    cor(as.vector(full_ci$ci), as.vector(target_ci$ci))
+  )
+})

--- a/tests/testthat/test-load-argument-guards.R
+++ b/tests/testthat/test-load-argument-guards.R
@@ -9,17 +9,9 @@
 # the unguarded code too if the collision is not planted -- which is exactly why
 # each one plants it explicitly.
 
-# The leading dot matters: R partially matches named arguments to formals, so a
-# formal called `rdata_path` would swallow a planted `rdata = ...` by prefix and
-# make the helper try to open the decoy instead of the fixture.
-plant_in_rdata <- function(.path, ...) {
-  e <- new.env()
-  load(.path, envir = e)
-  objs <- list(...)
-  for (nm in names(objs)) assign(nm, objs[[nm]], envir = e)
-  save(list = ls(e), file = .path, envir = e)
-  invisible(.path)
-}
+# Planting is done with mutate_rdata() from helper-fixtures.R, which the
+# "did not contain X" tests in test-error-paths.R also use, in its removing
+# direction.
 
 test_that("computeInfoVal2IFC scores the caller's CI, not one found in the .Rdata", {
   skip_if_not_installed("withr")
@@ -35,7 +27,7 @@ test_that("computeInfoVal2IFC scores the caller's CI, not one found in the .Rdat
   # after a *second* load() on the cache-writing path, so both loads need the
   # restore. A file carrying this name would return a plausible number for the
   # wrong image rather than an error, which is the worst shape this can take.
-  plant_in_rdata(rdata, target_ci = decoy)
+  mutate_rdata(rdata, target_ci = decoy)
 
   norms <- local({
     e <- new.env()
@@ -64,7 +56,7 @@ test_that("computeInfoVal2IFC keeps its own rdata path across the load", {
 
   # An older generateReferenceDistribution2IFC() saved its own `rdata` argument
   # into the file, so this name really does occur in the wild.
-  plant_in_rdata(rdata, rdata = file.path(dir, "does-not-exist.Rdata"))
+  mutate_rdata(rdata, rdata = file.path(dir, "does-not-exist.Rdata"))
 
   expect_no_error(
     suppressWarnings(computeInfoVal2IFC(target_ci = list(ci = matrix(0.1, 32, 32)),
@@ -86,8 +78,8 @@ test_that("computeCumulativeCICorrelation keeps its arguments across the load", 
 
   # Plant collisions for three arguments at once: the step size, the label used
   # to look up the parameters, and the stimulus indices themselves.
-  plant_in_rdata(rdata, step = 99L, baseimage = "not-a-real-label",
-                 stimuli = integer(0))
+  mutate_rdata(rdata, step = 99L, baseimage = "not-a-real-label",
+               stimuli = integer(0))
 
   planted <- suppressWarnings(computeCumulativeCICorrelation(
     stimuli = 1:6, responses = responses, baseimage = "base", rdata = rdata


### PR DESCRIPTION
Backlog item 37.

The suite had **9 failure assertions against 33 `stop()`/`warning()` calls**, so most of this package's error messages had never been run. That is not a cosmetic gap: an unexercised guard is indistinguishable from one that works, and it is how items 6, 23 and 28 each stayed broken for years. Item 38 was the most recent — a guard nothing ran, pasting 8,190 characters of pixel values into its own message.

## What is covered

New `tests/testthat/test-error-paths.R`:

- **The stimuli/responses length mismatch** — the likeliest user error in the package — including that it fires *before* the `.Rdata` file is read.
- **Every "did not contain X" guard** in `generateCI()` and `computeCumulativeCICorrelation()`, reached by removing the name from a good fixture so the file stays realistic in every other respect. This is the returning-user path the CRAN reinstatement is for.
- **All four `applyMask()` import failures**, plus the neighbouring case that must still *succeed* (greyscale stored as RGB) — because that `stop()` once ran unconditionally and rejected convertible images too.
- **Base images that are not PNG/JPEG, and that are not square.**
- **`computeCumulativeCICorrelation(targetci = ...)`**, which no test exercised. The old test asserted only that the last correlation is 1 — true by construction on the self-referential path, whatever the argument does.

`plant_in_rdata()` moves from `test-load-argument-guards.R` into `helper-fixtures.R` as `mutate_rdata()`, gaining a `.remove` argument: the collision guards are reached by *adding* a name and the "did not contain" guards by *removing* one.

## How these were verified — the usual method does not apply

This adds no `R/` change, so `git stash push -- R/` proves nothing. The real risk for a test of an error path is that it **passes on a different error than the guard it names**. All 13 were run directly and their `conditionMessage()` read, confirming each fires its own guard; every assertion matches a distinctive fragment of that message rather than merely expecting "an error".

## Two deliberate choices

- Assertions match **short fragments** (`"same length"`, `"did not contain"`, `"other than 0 or 1"`) rather than whole sentences, so item 14 can rewrite the wording without rewriting the suite.
- `generateStimuli2IFC.R:68-69` calls a **bare `stop()`** after writing to `stderr()`, so its condition carries an empty message and no regexp can match it. That test asserts only that it errors — the weakest assertion in the file, and weak because the code gives it nothing to match. Giving it a real message belongs to item 14.

## Verification

No behaviour changed. Suite **291 → 323**, 0 skipped. `R CMD check --as-cran` locally: **0 errors, 0 warnings, 2 NOTEs** (the usual incoming-feasibility and sandbox-clock pair), with `checking tests ... OK` in 19s.

The gate treats `tests/` as an inert path, so `compare` will skip in seconds — correct, but it means the **four `R CMD check` platforms are the only thing between a fragile test and a CRAN failure**, since these ship in the tarball and run on CRAN's farm. Those are the results worth reading here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)