### PR TITLE
Trim derivable content from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,26 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Common commands
 
-This is a standard R package (built with roxygen2 docs, with a testthat suite under `tests/testthat/` and GitHub Actions CI). Typical workflows, run from an R console with working directory set to the package root:
-
-```r
-# Regenerate NAMESPACE and man/*.Rd from roxygen comments in R/*.R
-roxygen2::roxygenise()
-
-# Load all package functions into an interactive session without installing
-devtools::load_all()
-
-# Run the testthat suite
-devtools::test()
-
-# Full package check (as CRAN would run it)
-devtools::check()
-# equivalent from shell:
-# R CMD build . && R CMD check --as-cran rcicr_<version>.tar.gz
-
-# Install local copy
-devtools::install()
-```
+A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`, GitHub Actions CI — so the usual `roxygen2::roxygenise()` / `devtools::load_all()` / `test()` / `check()` / `install()` workflow applies unchanged, run from the package root. Two things about it are *not* standard:
 
 Note: `generateStimuli2IFC()` spawns parallel workers via `parallel::makeCluster()` that each `library(rcicr)` themselves (`.packages='rcicr'` in its `foreach` call) — any test or script that calls it needs the package actually **installed** (`devtools::install()`), not just `load_all()`-loaded, or workers fail with "there is no package called 'rcicr'".
 
@@ -143,38 +124,15 @@ Feature branches → PR → squash onto `main`, and releases are marked by tags.
 
 The package has two pipeline halves that share state only through an `.RData` file written at stimulus-generation time:
 
-### 1. Stimulus generation (`generateStimuli2IFC.R`, `generateCI2IFC.R`, `generateStimuli.R`-family)
-
-- `generateNoisePattern()` builds the base noise basis: a stack of sinusoid (or Gabor) patches at multiple orientations, phases, and spatial scales (`nscales`), returned as `p` (a list with `patches`, `patchIdx`, `noise_type`). This is generated **once** per stimulus set and reused for every trial.
-- `generateNoiseImage()` takes a per-trial parameter vector (random contrast weights, one per patch/scale index) and combines it with `p` to produce a single noise image.
-- `generateStimuli2IFC()` orchestrates the full generation loop: loads base face image(s) (PNG/JPEG, must be square), generates one random parameter vector per trial (`stimuli_params`), and for each trial writes two PNGs per base face — the original stimulus (noise + base face) and its inverted/negative counterpart — using `parallel`/`doParallel`/`foreach` for the per-trial loop.
-- Critically, at the end it saves an `.RData` file containing `base_faces`, `stimuli_params`, `p`, `img_size`, `seed`, `noise_type`, etc. **This file is the only link between stimulus generation and later analysis** — every CI-computation function requires it via the `rdata` argument.
-
-### 2. Analysis / classification image computation (`generateCI.R`, `generateCI2IFC.R`, `batchGenerateCI.R`, `batchGenerateCI2IFC.R`, `computeInfoVal2IFC.R`, `computeCumulativeCICorrelation.R`, `plotZmap.R`)
-
-- `generateCI()` / `generateCI2IFC()` load the `rdata` file, look up the stimulus parameters (`stimuli_params[[baseimage]]`) that correspond to the stimulus numbers a participant actually saw, weight them by that participant's responses (1 = original chosen, -1 = inverted chosen), and sum/average them into a single noise image (the classification image). Scaling of the resulting pixel intensities (`none`, `constant`, `matched`, `independent`) is a key user-facing decision documented at length in `generateCI.R`'s roxygen header — read it before changing scaling logic.
-- `batchGenerateCI()` / `batchGenerateCI2IFC()` wrap the single-CI functions to compute one CI per participant/condition (grouped by a `by` column in a data frame), optionally followed by `autoscale()` to rescale a whole batch of CIs consistently so they remain visually comparable.
-- `autoscale()` finds the single scaling constant that works across a list of CIs without clipping any of them, then rewrites each `$scaled` field and optionally re-saves PNGs.
-- `computeInfoVal2IFC()` computes an "informational value" (a z-score-like signal-strength metric) for a CI by comparing it to a simulated null/reference distribution (`generateReferenceDistribution.R`, `simulateNoiseIntensities.R`). It contains a `ref_lookup` tibble intended to avoid expensive resimulation for common parameter combinations (seed/img_size/n_trials/iter), **but that table has been empty since 2018** — its rows were measured under the pre-erratum infoVal formula and were correctly commented out when `01e547e` adopted the Euclidean norm. So every lookup misses and the reference distribution is always regenerated. Do not describe the lookup as a working cache; the matching machinery is kept only so the table can be repopulated cheaply.
-- `plotZmap()` computes/plots a spatial z-map of a CI using `spatstat.explore::blur` for smoothing, to highlight image regions with statistically reliable signal.
-
-### Data flow summary
-
-```
-base face image(s) ─┐
-                     ├─> generateStimuli2IFC() ─> PNGs on disk + <label>_seed_<seed>_time_<ts>.Rdata
-random noise params ─┘                                  │
-                                                         ▼
-participant responses (stimulus #, 1/-1) ──────> generateCI()/generateCI2IFC() ──> classification image
-                                                         │
-                                            ┌────────────┼───────────────┐
-                                            ▼            ▼               ▼
-                                       autoscale()  computeInfoVal2IFC()  plotZmap()
-```
+The per-function walkthrough of both halves, the data-flow diagram and the anatomy of the
+`.RData` file live in `README.md` — sections "How it works" and "Anatomy of the `.Rdata` file".
+They were duplicated here; read them there rather than maintaining two copies that drift.
 
 ### Notes on conventions in this codebase
 
 - Functions generally use `save_as_png=TRUE` / `save_rdata=TRUE`-style side-effecting defaults — most analysis functions write PNGs to disk (`targetpath`/`stimulus_path` args) in addition to returning data structures.
+- Scaling of CI pixel intensities (`none`, `constant`, `matched`, `independent`) is a key user-facing decision, documented at length in `generateCI.R`'s roxygen header — read it before changing scaling logic.
+- `computeInfoVal2IFC()`'s `ref_lookup` tibble looks like a cache for avoiding expensive resimulation, and is not one: **it has been empty since 2018.** Its rows were measured under the pre-erratum infoVal formula and were correctly commented out when `01e547e` adopted the Euclidean norm, so every lookup misses and the reference distribution is always regenerated. Do not describe it as a working cache; the matching machinery is kept only so the table can be repopulated cheaply.
 - `pre_0.3.0` / `generator_version` fields exist to keep backward compatibility with `.Rdata` files produced by older versions of the package (index-counter starts at 0 vs 1) — do not remove without understanding this.
 - `R/zzz.R` declares `utils::globalVariables()` for names that only exist at runtime after `load()`-ing an `.Rdata` file (e.g. `base_faces`, `stimuli_params`, `p`, `seed`) or inside `foreach` loops (`obs`) — when adding new variables loaded this way, add them here to avoid `R CMD check` NOTEs.
 - Parallelism is via base `parallel` + `doParallel`/`foreach`, not newer alternatives (e.g. `future`) — match this pattern for new parallel code, and remember worker processes need `.packages='rcicr'` set on `foreach` calls.


### PR DESCRIPTION
Two blocks of `CLAUDE.md` were content a fresh session can reconstruct on its own, so every session paid for them and got nothing back. 21,396 → 17,827 chars, **~892 est. tokens saved per session**.

Every gotcha, rationale and convention is kept. Two items that happened to live *inside* the cut region were relocated rather than deleted (below).

## Cut A — the `devtools` command block (18 lines)

```r
roxygen2::roxygenise()
devtools::load_all()
devtools::test()
devtools::check()
devtools::install()
```

These are the standard invocations for any R package, inferable from `DESCRIPTION` + `R/` + `tests/testthat/` alone. Replaced by one line saying the usual workflow applies unchanged — which also fixes a lead-in sentence (`Typical workflows…:`) that would otherwise dangle.

**Kept:** the `generateStimuli2IFC()` parallel-worker gotcha (workers `library(rcicr)` themselves, so the package must be *installed*, not just `load_all()`-loaded, or they fail with "there is no package called 'rcicr'") and the `ChangeLog` convention.

## Cut B — the architecture walkthrough (29 lines)

The two per-function subsections and the ASCII data-flow diagram. This is not merely derivable from the code — **it duplicates `README.md`**, which covers the same pipeline, the same `.Rdata` contract and the same flow in "How it works" (line 64) and "Anatomy of the `.Rdata` file" (line 113). Two copies of the same explanation drift, and the copy a reader hits first is then the wrong one.

Replaced by a pointer to those two README sections. Verified both headings exist, and that nothing anywhere in the repo cross-referenced the removed subsections or the diagram.

**Kept:** the section intro (the `.RData`-is-the-only-link contract) and all of "Notes on conventions in this codebase".

## Two items relocated, not deleted

Both sat inside cut B's line range rather than in "Notes on conventions", so a straight deletion would have lost them. They are now bullets under "Notes on conventions":

- The `generateCI.R` scaling pointer — that `none`/`constant`/`matched`/`independent` is a user-facing decision documented at length in the roxygen header, to be read before changing scaling logic.
- The `ref_lookup` trap — that it **looks** like a cache for avoiding resimulation and is not one, having been empty since 2018 because its rows were measured under the pre-erratum infoVal formula and were correctly commented out when `01e547e` adopted the Euclidean norm.

That second one is the reason this PR saves ~892 est. tokens rather than the ~1,156 first estimated. Worth it: a "looks like a cache, isn't" note cannot be recovered by reading the code, which is the whole test for what belongs in this file.

## Not proposed

Migrating "Releases and versioning" (38 lines) to a lazily-loaded skill. Its content is correctness traps that fire exactly once, at release time — "never put a version number in a `NEWS.md` section heading" cost a real `R CMD check` NOTE on 2026-07-28 — and a skill that fails to trigger pays that cost twice. At 44% of the ~40,000-char warning threshold there is no pressure justifying the risk.

## Checked

- Every remaining section is gotchas, rationale or repo etiquette. Spot-verified after the rebase that the parallel-worker failure, `ref_lookup`, `pre_0.3.0`/`generator_version`, `R/zzz.R` globals, the `parallel`-not-`future` convention, the scaling pointer and the `ChangeLog` convention all survive.
- The content #156 added to this file — the five required-status-check contexts and the `0xC0000409` Windows-flake note — was re-tested against the same derivability bar and **kept**. The flake note is a specific observed failure with its resolution; the context list is enumerable via `gh api` but records *intent*, and its surrounding gotcha (the classic branches endpoint reports empty and misleads you) is the non-derivable part. One reservation for later: a list stamped "as of 2026-07-29" is a drift risk, and if it ever goes stale the fix is to keep the endpoint pointer and drop the enumeration rather than re-date it.
- `CLAUDE.md` is `.Rbuildignore`d, so nothing here can reach the built tarball, and the file is on the reproducibility gate's inert allowlist — `compare` should post green without doing work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M4j1pEStw2piD1FJXrBfEY)_