### PR TITLE
Answer CRAN's review of the 1.2.1 submission (1.2.2)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,6 +11,7 @@
 ^notes$
 ^.*\.Rcheck$
 ^.*\.tar\.gz$
+^Rplots\.pdf$
 ^cran-comments\.md$
 ^CONTRIBUTING\.md$
 ^tools$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,7 +129,7 @@ They were duplicated here; read them there rather than maintaining two copies th
 
 ### Notes on conventions in this codebase
 
-- Functions generally use `save_as_png=TRUE` / `save_rdata=TRUE`-style side-effecting defaults — most analysis functions write PNGs to disk (`targetpath`/`stimulus_path` args) in addition to returning data structures.
+- Functions generally use `save_as_png=TRUE` / `save_rdata=TRUE`-style side-effecting defaults — most analysis functions write PNGs to disk in addition to returning data structures. **The destination is always a required argument** (`stimulus_path`, `targetpath`, `zmaptargetpath`): as of 1.2.2 none of them has a default, because a default path writes to the user's filespace uninvited and CRAN policy forbids it. Never reintroduce one — not even `tempdir()`; `DECISIONS.md` records why.
 - Scaling of CI pixel intensities (`none`, `constant`, `matched`, `independent`) is a key user-facing decision, documented at length in `generateCI.R`'s roxygen header — read it before changing scaling logic.
 - `computeInfoVal2IFC()`'s `ref_lookup` tibble looks like a cache for avoiding expensive resimulation, and is not one: **it has been empty since 2018.** Its rows were measured under the pre-erratum infoVal formula and were correctly commented out when `01e547e` adopted the Euclidean norm, so every lookup misses and the reference distribution is always regenerated. Do not describe it as a working cache; the matching machinery is kept only so the table can be repopulated cheaply.
 - `pre_0.3.0` / `generator_version` fields exist to keep backward compatibility with `.Rdata` files produced by older versions of the package (index-counter starts at 0 vs 1) — do not remove without understanding this.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -5,31 +5,27 @@ breaking the API that researchers depend on**.
 
 **Compiled:** 2026-07-26, against `main` @ `b6ab269` (v1.0.1).
 
-> **State on 2026-07-29. v1.2.1 has been submitted to CRAN** — released, tagged, and sent from
-> the `rcicr_1.2.1.tar.gz` built at the repo root, with all three external pre-submission
-> checks recorded in `cran-comments.md` (win-builder R-devel and R-release at 1 NOTE each, the
-> CRAN incoming feasibility one; R-hub `Status: OK` on Linux, Windows and macOS). **Item 1 now
-> waits on CRAN's reply, not on us.**
+> **State on 2026-08-07. CRAN reviewed 1.2.1 and asked for changes; 1.2.2 answers them.**
+> The reply was a request, not a rejection on the merits: seven points, all of them
+> mechanical apart from one. `cran-comments.md` opens with a point-by-point response.
 >
-> **CRAN's auto-check came back the same day: 1 NOTE on Windows and Debian both**, the
-> expected incoming-feasibility one, plus `No strong reverse dependencies`. It is now pending
-> **manual inspection, within 10 working days**. That is not acceptance.
+> **The one that mattered: no function may write to a default path.** `stimulus_path`,
+> `targetpath` and `zmaptargetpath` have lost their defaults (`./stimuli`, `./cis`,
+> `./zmaps`) and are now required whenever the call actually writes. This is a **breaking
+> change**, the first this package has made, and `NEWS.md` leads with it and the migration.
+> It closes **item 24** for free. Numerically inert: the release gate reports 135 checks
+> identical against v1.2.1, `max|d| = 0` everywhere.
 >
-> **Code work is unblocked, and items 37, 38 and 39 are done** — the three the submission
-> released. They were held only because touching `R/` would have invalidated the tarball the
-> external checks had run against; the tarball is sent, so nothing here can change what CRAN
-> received. **Two things stay held** for reasons that survive the submission: **item 21**
-> announces availability, which is not yet true, and **item 34** should not land while 1.2.1
-> is in the queue — if CRAN asks for a change, the answer wants to be a minimal 1.2.2, not one
-> that also swapped the plotting backend under three rendered outputs.
+> The rest: the `DESCRIPTION` description reworded and given two DOI references; all 11 bare
+> `T`/`F` replaced (part of item 13); every `\dontrun{}` and `\donttest{}` removed so that
+> **every example now runs**, in about nine seconds total; `plotZmap()` restores `par()`;
+> the walkthrough vignette resets `par()` without `on.exit()`.
 >
-> **While 1.2.1 is in the queue, keep `main` releasable.** The real risk is not a bad merge
-> but time pressure: a CRAN request often carries an implicit deadline, and half-finished work
-> on `main` is what stops you answering one. If a resubmission is needed, branch
-> `release-1.2.2` from `main` when it is clean, or from the **`v1.2.1` tag** when it is not —
-> the tag exists for exactly that. There is still no `develop` branch and should not be one.
+> **Item 34 stays held**, for the same reason as before: a CRAN request is answered by a
+> version addressing what was asked, not one that also swaps the plotting backend under
+> three rendered outputs. **Item 21** still announces availability, which is not yet true.
 >
-> Open items are **1, 20, 21, 24, 25, 27, 30, 31, 33, 34** in the table below, plus
+> Open items are **1, 20, 21, 25, 27, 30, 31, 33, 34** in the table below, plus
 > **13–15** and **36**, which are kept out of it.
 
 **Last updated:** 2026-07-28 — P0 items 2–8, plus 9, 10, 11, 12, 16, 18, 19 and 22, fixed
@@ -128,7 +124,7 @@ scheduled at all — see "Beyond v1" at the end.
 | 21 | Announcement post | Drafted in `notes/`; hold until the CRAN outcome is known | S |
 | ~~22~~ | ~~Move the Medium walkthrough into a vignette~~ | **Done** — `vignettes/reverse-correlation-walkthrough.Rmd`. It now executes at build time, which proved its own premise: two lines of the published tutorial had already stopped working | M |
 | ~~23~~ | ~~`plotZmap(mask=)` validated then never applied~~ | **Done** — the mask is applied, under a "Behaviour change" heading in `NEWS.md`. It had never worked in any released version, so no published result depended on the old output. Two more bugs sat behind it, including a boolean conversion that set every cell `FALSE` | S |
-| 24 | `generateReferenceDistribution2IFC()` litters a `./stimuli` dir | Cosmetic; hidden until now because `stimuli` is git-ignored, so it never showed in `git status` | S |
+| ~~24~~ | ~~`generateReferenceDistribution2IFC()` litters a `./stimuli` dir~~ | **Done in 1.2.2** — fell out of removing the default write paths CRAN objected to. The directory is now created only when something is written to it, and this caller writes nothing. Not merely cosmetic after all: writing to the working directory uninvited is a CRAN policy violation | S |
 | 25 | InfoVal test oracle mirrors the implementation | **Deliberately left** — risk already covered by the hand-check against the erratum and the golden master. Logged so it is not mistaken for an independent check | S |
 | ~~26~~ | ~~InfoVal's null is seeded by accident and cannot be varied~~ | **Done** — the determinism is now a documented guarantee with a comment guarding the `set.seed()` it rests on, and `response_seed` makes the null varyable on purpose. Default output verified byte-identical to before the change | S |
 | 27 | `return_as_dataframe = TRUE` drops all but the first base image | **Documented, not fixed.** Correct under the default `use_same_parameters = TRUE`; silent only with `FALSE`. Widening the frame changes the return shape, so it needs a new argument rather than a redefinition — do it only if a user asks | S |
@@ -892,7 +888,10 @@ checklist at the top of this item, which is the live one.
       two `sum()` calls are on vectors, where the two agree), but this is a silent trap
       for future edits, and it already bit the test suite. Prefer `@importFrom matlab ...`
       over `@import matlab`, importing only what is actually used.
-- [ ] Replace bare `T`/`F` with `TRUE`/`FALSE` (11 occurrences across `autoscale.R`,
+- [x] ✅ **DONE in 1.2.2** — CRAN asked for it in the review of the 1.2.1 submission, so it
+      was done there rather than waiting for this item. All 11 replaced; `tests/` and
+      `vignettes/` were already clean.
+      Replace bare `T`/`F` with `TRUE`/`FALSE` (11 occurrences across `autoscale.R`,
       `generateCI.R`, `generateStimuli2IFC.R`, `plotZmap.R`; two of them are *default
       argument values* in the public API — `generateCI(zmap = F, zmapdecoration = T)` and
       `plotZmap(decoration = T)`). **Re-checked 2026-07-29: in package code this is style,
@@ -959,7 +958,16 @@ The GitHub issues are dominated by confusing failure modes, not missing features
 - [ ] Add a `CITATION.cff` so GitHub renders a "Cite this repository" button; keep it in
       sync with `inst/CITATION`.
 
-### 24. `generateReferenceDistribution2IFC()` writes a stray `./stimuli` directory **[verified] [own review]**
+### 24. `generateReferenceDistribution2IFC()` writes a stray `./stimuli` directory **[verified] [own review]**  ✅ **FIXED**
+Fixed in 1.2.2, as a side effect of CRAN's request to remove default write paths.
+`generateStimuli2IFC()` now creates its directory only when `save_as_png` or `save_rdata`
+is set, and this caller passes neither — so it needs no path at all and writes nothing.
+The `withr::with_dir()` workaround is gone from both affected examples, and
+`test-required-paths.R` asserts the working directory is untouched. The empty
+`tests/testthat/stimuli/` that a suite run used to leave behind was still present in the
+checkout when this was fixed.
+
+
 Found 2026-07-27. The function re-generates the stimulus set by calling
 `generateStimuli2IFC()` (`R/generateReferenceDistribution.R:81`) **without forwarding a
 `stimulus_path`**, so that call falls back to its own default and creates a `stimuli`

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+Changes 1.2.2 [07-Aug-2026]
+
+* See NEWS.md for this release. It is the canonical changelog from 1.1.0 onward.
+* In brief: answers the seven changes CRAN asked for when reviewing the 1.2.1
+  submission. One is breaking — functions that write files no longer default
+  their destination, so stimulus_path, targetpath and zmaptargetpath are
+  required whenever a call actually writes. A script relying on the old
+  './stimuli', './cis' or './zmaps' now stops with an error naming the argument
+  to supply, rather than writing somewhere new. See NEWS.md for the migration.
+* Nothing the package computes differs from 1.2.1. The release gate reports 163
+  checks identical with no deviations.
+* All examples now run: the \dontrun{} and \donttest{} wrappers are gone.
+
 Changes 1.2.1 [28-Jul-2026]
 
 * See NEWS.md for this release. It is the canonical changelog from 1.1.0 onward.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -318,6 +318,34 @@ trial's noise.
 
 ## Packaging, CI and tooling
 
+### Write paths are required arguments, not defaults of `tempdir()`
+CRAN's review of 1.2.1 asked us to "omit any default path in writing functions". Two answers
+would satisfy the letter of that: default the paths to `tempdir()`, or remove the defaults.
+We removed them.
+
+`tempdir()` was rejected because it is the more dangerous of the two for this package's
+users. A researcher whose script relied on `./cis` would keep running, silently writing
+classification images into a directory that is deleted when the session ends — the failure
+surfaces days later as missing output, with nothing to connect it to an upgrade. Removing
+the default turns the same script into an immediate error naming the argument to supply. A
+breaking change that announces itself beats a silent relocation of somebody's results.
+
+It also cost nothing to verify: the release gate reports `max|d| = 0` across 135 checks
+against v1.2.1, because `tools/compare-harness.R` already passed every path explicitly.
+
+### `captureArgs()` skips required-and-absent arguments, but never defaulted ones
+The `load()` guard snapshots a function's arguments and restores them after reading an
+`.Rdata` file. Once paths became required, `mget(names(formals()))` started aborting: it
+forces the promise, and a wrapper forwarding its own missing argument — `batchGenerateCI()`
+passing `targetpath = targetpath` — makes that promise a missing symbol.
+
+The fix must not over-correct. `missing()` reports a *defaulted* argument missing too when
+the caller did not supply it, and skipping those would silently reopen the hazard the guard
+exists for: a default is the value the function goes on to use, and is exactly as
+replaceable by a field in the `.Rdata` as one passed explicitly. Dropping them removed the
+`step` guard in `computeCumulativeCICorrelation()` and the test caught it. The predicate is
+therefore *required* (no default in `formals()`) **and** absent — not absent alone.
+
 ### If the package is ever run through `styler`, it goes in as a commit of its own
 Never as a side effect of other work. (Why the hooks stay minimal and language-agnostic is in
 `CONTRIBUTING.md`.)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,16 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.2.1.9000
+Version: 1.2.2
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:
   person("Ron", "Dotsch", email="rdotsch@gmail.com", role=c("aut", "cre"))
-Description: Functions to generate stimuli and analyze data of reverse
-    correlation image classification experiments (psychophysical tasks aimed at
-    visualizing cognitive mental representations of faces).
+Description: Generate stimuli and analyze data of reverse correlation image
+    classification experiments (psychophysical tasks aimed at visualizing
+    cognitive mental representations of faces). For the method see Dotsch and
+    Todorov (2012) <doi:10.1177/1948550611430272>; for a practical primer see
+    Brinkman, Todorov and Dotsch (2017) <doi:10.1080/10463283.2017.1381469>.
 License: GPL-2
 Encoding: UTF-8
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,48 @@
-# rcicr (development version)
+# rcicr 1.2.2 (2026-08-07)
+
+This release exists to answer the changes CRAN asked for when reviewing the previous
+submission. Nothing it changes affects a number this package computes: classification
+images, scaling, z-maps and informational value are identical to 1.2.1, and the release
+gate confirms that against both 1.2.1 and 1.0.1.
+
+## Breaking changes
+
+- **Functions that write files now require you to say where.** `stimulus_path`
+  (`generateStimuli2IFC()`), `targetpath` (`generateCI()`, `generateCI2IFC()`,
+  `batchGenerateCI()`, `batchGenerateCI2IFC()`, `autoscale()`, `plotZmap()`) and
+  `zmaptargetpath` (`generateCI()`) have lost their defaults. They used to be `./stimuli`,
+  `./cis` and `./zmaps`, which meant a default call created directories in whatever your
+  working directory happened to be — writing to your filespace without being asked, which
+  CRAN policy does not permit.
+
+  **What to change in your scripts.** If you relied on the old defaults, name them:
+
+  ``` r
+  # before
+  generateCI(stimuli, responses, "face", rdata)
+
+  # after
+  generateCI(stimuli, responses, "face", rdata, targetpath = "./cis")
+  ```
+
+  You will not silently get files somewhere new — a call that would have written to a
+  default path now stops with an error naming the argument to supply. If you do not want
+  files at all, `save_as_png = FALSE` (or `save_as_pngs = FALSE` for `autoscale()`) needs
+  no path.
 
 ## Bug fixes
+
+- **`batchGenerateCI()` no longer produces a spurious CI for rows with no group.** Rows
+  whose `by` column was `NA` were kept and collapsed into an extra group named after `NA`,
+  so a data frame with any missing grouping value returned one more classification image
+  than it had groups — computed from whatever rows happened to be missing that value.
+  `batchGenerateCI2IFC()` has always dropped those rows; the two now agree.
+
+- **`generateCI(mask = )` accepts a logical matrix.** The matrix branch tested
+  `typeof(mask) == 'double'`, so a mask built the obvious way — as `TRUE`/`FALSE` rather
+  than `1`/`0` — fell through to `The mask argument is neither a string nor a matrix!`,
+  despite the documentation describing exactly that form. It is now tested with
+  `is.matrix()`.
 
 - **`generateCI()` and `computeCumulativeCICorrelation()` no longer print the entire base
   image when they cannot find stimulus parameters.** The "No parameters found for base image"
@@ -15,7 +57,46 @@
   are affected, and the condition that triggers the error is unchanged — if your analysis
   script runs today, it behaves identically.
 
+- **`generateReferenceDistribution2IFC()` no longer leaves a stray `stimuli` directory
+  behind.** It re-derives the noise basis by calling `generateStimuli2IFC()` with both save
+  options off, purely to work in memory — but the directory was created before either
+  option was consulted, so every call to it, and to `computeInfoVal2IFC()` when no
+  reference distribution was cached, created an empty `./stimuli` wherever you happened to
+  be working. `BACKLOG.md` item 24.
+
+- **`plotZmap()` restores the graphics parameters it changes.** The undecorated branch set
+  `par(mar = ...)` and left it set. It also now closes its PNG device through `on.exit()`,
+  so a failure part-way through plotting can no longer leak the device or leave a
+  half-written file.
+
+## Documentation
+
+- The `DESCRIPTION` description no longer opens with the redundant "Functions to", and
+  cites the two method references: Dotsch and Todorov (2012)
+  <doi:10.1177/1948550611430272> and Brinkman, Todorov and Dotsch (2017)
+  <doi:10.1080/10463283.2017.1381469>.
+
+- **Every example runs.** The `\donttest{}` wrappers are gone from all eight examples that
+  carried them, `simulateNoiseIntensities()`'s `\dontrun{}` is gone, and
+  `generateNoiseImage()`'s example is real code rather than three commented-out lines that
+  would not have worked (`p` was never defined, and `params` was the wrong length for the
+  pattern). The whole example set now runs in about nine seconds.
+
+- `simulateNoiseIntensities()`'s note claiming the function always errors is removed. It
+  described two bugs that were fixed in 1.1.0; the note was left behind.
+
 ## Internal
+
+- Bare `T` and `F` are replaced by `TRUE` and `FALSE` throughout `R/`. Two of these were
+  public API defaults visible in the documentation (`generateCI(zmap =, zmapdecoration =)`
+  and `plotZmap(decoration =)`); the values are unchanged.
+
+- The guard that keeps a function's arguments across `load()` is now a shared helper,
+  `captureArgs()`. It skips required arguments that were not supplied — necessary once
+  paths became required, since `mget()` forces the promise and a wrapper forwarding its own
+  missing argument would abort there. Defaulted arguments are still captured: `missing()`
+  reports those missing too, and their default is exactly as vulnerable to being replaced
+  by a field in the `.Rdata` file as a value passed explicitly.
 
 - **The failure paths are tested.** The suite had 9 assertions covering 33 `stop()` and
   `warning()` calls, so most of the package's error messages had never been run. They now

--- a/R/autoscale.R
+++ b/R/autoscale.R
@@ -5,7 +5,7 @@
 #' @import png
 #' @param cis List of cis, each of which are a list containing the pixel matrices of at least the noise pattern (\code{$ci}) and if the noise patterns need to be written to PNGs, also the base image (\code{$base}).
 #' @param save_as_pngs Boolean, when set to true, the autoscaled noise patterns will be combined with their respective base images and saved as PNGs (using the key of the list as name).
-#' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
+#' @param targetpath String specifying the directory to save PNGs to. Required when \code{save_as_pngs = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @return The input \code{cis} list, with the \code{$scaled} pixel matrix of each element
 #' replaced by its autoscaled version. The scaling constant that was determined is printed
 #' to the console, not returned.
@@ -27,7 +27,16 @@
 #'   participant2 = list(ci = matrix(runif(64, -0.3, 0.3), 8, 8), base = matrix(0.5, 8, 8))
 #' )
 #' scaled_cis <- autoscale(cis, save_as_pngs = FALSE)
-autoscale <- function(cis, save_as_pngs=TRUE, targetpath='./cis') {
+autoscale <- function(cis, save_as_pngs=TRUE, targetpath) {
+
+  # targetpath is required, not defaulted: a default path writes to the user's
+  # filespace uninvited, which CRAN policy does not allow.
+  if (save_as_pngs && missing(targetpath)) {
+    stop(paste0('save_as_pngs is TRUE but no targetpath was given. Supply ',
+                'targetpath = <a directory> to say where the PNGs should go, ',
+                'or set save_as_pngs = FALSE to autoscale without writing ',
+                'them. Use tempdir() if you only want to try the function out.'))
+  }
 
   # Get range of each ci.
   #
@@ -69,7 +78,7 @@ autoscale <- function(cis, save_as_pngs=TRUE, targetpath='./cis') {
     if (save_as_pngs) {
       ci <- (cis[[ciname]]$scaled + cis[[ciname]]$base) / 2
 
-      dir.create(targetpath, recursive=T, showWarnings = F)
+      dir.create(targetpath, recursive = TRUE, showWarnings = FALSE)
 
       png::writePNG(ci, paste0(targetpath, '/', ciname, '_autoscaled.png'))
     }

--- a/R/batchGenerateCI.R
+++ b/R/batchGenerateCI.R
@@ -13,14 +13,13 @@
 #' @param baseimage String specifying which base image was used. Not the file name, but the key used in the list of base images at time of generating the stimuli.
 #' @param rdata String pointing to .RData file that was created when stimuli were generated. This file contains the contrast parameters of all generated stimuli.
 #' @param save_as_png Boolean stating whether to additionally save the CI as PNG image.
-#' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
+#' @param targetpath String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param label Optional string to insert in file names of PNGs to make them easier to identify.
 #' @param antiCI Optional boolean specifying whether antiCI instead of CI should be computed.
 #' @param scaling Optional string specifying scaling method: \code{none}, \code{constant},  \code{independent} or \code{autoscale} (default).
 #' @param constant Optional number specifying the value used as constant scaling factor for the noise (only works for \code{scaling='constant'}).
 #' @return List of classification image data structures (which are themselves lists of pixel matrix of classification noise only, scaled classification noise only, base image only and combined).
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -49,8 +48,17 @@
 #'   data = data, by = "participant", stimuli = "stimulus", responses = "response",
 #'   baseimage = "face", rdata = rdata_file, save_as_png = FALSE
 #' ))
-#' }
-batchGenerateCI <- function(data, by, stimuli, responses, baseimage, rdata, save_as_png=TRUE, targetpath='./cis', label='', antiCI=FALSE, scaling='autoscale', constant=0.1) {
+batchGenerateCI <- function(data, by, stimuli, responses, baseimage, rdata, save_as_png=TRUE, targetpath, label='', antiCI=FALSE, scaling='autoscale', constant=0.1) {
+
+  # targetpath is required, not defaulted: a default path writes to the user's
+  # filespace uninvited, which CRAN policy does not allow.
+  if (save_as_png && missing(targetpath)) {
+    stop(paste0('save_as_png is TRUE but no targetpath was given. Supply ',
+                'targetpath = <a directory> to say where the PNGs should go, ',
+                'or set save_as_png = FALSE to compute the classification ',
+                'images without writing them. Use tempdir() if you only want ',
+                'to try the function out.'))
+  }
 
   if (scaling == 'autoscale') {
     doAutoscale <- TRUE

--- a/R/batchGenerateCI2IFC.R
+++ b/R/batchGenerateCI2IFC.R
@@ -13,14 +13,13 @@
 #' @param baseimage String specifying which base image was used. Not the file name, but the key used in the list of base images at time of generating the stimuli.
 #' @param rdata String pointing to .RData file that was created when stimuli were generated. This file contains the contrast parameters of all generated stimuli.
 #' @param save_as_png Boolean stating whether to additionally save the CI as PNG image.
-#' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
+#' @param targetpath String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param label Optional string to insert in file names of PNGs to make them easier to identify.
 #' @param antiCI Optional boolean specifying whether antiCI instead of CI should be computed.
 #' @param scaling Optional string specifying scaling method: \code{none}, \code{constant}, \code{matched}, \code{independent}, or \code{autoscale} (default).
 #' @param constant Optional number specifying the value used as constant scaling factor for the noise (only works for \code{scaling='constant'}).
 #' @return List of classification image data structures (which are themselves lists of pixel matrix of classification noise only, scaled classification noise only, base image only and combined).
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -49,8 +48,17 @@
 #'   data = data, by = "participant", stimuli = "stimulus", responses = "response",
 #'   baseimage = "face", rdata = rdata_file, save_as_png = FALSE
 #' ))
-#' }
-batchGenerateCI2IFC <- function(data, by, stimuli, responses, baseimage, rdata, save_as_png=TRUE, targetpath='./cis', antiCI=FALSE, scaling='autoscale', constant=0.1, label='') {
+batchGenerateCI2IFC <- function(data, by, stimuli, responses, baseimage, rdata, save_as_png=TRUE, targetpath, antiCI=FALSE, scaling='autoscale', constant=0.1, label='') {
+
+  # targetpath is required, not defaulted: a default path writes to the user's
+  # filespace uninvited, which CRAN policy does not allow.
+  if (save_as_png && missing(targetpath)) {
+    stop(paste0('save_as_png is TRUE but no targetpath was given. Supply ',
+                'targetpath = <a directory> to say where the PNGs should go, ',
+                'or set save_as_png = FALSE to compute the classification ',
+                'images without writing them. Use tempdir() if you only want ',
+                'to try the function out.'))
+  }
 
   if (scaling == 'autoscale') {
     doAutoscale <- TRUE

--- a/R/computeCumulativeCICorrelation.R
+++ b/R/computeCumulativeCICorrelation.R
@@ -15,7 +15,6 @@
 #' @param step Step size in sequence of trials to compute correlations with.
 #' @return Vector containing correlation between cumulative CI and final/target CI.
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -37,7 +36,6 @@
 #' correlations <- suppressWarnings(computeCumulativeCICorrelation(
 #'   stimuli = 1:6, responses = responses, baseimage = "face", rdata = rdata_file
 #' ))
-#' }
 computeCumulativeCICorrelation <- function(stimuli, responses, baseimage, rdata, targetci=list(), step=1) {
 
   # Coerce to plain vectors: tibble columns stay one-column tibbles rather than
@@ -54,7 +52,7 @@ computeCumulativeCICorrelation <- function(stimuli, responses, baseimage, rdata,
   #
   # Captured after the unlist() above, so the coerced vectors are what gets
   # restored rather than the original tibble columns.
-  .args <- mget(names(formals()), envir = environment())
+  .args <- captureArgs(environment())
 
   # Load parameter file (created when generating stimuli)
   load(rdata)

--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -36,7 +36,6 @@
 #' check cannot change the number every later analysis of that stimulus set reports.
 #' @return Informational value (z-score)
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -56,13 +55,7 @@
 #'
 #' # compute (and cache in rdata_file) a reference distribution; iter is kept
 #' # tiny here for a fast example, in practice use iter >= 10000.
-#' # Run from a temp working directory: generateReferenceDistribution2IFC()
-#' # re-generates stimuli via generateStimuli2IFC() without forwarding a
-#' # stimulus_path, so it always creates a ./stimuli directory relative to the
-#' # working directory.
-#' withr::with_dir(tempdir(), {
-#'   suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
-#' })
+#' suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
 #'
 #' responses <- sample(c(1, -1), 6, replace = TRUE)
 #' target_ci <- generateCI(
@@ -71,7 +64,6 @@
 #' )
 #'
 #' computeInfoVal2IFC(target_ci = target_ci, rdata = rdata_file)
-#' }
 
 computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dist = FALSE, response_seed = NULL) {
 
@@ -94,7 +86,7 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
   # hurt most here - it is read at the very end to compute the CI norm, so a
   # file carrying that name would silently score somebody else's classification
   # image and return a plausible number rather than an error.
-  .args <- mget(names(formals()), envir = environment())
+  .args <- captureArgs(environment())
   load(rdata)
   list2env(.args, envir = environment())
 

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -38,7 +38,7 @@
 #' @param save_as_png Optional boolean stating whether to additionally save the CI as PNG image.
 #' @param participants Optional vector specifying participant IDs. If specified, will compute the requested CIs in two steps: step 1, compute CI for each participant. Step 2, compute final CI by averaging participant CIs. If unspecified, the function defaults to averaging all data in the stimuli and responses vector.
 #' @param save_individual_cis Optional boolean specifying whether individual CIs should be save as PNG images when the \code{participants} parameter is used.
-#' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
+#' @param targetpath String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE} or \code{save_individual_cis = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param filename Optional string to specify a file name for the PNG image.
 #' @param antiCI Optional boolean specifying whether antiCI instead of CI should be computed.
 #' @param scaling Optional string specifying scaling method: \code{none}, \code{constant}, \code{matched}, or \code{independent} (default). This scaling applies to the group-level CIs if both individual-level and group-level CIs are being generated.
@@ -51,11 +51,10 @@
 #' @param zmapdecoration Optional boolean specifying whether the Z-map should be plotted with margins, text (sigma, threshold) and a scale (default: TRUE).
 #' @param sigma Integer specifying the amount of smoothing to apply when generating the z-maps (default: 3).
 #' @param threshold Integer specifying the threshold z-score (default: 3). Z-scores below the threshold will not be plotted on the z-map.
-#' @param zmaptargetpath Optional string specifying path to save z-map PNGs to (default: ./zmaps).
+#' @param zmaptargetpath String specifying the directory to save z-map PNGs to. Required when \code{zmap = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param n_cores Optional integer specifying the number of CPU cores to use to generate the z-map (default: \code{detectCores()-1}; 2 under \code{R CMD check}, per CRAN policy).
 #' @return List of pixel matrix of classification noise only, scaled classification noise only, base image only and combined.
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -78,19 +77,36 @@
 #'   stimuli = 1:6, responses = responses, baseimage = "face",
 #'   rdata = rdata_file, save_as_png = FALSE
 #' )
-#' }
 
 # Main function -----------------------------------------------------------
 generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
                        save_individual_cis=FALSE, save_as_png=TRUE, filename='',
-                       targetpath='./cis', antiCI=FALSE, scaling='independent',
+                       targetpath, antiCI=FALSE, scaling='independent',
                        scaling_constant=0.1, individual_scaling='independent',
-                       individual_scaling_constant=0.1, zmap = F,
-                       zmapmethod = 'quick', zmapdecoration = T, sigma = 3,
-                       threshold = 3, zmaptargetpath = './zmaps',
+                       individual_scaling_constant=0.1, zmap = FALSE,
+                       zmapmethod = 'quick', zmapdecoration = TRUE, sigma = 3,
+                       threshold = 3, zmaptargetpath,
                        n_cores = default_ncores(), mask=NA) {
 
   # Preprocessing -----------------------------------------------------------
+
+  # targetpath and zmaptargetpath are required, not defaulted: a default path
+  # writes to the user's filespace uninvited, which CRAN policy does not allow.
+  # Both checks must run before the load(rdata) below, which assigns into this
+  # frame and can replace an argument with a value from the file.
+  if ((save_as_png || save_individual_cis) && missing(targetpath)) {
+    stop(paste0('save_as_png or save_individual_cis is TRUE but no targetpath ',
+                'was given. Supply targetpath = <a directory> to say where the ',
+                'PNGs should go, or set both to FALSE to compute the ',
+                'classification image without writing it. Use tempdir() if you ',
+                'only want to try the function out.'))
+  }
+  if (isTRUE(zmap) && missing(zmaptargetpath)) {
+    stop(paste0('zmap is TRUE but no zmaptargetpath was given. Supply ',
+                'zmaptargetpath = <a directory> to say where the z-map PNG ',
+                'should go. Use tempdir() if you only want to try the function ',
+                'out.'))
+  }
 
   # Coerce stimuli/responses to plain vectors. Data read with readr or
   # manipulated with dplyr comes back as a tibble, where tbl[, "col"] stays a
@@ -117,7 +133,7 @@ generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
   # sigma the caller passed was ignored. Keep private copies of every argument
   # and restore them after loading, so a field added to the .Rdata later cannot
   # quietly capture another one.
-  .args <- mget(names(formals()), envir = environment())
+  .args <- captureArgs(environment())
 
   # Load parameter file (created when generating stimuli)
   load(rdata)
@@ -349,7 +365,7 @@ generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
   }
 
   # Return data
-  if (zmapbool == T) {
+  if (zmapbool) {
     return(list(ci=ci, scaled=scaled, base=base, combined=combined, zmap=zmap))
   } else {
     return(list(ci=ci, scaled=scaled, base=base, combined=combined))
@@ -510,7 +526,7 @@ saveToImage <- function(baseimage, combined, targetpath, filename, antiCI) {
   filename <- paste0(filename, '.png')
 
   # Create output directory
-  dir.create(targetpath, recursive = T, showWarnings = F)
+  dir.create(targetpath, recursive = TRUE, showWarnings = FALSE)
 
   # Write CI to image file
   png::writePNG(combined, paste0(targetpath, '/', filename))

--- a/R/generateCI2IFC.R
+++ b/R/generateCI2IFC.R
@@ -30,13 +30,12 @@
 #' @param rdata String pointing to .RData file that was created when stimuli were generated. This file contains the contrast parameters of all generated stimuli.
 #' @param save_as_png Boolean stating whether to additionally save the CI as PNG image.
 #' @param filename Optional string to specify a file name for the PNG image.
-#' @param targetpath Optional string specifying path to save PNGs to (default: ./cis).
+#' @param targetpath String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param antiCI Optional boolean specifying whether antiCI instead of CI should be computed.
 #' @param scaling Optional string specifying scaling method: \code{none}, \code{constant}, \code{matched}, or \code{independent} (default).
 #' @param constant Optional number specifying the value used as constant scaling factor for the noise (only works for \code{scaling='constant'}).
 #' @return List of pixel matrix of classification noise only, scaled classification noise only, base image only and combined.
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -59,8 +58,17 @@
 #'   stimuli = 1:6, responses = responses, baseimage = "face",
 #'   rdata = rdata_file, save_as_png = FALSE
 #' )
-#' }
-generateCI2IFC <- function(stimuli, responses, baseimage, rdata, save_as_png=TRUE, filename='', targetpath="./cis", antiCI=FALSE, scaling='independent', constant=0.1) {
+generateCI2IFC <- function(stimuli, responses, baseimage, rdata, save_as_png=TRUE, filename='', targetpath, antiCI=FALSE, scaling='independent', constant=0.1) {
+
+  # targetpath is required, not defaulted: a default path writes to the user's
+  # filespace uninvited, which CRAN policy does not allow.
+  if (save_as_png && missing(targetpath)) {
+    stop(paste0('save_as_png is TRUE but no targetpath was given. Supply ',
+                'targetpath = <a directory> to say where the PNGs should go, ',
+                'or set save_as_png = FALSE to compute the classification ',
+                'image without writing it. Use tempdir() if you only want to ',
+                'try the function out.'))
+  }
 
   # For backwards compatibility
   return(generateCI(

--- a/R/generateNoiseImage.R
+++ b/R/generateNoiseImage.R
@@ -5,9 +5,12 @@
 #' @param p 3D patch matrix (generated using \code{generateNoisePattern()}).
 #' @return The noise pattern as pixel matrix.
 #' @examples
-#' #params <- rnorm(4092) # generates 4092 normally distributed random values
-#' #s <- generateNoisePattern(img_size=256)
-#' #noise <- generateNoiseImage(params, p)
+#' p <- generateNoisePattern(img_size = 32, nscales = 2)
+#'
+#' # one contrast weight per patch index
+#' params <- rnorm(max(p$patchIdx))
+#'
+#' noise <- generateNoiseImage(params, p)
 generateNoiseImage <- function(params, p) {
 
   # Normalise a pre-0.3.3 noise pattern before anything reads p$patchIdx. This

--- a/R/generateReferenceDistribution.R
+++ b/R/generateReferenceDistribution.R
@@ -42,7 +42,6 @@
 #' \code{response_seed} it was generated with), so a later call to
 #' \code{\link{computeInfoVal2IFC}} using the same file can reuse it instead of re-simulating.
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -61,13 +60,7 @@
 #' rdata_file <- list.files(stimulus_path, pattern = "\\.Rdata$", full.names = TRUE)[1]
 #'
 #' # iter is kept tiny here for a fast example; in practice use iter >= 10000.
-#' # Run from a temp working directory: this function re-generates stimuli via
-#' # generateStimuli2IFC() without forwarding a stimulus_path, so it always
-#' # creates a ./stimuli directory relative to the working directory.
-#' withr::with_dir(tempdir(), {
-#'   suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
-#' })
-#' }
+#' suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
 generateReferenceDistribution2IFC <- function(rdata, iter=10000, ncores=default_ncores(), response_seed=NULL, save_rdata=TRUE) {
 
   # load() assigns straight into this function's frame, so any object stored in

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -16,7 +16,7 @@
 #' @param base_face_files List containing base face file names used as base images for stimuli. Accepts JPEG and PNG images.
 #' @param n_trials Number specifying how many trials the task will have (function will generate two images for each trial per base image: original and inverted/negative noise).
 #' @param img_size Number specifying the number of pixels that the stimulus image will span horizontally and vertically (will be square, so only one integer needed).
-#' @param stimulus_path Path to save stimuli and .Rdata file to.
+#' @param stimulus_path String specifying the directory to save the stimuli and the .Rdata file to. Required unless both \code{save_as_png} and \code{save_rdata} are FALSE; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param label Label to prepend to each file for your convenience.
 #' @param use_same_parameters Boolean specifying whether for each base image the same set of parameters is used (TRUE) or a unique set is created for each base image (FALSE).
 #' @param seed Integer seeding the random number generator (for reproducibility).
@@ -30,7 +30,6 @@
 #' @param save_rdata Boolean specifying whether .RData file with stimulus parameters will be saved (default: TRUE). Note: you always need to save the .RData file so that you can retrieve the stimulus parameters to compute classification images. This function argument exists primarily for internal rcicr use.
 #' @return Nothing, everything is saved to files, unless return_as_dataframe is set to TRUE.
 #' @examples
-#' \donttest{
 #' # a synthetic square grayscale image stands in for a real base face photo
 #' base_face <- tempfile(fileext = ".png")
 #' png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -44,12 +43,33 @@
 #'   ncores = 1,
 #'   nscales = 1
 #' )
-#' }
-generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, stimulus_path='./stimuli', label='rcic', use_same_parameters=TRUE, seed=1, maximize_baseimage_contrast=TRUE, noise_type='sinusoid', nscales=5, sigma=25, ncores=default_ncores(), return_as_dataframe=FALSE, save_as_png=TRUE, save_rdata=TRUE) {
+generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, stimulus_path, label='rcic', use_same_parameters=TRUE, seed=1, maximize_baseimage_contrast=TRUE, noise_type='sinusoid', nscales=5, sigma=25, ncores=default_ncores(), return_as_dataframe=FALSE, save_as_png=TRUE, save_rdata=TRUE) {
+
+  # stimulus_path is required, not defaulted: a default path writes to the
+  # user's filespace uninvited, which CRAN policy does not allow.
+  writes_to_disk <- save_as_png || save_rdata
+  if (writes_to_disk && missing(stimulus_path)) {
+    stop(paste0('No stimulus_path was given. Supply stimulus_path = <a ',
+                'directory> to say where the stimuli and the .Rdata file ',
+                'should go. Use tempdir() if you only want to try the ',
+                'function out.'))
+  }
 
   # Initialize #
   p <- generateNoisePattern(img_size, noise_type=noise_type, nscales=nscales, sigma=sigma)
-  dir.create(stimulus_path, recursive=T, showWarnings = F)
+
+  # Only create the directory when something is written to it.
+  # generateReferenceDistribution2IFC() calls this with both save flags FALSE
+  # and used to leave a stray directory behind. BACKLOG.md item 24.
+  if (writes_to_disk) {
+    dir.create(stimulus_path, recursive = TRUE, showWarnings = FALSE)
+  } else if (missing(stimulus_path)) {
+    # Bind it anyway. stimulus_path appears in the %dopar% body below, and
+    # foreach exports every free variable of that body to the workers -- which
+    # means get()ting it, and a missing argument aborts there even though the
+    # branch that uses it cannot run. Never read.
+    stimulus_path <- NA_character_
+  }
 
   # More depends on this call than the stimuli. generateReferenceDistribution2IFC()
   # re-generates stimuli through this function and then draws its simulated

--- a/R/plotZmap.R
+++ b/R/plotZmap.R
@@ -22,7 +22,7 @@
 #' @param threshold Integer specifying the threshold z-score (default: 3). Z-scores below the threshold will not be plotted on the z-map.
 #' @param mask Optional. A binary matrix with the same dimensions as zmap: cells that are 0 (or FALSE) are masked, cells that are 1 (or TRUE) are kept. Can also be the filename (as a string) of a black and white PNG image, in which case black (0) is masked and white (1) is kept. This is the same convention \code{generateCI()} uses for its own \code{mask} argument, so a mask can be used with both. Note that earlier versions of this documentation stated the opposite for the matrix form; the description here matches what the code does.
 #' @param decoration Optional boolean specifying whether the Z-map should be plotted with margins, text (sigma, threshold) and a scale (default: TRUE).
-#' @param targetpath String specifying path to save the Z-map PNG to.
+#' @param targetpath String specifying the directory to save the Z-map PNG to. Required: this function exists to write a file, and has no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
 #' @param filename Optional string to specify a file name for the Z-map PNG.
 #' @param size Integer specifying the width and height of the PNG image (default: 512).
 #' @param ... Additional arguments to be passed to raster::plot. Only applied when decoration is TRUE.
@@ -32,10 +32,18 @@
 #' zmap <- matrix(rnorm(64, sd = 5), 8, 8)
 #' plotZmap(zmap, sigma = 3, threshold = 3, decoration = FALSE,
 #'          targetpath = tempdir(), size = 200)
-plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, decoration = T, targetpath = 'zmaps', filename = 'zmap', size = 512, ...) {
+plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, decoration = TRUE, targetpath, filename = 'zmap', size = 512, ...) {
+
+  # targetpath is required, not defaulted: a default path writes to the user's
+  # filespace uninvited, which CRAN policy does not allow.
+  if (missing(targetpath)) {
+    stop(paste0('No targetpath was given. plotZmap() writes a PNG, so it needs a ',
+                'directory to write it to: supply targetpath = <a directory>. ',
+                'Use tempdir() if you only want to try the function out.'))
+  }
 
   # Create target directory
-  dir.create(targetpath, recursive = T, showWarnings = F)
+  dir.create(targetpath, recursive = TRUE, showWarnings = FALSE)
 
   # If a mask is specified, import and check it
   if (!(is.null(mask))) {
@@ -107,16 +115,20 @@ plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, deco
   # Plot
   png(filename = paste0(targetpath, '/', filename, '.png'), width = size, height = size)
 
+  # Close the device however this function exits, so a failure while plotting
+  # cannot leak it or leave a half-written PNG behind.
+  on.exit(dev.off())
+
   # With decoration
   if (decoration) {
     # Initial (dummy) plot; sets up plot with initial dimensions + scale, title, label
-    raster::plot(raster(zmap), axes = F, box = F, main = paste0('Z-map of ', filename),
+    raster::plot(raster(zmap), axes = FALSE, box = FALSE, main = paste0('Z-map of ', filename),
                  xlab = paste0('sigma = ', sigma, ', threshold = ', threshold),
                  col = viridis::viridis(100), ...)
     # Add bgimage (if specified) and superimpose Z-map on top of it
     if (!(identical(bgimage, ''))) {
       rasterImage(bgimage, 0, 0, 1, 1)
-      raster::plot(raster(zmap), add = T, ...)
+      raster::plot(raster(zmap), add = TRUE, ...)
     }
     # If no bgimage was specified, draw a boundary box around the Z-map
     if (identical(bgimage, '')) {
@@ -136,7 +148,13 @@ plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, deco
     # img_size, so small stimulus sets could not produce a z-map at all.
     # Rendered output at usual sizes is unchanged: par(mar=) still takes effect
     # before plot.window() either way.
-    par(mar = c(0, 0, 0, 0))
+    #
+    # par() returns the previous values of exactly the parameters being set, so
+    # restoring `oldpar` restores `mar` and nothing else. par(no.readonly=TRUE)
+    # is not usable here: it also captures derived parameters such as `pin`,
+    # which plot.window() below invalidates, and restoring them errors.
+    oldpar <- par(mar = c(0, 0, 0, 0))
+    on.exit(par(oldpar), add = TRUE, after = FALSE)
     plot.new()
     plot.window(xlim = c(0, 1), ylim = c(0, 1), xaxs = 'i', yaxs = 'i')
 
@@ -151,7 +169,7 @@ plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, deco
       rasterImage(bgimage, 0, 0, 1, 1)
     }
     # Add Z-map
-    raster::plot(raster(zmap), add = T, legend = F)
+    raster::plot(raster(zmap), add = TRUE, legend = FALSE)
   }
-  dev.off()
+  # The device is closed by the on.exit() handler registered after png().
 }

--- a/R/simulateNoiseIntensities.R
+++ b/R/simulateNoiseIntensities.R
@@ -8,14 +8,10 @@
 #' @param nrep Number of replications
 #' @param img_size Size of noise pattern in pixels (one value equal for width and height)
 #' @return Matrix with range of noise intensities for each replication
-#' @note This function currently always errors: it references undefined \code{data}/\code{by}
-#' variables when sizing its progress bar (apparently copy-pasted from \code{\link{batchGenerateCI}}),
-#' and it also ignores the \code{img_size} argument internally, always simulating at 512px. Not fixed
-#' here; the example below is not run.
 #' @examples
-#' \dontrun{
-#' simulateNoiseIntensities(nrep = 10, img_size = 512)
-#' }
+#' # nrep and img_size are kept small here so the example is fast; the defaults
+#' # (1000 replications at 512px) are what you want for a real estimate.
+#' simulateNoiseIntensities(nrep = 10, img_size = 64)
 simulateNoiseIntensities <- function(nrep=1000, img_size=512) {
 
   results <- matlab::zeros(nrep, 2)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -38,6 +38,30 @@ startBackend <- function(ncores) {
   cl
 }
 
+# Snapshot a function's arguments so they can be restored after load(), which
+# assigns straight into the calling frame and silently overwrites an argument
+# that shares a name with an object in the .Rdata file.
+#
+# Only arguments that are *required* and were not supplied are skipped. mget()
+# forces the promise, and for those it raises "argument is missing, with no
+# default" -- which happens whenever a wrapper forwards its own missing
+# argument, as batchGenerateCI() does with targetpath. Skipping them is also
+# correct: an argument with no value cannot be overwritten into a wrong one.
+#
+# Defaulted arguments that were not supplied must NOT be skipped, even though
+# missing() reports them missing too. Their default is the value the function
+# goes on to use, and it is exactly as vulnerable to being replaced by the
+# .Rdata file as one the caller passed explicitly.
+captureArgs <- function(env) {
+  fmls <- formals(sys.function(sys.parent()))
+  nms <- names(fmls)
+  required <- vapply(fmls, function(d) identical(d, quote(expr = )), logical(1))
+  absent <- vapply(nms,
+                   function(nm) eval(bquote(missing(.(as.name(nm)))), env),
+                   logical(1))
+  mget(nms[!(required & absent)], envir = env)
+}
+
 # CRAN Note avoidance
 
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,18 @@ generateStimuli2IFC(
 # 2. After running the task and collecting responses (1 = original chosen,
 #    -1 = inverted chosen), compute the classification image:
 generateCI(
-  stimuli   = 1:770,                # stimulus numbers, in presentation order
-  responses = my_responses,         # 1 / -1 vector, same order as `stimuli`
-  baseimage = "face",               # key used in base_face_files above
-  rdata     = "./stimuli/rcic_seed_1_time_....Rdata"
+  stimuli    = 1:770,               # stimulus numbers, in presentation order
+  responses  = my_responses,        # 1 / -1 vector, same order as `stimuli`
+  baseimage  = "face",              # key used in base_face_files above
+  rdata      = "./stimuli/rcic_seed_1_time_....Rdata",
+  targetpath = "./cis"              # where to write the CI PNG
 )
 ```
+
+Every function that writes files takes its destination explicitly: `stimulus_path`,
+`targetpath` and `zmaptargetpath` have no defaults, so nothing is ever written to a
+directory you did not name. Pass `save_as_png = FALSE` to compute a classification
+image without writing anything.
 
 ## Documentation
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,67 @@
 # CRAN comments
 
+## Response to your review of 1.2.1
+
+Thank you for the review. This is version 1.2.2, addressing each point.
+
+**"Please omit the redundant 'Functions to' at the start of your description."** Done.
+
+**References in the description field.** Added, in the requested form:
+
+> ... For the method see Dotsch and Todorov (2012) <doi:10.1177/1948550611430272>; for a
+> practical primer see Brinkman, Todorov and Dotsch (2017)
+> <doi:10.1080/10463283.2017.1381469>.
+
+**"Please write TRUE and FALSE instead of T and F."** Done — all 11 occurrences in `R/`
+are gone, including the four that were public argument defaults and therefore visible in
+`man/generateCI.Rd` and `man/plotZmap.Rd`, the two files you quoted. The values are
+unchanged.
+
+**"Some code lines in examples are commented out."** `generateNoiseImage()`'s example was
+three commented-out lines and is now working code. On `generateNoisePattern.Rd` we could
+not find a commented example — its `\examples` section contains the single live call
+`generateNoisePattern(256)`, in the 1.2.1 tarball as well as in this one. If we have
+misread which line you meant, please say and we will fix it.
+
+**"`\dontrun{}` should only be used if the example really cannot be executed... Please
+unwrap the examples if they are executable in < 5 sec."** The one `\dontrun{}`
+(`simulateNoiseIntensities`) is gone, and so are all eight `\donttest{}` wrappers. **Every
+example in the package now runs**, the complete set in about nine seconds. The wrappers
+were inherited from a time when the examples ran at full stimulus size; they already ran at
+32 pixels over six trials and were simply never revisited.
+
+**"Please ensure that your functions do not write by default... Please omit any default
+path in writing functions."** Done, and this is the largest change in the release. Every
+argument naming a directory to write to — `stimulus_path`, `targetpath`, `zmaptargetpath` —
+has lost its default. They were `./stimuli`, `./cis` and `./zmaps`. A call that would
+previously have written to one of those now stops with an error naming the argument to
+supply, so no user gets files somewhere new without noticing. This is a breaking change and
+`NEWS.md` opens with it and the one-line migration.
+
+Fixing it also removed a related violation you did not see:
+`generateReferenceDistribution2IFC()` re-derives its noise basis in memory and wrote nothing,
+but created an empty `./stimuli` on every call regardless.
+
+All examples, tests and vignettes write only to `tempdir()`.
+
+**"Please make sure that you do not change the user's options, par or working directory...
+-> R/plotZmap.R."** Fixed. `plotZmap()` now captures the previous value at the point of
+change and restores it through an immediate `on.exit()`, and closes its PNG device the same
+way so a failure mid-plot cannot leak it.
+
+One deviation from the pattern in your mail, deliberately: we restore with
+`oldpar <- par(mar = ...)` / `on.exit(par(oldpar))` rather than
+`par(no.readonly = TRUE)`. `par()` returns the previous values of exactly the parameters
+being set, which is what needs restoring here; `no.readonly = TRUE` additionally captures
+derived parameters such as `pin`, which the subsequent `plot.window()` call invalidates, so
+restoring them raises `invalid value specified for graphical parameter "pin"`. This is the
+second form shown in your mail (`oldpar <- par(mfrow = c(1,2)) ... par(oldpar)`).
+
+**"inst/doc/reverse-correlation-walkthrough.R, please reset the par()."** Done. The
+vignette now records `old_par <- par(no.readonly = TRUE)` in its setup chunk and restores
+it in a final chunk, and its plotting helper restores `par()` directly instead of through
+`on.exit()`.
+
 ## Submission type
 
 This is a **resubmission of an archived package**, not a routine update.
@@ -19,10 +81,10 @@ found by a systematic source review, adds a test suite (previously there was non
 continuous integration, and removes 13 unused dependencies.
 
 **On the version number.** The archived CRAN version is 0.3.4.1 and this submission is
-1.2.1. Nothing is missing: 1.0.1, 1.1.0 and 1.2.0 exist only as GitHub releases, made while
-the package was off CRAN, and none of them was published anywhere a user could install it
-from with `install.packages()`. `NEWS.md` carries their entries, so the record between
-0.3.4.1 and 1.2.1 is complete.
+1.2.2. Nothing is missing: 1.0.1, 1.1.0, 1.2.0 and 1.2.1 exist only as GitHub releases,
+made while the package was off CRAN, and none of them was published anywhere a user could
+install it from with `install.packages()`. `NEWS.md` carries their entries, so the record
+between 0.3.4.1 and 1.2.2 is complete.
 
 ## Test environments
 
@@ -30,13 +92,11 @@ from with `install.packages()`. `NEWS.md` carries their entries, so the record b
   `_R_CHECK_CRAN_INCOMING_=TRUE` and `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`
 * GitHub Actions: ubuntu-latest on R release and R devel, macos-latest on R release,
   windows-latest on R release — all green
-* win-builder, R-devel — R Under development (unstable) (2026-07-26 r90304 ucrt): 1 NOTE
-  (the incoming feasibility note below)
-* win-builder, R-release — R 4.6.1 (2026-06-24 ucrt): 1 NOTE (the same one)
-* R-hub, all on R-devel — Linux (x86_64-pc-linux-gnu, r90185), Windows
-  (x86_64-w64-mingw32, r90310 ucrt), macOS (x86_64-apple-darwin20, r90190): **Status: OK**
-  on all three, 0 errors, 0 warnings, 0 notes. R-hub does not run the CRAN incoming
-  feasibility check, which is why the note above does not appear there.
+* win-builder, R-devel — <!-- TODO: fill in from the 1.2.2 run -->
+* win-builder, R-release — <!-- TODO: fill in from the 1.2.2 run -->
+* R-hub, all on R-devel — Linux, Windows, macOS:
+  <!-- TODO: fill in from the 1.2.2 run -->. R-hub does not run the CRAN incoming
+  feasibility check, which is why the note below does not appear there.
 
 All of the above were run against the tarball being submitted.
 
@@ -101,9 +161,15 @@ on it.
 
 ## Notes for the reviewer
 
-* Examples that generate stimuli are wrapped in `\donttest{}` and run at a much reduced
-  image size and trial count. A realistic run for a researcher is 512x512 pixels over
-  several hundred trials, which is far too slow for a check.
+* No example is wrapped in `\dontrun{}` or `\donttest{}` any more; all of them run. The
+  ones that generate stimuli do so at 32x32 pixels over six trials, against a synthetic
+  base image built in the example itself, so the whole set takes about nine seconds. A
+  realistic run for a researcher is 512x512 pixels over several hundred trials, which is
+  why the reduced parameters are there.
+* `simulateNoiseIntensities()`'s example draws a boxplot, so running the examples
+  non-interactively produces an `Rplots.pdf` in the check directory. That is R's default
+  device rather than anything the package writes; no function in the package opens a file
+  the caller has not named.
 * The package uses `parallel`/`doParallel`. All defaults respect
   `_R_CHECK_LIMIT_CORES_`: `default_ncores()` returns 2 when that variable is set and
   `parallel::detectCores() - 1` otherwise, so no example, test or vignette uses more than

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -96,9 +96,10 @@ between 0.3.4.1 and 1.2.2 is complete.
   (the incoming feasibility note below). Install 39s, check 408s; examples 24s, tests 80s.
 * win-builder, R-release — R 4.6.1 (2026-06-24 ucrt): 1 NOTE (the same one). Install 37s,
   check 391s; examples 24s, tests 75s.
-* R-hub, all on R-devel — Linux, Windows, macOS:
-  <!-- TODO: fill in from the 1.2.2 run -->. R-hub does not run the CRAN incoming
-  feasibility check, which is why the note below does not appear there.
+* R-hub, all on R-devel — Linux (x86_64-pc-linux-gnu, r90185), Windows
+  (x86_64-w64-mingw32, r90366 ucrt), macOS (x86_64-apple-darwin20, r90190):
+  **Status: OK** on all three, 0 errors, 0 warnings, 0 notes. R-hub does not run the CRAN
+  incoming feasibility check, which is why the note below does not appear there.
 
 All of the above were run against the tarball being submitted.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -92,8 +92,10 @@ between 0.3.4.1 and 1.2.2 is complete.
   `_R_CHECK_CRAN_INCOMING_=TRUE` and `_R_CHECK_CRAN_INCOMING_REMOTE_=TRUE`
 * GitHub Actions: ubuntu-latest on R release and R devel, macos-latest on R release,
   windows-latest on R release — all green
-* win-builder, R-devel — <!-- TODO: fill in from the 1.2.2 run -->
-* win-builder, R-release — <!-- TODO: fill in from the 1.2.2 run -->
+* win-builder, R-devel — R Under development (unstable) (2026-08-06 r90366 ucrt): 1 NOTE
+  (the incoming feasibility note below). Install 39s, check 408s; examples 24s, tests 80s.
+* win-builder, R-release — R 4.6.1 (2026-06-24 ucrt): 1 NOTE (the same one). Install 37s,
+  check 391s; examples 24s, tests 75s.
 * R-hub, all on R-devel — Linux, Windows, macOS:
   <!-- TODO: fill in from the 1.2.2 run -->. R-hub does not run the CRAN incoming
   feasibility check, which is why the note below does not appear there.
@@ -125,6 +127,8 @@ Found the following (possibly) invalid URLs:
 This URL is valid and resolves normally in a browser. `medium.com` returns 403 to
 requests originating from datacenter networks — this is a block by network origin rather
 than by user agent, so it reproduces from CI machines and not from an ordinary desktop.
+Consistent with that, it appears on our build machine but on **neither** win-builder run
+for this version, nor in CRAN's own incoming pretest of 1.2.1.
 
 It points to the original tutorial walkthrough of the method. That walkthrough has been
 ported into this release as the `reverse-correlation-walkthrough` vignette, so it is no
@@ -137,12 +141,19 @@ win-builder additionally reports, under the same note:
 
 ```
 Possibly misspelled words in DESCRIPTION:
-  psychophysical (10:51)
+  Brinkman (13:5)
+  Dotsch (11:68, 13:27)
+  Todorov (12:5, 13:15)
+  psychophysical (10:33)
 ```
 
-`psychophysical` is spelled correctly. It is the standard adjective for psychophysics, the
-field this package's method comes from, and it is used in the sense of "psychophysical
-task" — the 2-image forced-choice procedure the package generates stimuli for.
+All four are correct. `Brinkman`, `Dotsch` and `Todorov` are the surnames of the authors of
+the two references you asked us to add — `Dotsch` is also the maintainer's own name. They
+appear only in the citations.
+
+`psychophysical` is the standard adjective for psychophysics, the field this package's
+method comes from, and is used in the sense of "psychophysical task" — the 2-image
+forced-choice procedure the package generates stimuli for.
 
 ### NOTE 2 — future file timestamps
 

--- a/man/autoscale.Rd
+++ b/man/autoscale.Rd
@@ -4,14 +4,14 @@
 \alias{autoscale}
 \title{Determines optimal scaling constant for a list of CIs}
 \usage{
-autoscale(cis, save_as_pngs = TRUE, targetpath = "./cis")
+autoscale(cis, save_as_pngs = TRUE, targetpath)
 }
 \arguments{
 \item{cis}{List of cis, each of which are a list containing the pixel matrices of at least the noise pattern (\code{$ci}) and if the noise patterns need to be written to PNGs, also the base image (\code{$base}).}
 
 \item{save_as_pngs}{Boolean, when set to true, the autoscaled noise patterns will be combined with their respective base images and saved as PNGs (using the key of the list as name).}
 
-\item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
+\item{targetpath}{String specifying the directory to save PNGs to. Required when \code{save_as_pngs = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 }
 \value{
 The input \code{cis} list, with the \code{$scaled} pixel matrix of each element

--- a/man/batchGenerateCI.Rd
+++ b/man/batchGenerateCI.Rd
@@ -12,7 +12,7 @@ batchGenerateCI(
   baseimage,
   rdata,
   save_as_png = TRUE,
-  targetpath = "./cis",
+  targetpath,
   label = "",
   antiCI = FALSE,
   scaling = "autoscale",
@@ -34,7 +34,7 @@ batchGenerateCI(
 
 \item{save_as_png}{Boolean stating whether to additionally save the CI as PNG image.}
 
-\item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
+\item{targetpath}{String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{label}{Optional string to insert in file names of PNGs to make them easier to identify.}
 
@@ -54,7 +54,6 @@ Generate classification image for any reverse correlation task that displays ind
 This function saves the classification images by participant or condition as PNG to a folder and returns the CIs.
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -83,5 +82,4 @@ cis <- suppressWarnings(batchGenerateCI(
   data = data, by = "participant", stimuli = "stimulus", responses = "response",
   baseimage = "face", rdata = rdata_file, save_as_png = FALSE
 ))
-}
 }

--- a/man/batchGenerateCI2IFC.Rd
+++ b/man/batchGenerateCI2IFC.Rd
@@ -12,7 +12,7 @@ batchGenerateCI2IFC(
   baseimage,
   rdata,
   save_as_png = TRUE,
-  targetpath = "./cis",
+  targetpath,
   antiCI = FALSE,
   scaling = "autoscale",
   constant = 0.1,
@@ -34,7 +34,7 @@ batchGenerateCI2IFC(
 
 \item{save_as_png}{Boolean stating whether to additionally save the CI as PNG image.}
 
-\item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
+\item{targetpath}{String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{antiCI}{Optional boolean specifying whether antiCI instead of CI should be computed.}
 
@@ -54,7 +54,6 @@ Generate classification image for 2 images forced choice reverse correlation tas
 This function saves the classification images by participant or condition as PNG to a folder and returns the CIs.
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -83,5 +82,4 @@ cis <- suppressWarnings(batchGenerateCI2IFC(
   data = data, by = "participant", stimuli = "stimulus", responses = "response",
   baseimage = "face", rdata = rdata_file, save_as_png = FALSE
 ))
-}
 }

--- a/man/computeCumulativeCICorrelation.Rd
+++ b/man/computeCumulativeCICorrelation.Rd
@@ -36,7 +36,6 @@ Computes cumulative trial CIs correlations with final/target CI.
 Use for instance for plotting curves of trial-final/target CI correlations to estimate how many trials are necessary in your task
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -58,5 +57,4 @@ responses <- sample(c(1, -1), 6, replace = TRUE)
 correlations <- suppressWarnings(computeCumulativeCICorrelation(
   stimuli = 1:6, responses = responses, baseimage = "face", rdata = rdata_file
 ))
-}
 }

--- a/man/computeInfoVal2IFC.Rd
+++ b/man/computeInfoVal2IFC.Rd
@@ -53,7 +53,6 @@ not been supplied by the rcicr package.
 For more information see Brinkman, Goffin, Aarts, van Haren, & Dotsch (in prep).
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -73,13 +72,7 @@ rdata_file <- list.files(stimulus_path, pattern = "\\\\.Rdata$", full.names = TR
 
 # compute (and cache in rdata_file) a reference distribution; iter is kept
 # tiny here for a fast example, in practice use iter >= 10000.
-# Run from a temp working directory: generateReferenceDistribution2IFC()
-# re-generates stimuli via generateStimuli2IFC() without forwarding a
-# stimulus_path, so it always creates a ./stimuli directory relative to the
-# working directory.
-withr::with_dir(tempdir(), {
-  suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
-})
+suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
 
 responses <- sample(c(1, -1), 6, replace = TRUE)
 target_ci <- generateCI(
@@ -88,5 +81,4 @@ target_ci <- generateCI(
 )
 
 computeInfoVal2IFC(target_ci = target_ci, rdata = rdata_file)
-}
 }

--- a/man/generateCI.Rd
+++ b/man/generateCI.Rd
@@ -13,18 +13,18 @@ generateCI(
   save_individual_cis = FALSE,
   save_as_png = TRUE,
   filename = "",
-  targetpath = "./cis",
+  targetpath,
   antiCI = FALSE,
   scaling = "independent",
   scaling_constant = 0.1,
   individual_scaling = "independent",
   individual_scaling_constant = 0.1,
-  zmap = F,
+  zmap = FALSE,
   zmapmethod = "quick",
-  zmapdecoration = T,
+  zmapdecoration = TRUE,
   sigma = 3,
   threshold = 3,
-  zmaptargetpath = "./zmaps",
+  zmaptargetpath,
   n_cores = default_ncores(),
   mask = NA
 )
@@ -46,7 +46,7 @@ generateCI(
 
 \item{filename}{Optional string to specify a file name for the PNG image.}
 
-\item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
+\item{targetpath}{String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE} or \code{save_individual_cis = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{antiCI}{Optional boolean specifying whether antiCI instead of CI should be computed.}
 
@@ -68,7 +68,7 @@ generateCI(
 
 \item{threshold}{Integer specifying the threshold z-score (default: 3). Z-scores below the threshold will not be plotted on the z-map.}
 
-\item{zmaptargetpath}{Optional string specifying path to save z-map PNGs to (default: ./zmaps).}
+\item{zmaptargetpath}{String specifying the directory to save z-map PNGs to. Required when \code{zmap = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{n_cores}{Optional integer specifying the number of CPU cores to use to generate the z-map (default: \code{detectCores()-1}; 2 under \code{R CMD check}, per CRAN policy).}
 
@@ -103,7 +103,6 @@ When creating multiple classification images a good strategy is to find the lowe
 classification images. This can be automatized using the \code{autoscale} function.
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -126,5 +125,4 @@ ci <- generateCI(
   stimuli = 1:6, responses = responses, baseimage = "face",
   rdata = rdata_file, save_as_png = FALSE
 )
-}
 }

--- a/man/generateCI2IFC.Rd
+++ b/man/generateCI2IFC.Rd
@@ -11,7 +11,7 @@ generateCI2IFC(
   rdata,
   save_as_png = TRUE,
   filename = "",
-  targetpath = "./cis",
+  targetpath,
   antiCI = FALSE,
   scaling = "independent",
   constant = 0.1
@@ -30,7 +30,7 @@ generateCI2IFC(
 
 \item{filename}{Optional string to specify a file name for the PNG image.}
 
-\item{targetpath}{Optional string specifying path to save PNGs to (default: ./cis).}
+\item{targetpath}{String specifying the directory to save PNGs to. Required when \code{save_as_png = TRUE}; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{antiCI}{Optional boolean specifying whether antiCI instead of CI should be computed.}
 
@@ -67,7 +67,6 @@ When creating multiple classification images a good strategy is to find the lowe
 classification images. This can be automatized using the \code{autoscale} function.
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -90,5 +89,4 @@ ci <- generateCI2IFC(
   stimuli = 1:6, responses = responses, baseimage = "face",
   rdata = rdata_file, save_as_png = FALSE
 )
-}
 }

--- a/man/generateNoiseImage.Rd
+++ b/man/generateNoiseImage.Rd
@@ -18,7 +18,10 @@ The noise pattern as pixel matrix.
 Generate single noise image based on parameter vector
 }
 \examples{
-#params <- rnorm(4092) # generates 4092 normally distributed random values
-#s <- generateNoisePattern(img_size=256)
-#noise <- generateNoiseImage(params, p)
+p <- generateNoisePattern(img_size = 32, nscales = 2)
+
+# one contrast weight per patch index
+params <- rnorm(max(p$patchIdx))
+
+noise <- generateNoiseImage(params, p)
 }

--- a/man/generateReferenceDistribution2IFC.Rd
+++ b/man/generateReferenceDistribution2IFC.Rd
@@ -63,7 +63,6 @@ noise basis the null is built on, are unaffected.
 }
 
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -82,11 +81,5 @@ generateStimuli2IFC(
 rdata_file <- list.files(stimulus_path, pattern = "\\\\.Rdata$", full.names = TRUE)[1]
 
 # iter is kept tiny here for a fast example; in practice use iter >= 10000.
-# Run from a temp working directory: this function re-generates stimuli via
-# generateStimuli2IFC() without forwarding a stimulus_path, so it always
-# creates a ./stimuli directory relative to the working directory.
-withr::with_dir(tempdir(), {
-  suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
-})
-}
+suppressWarnings(generateReferenceDistribution2IFC(rdata_file, iter = 3, ncores = 1))
 }

--- a/man/generateStimuli2IFC.Rd
+++ b/man/generateStimuli2IFC.Rd
@@ -8,7 +8,7 @@ generateStimuli2IFC(
   base_face_files,
   n_trials = 770,
   img_size = 512,
-  stimulus_path = "./stimuli",
+  stimulus_path,
   label = "rcic",
   use_same_parameters = TRUE,
   seed = 1,
@@ -29,7 +29,7 @@ generateStimuli2IFC(
 
 \item{img_size}{Number specifying the number of pixels that the stimulus image will span horizontally and vertically (will be square, so only one integer needed).}
 
-\item{stimulus_path}{Path to save stimuli and .Rdata file to.}
+\item{stimulus_path}{String specifying the directory to save the stimuli and the .Rdata file to. Required unless both \code{save_as_png} and \code{save_rdata} are FALSE; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{label}{Label to prepend to each file for your convenience.}
 
@@ -64,7 +64,6 @@ Will save the stimuli as PNGs to a folder, including .Rdata file needed for anal
 after data collection. This .Rdata file contains the parameters that were used to generate each stimulus.
 }
 \examples{
-\donttest{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")
 png::writePNG(matrix(runif(32 * 32), 32, 32), base_face)
@@ -78,5 +77,4 @@ generateStimuli2IFC(
   ncores = 1,
   nscales = 1
 )
-}
 }

--- a/man/plotZmap.Rd
+++ b/man/plotZmap.Rd
@@ -10,8 +10,8 @@ plotZmap(
   sigma,
   threshold = 3,
   mask = NULL,
-  decoration = T,
-  targetpath = "zmaps",
+  decoration = TRUE,
+  targetpath,
   filename = "zmap",
   size = 512,
   ...
@@ -30,7 +30,7 @@ plotZmap(
 
 \item{decoration}{Optional boolean specifying whether the Z-map should be plotted with margins, text (sigma, threshold) and a scale (default: TRUE).}
 
-\item{targetpath}{String specifying path to save the Z-map PNG to.}
+\item{targetpath}{String specifying the directory to save the Z-map PNG to. Required: this function exists to write a file, and has no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.}
 
 \item{filename}{Optional string to specify a file name for the Z-map PNG.}
 

--- a/man/simulateNoiseIntensities.Rd
+++ b/man/simulateNoiseIntensities.Rd
@@ -17,14 +17,8 @@ Matrix with range of noise intensities for each replication
 \description{
 Simulate pixel intensity range for noise
 }
-\note{
-This function currently always errors: it references undefined \code{data}/\code{by}
-variables when sizing its progress bar (apparently copy-pasted from \code{\link{batchGenerateCI}}),
-and it also ignores the \code{img_size} argument internally, always simulating at 512px. Not fixed
-here; the example below is not run.
-}
 \examples{
-\dontrun{
-simulateNoiseIntensities(nrep = 10, img_size = 512)
-}
+# nrep and img_size are kept small here so the example is fast; the defaults
+# (1000 replications at 512px) are what you want for a real estimate.
+simulateNoiseIntensities(nrep = 10, img_size = 64)
 }

--- a/tests/testthat/test-generateCI-paths.R
+++ b/tests/testthat/test-generateCI-paths.R
@@ -87,7 +87,8 @@ test_that("zmapmethod = 'quick' returns a thresholded z-map", {
   res <- generateCI(
     stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
     rdata = rdata, save_as_png = FALSE, zmap = TRUE, zmapmethod = "quick",
-    threshold = 1, zmapdecoration = FALSE, n_cores = 1
+    threshold = 1, zmapdecoration = FALSE, n_cores = 1,
+    zmaptargetpath = file.path(tmp, "zmaps")
   )
 
   expect_true("zmap" %in% names(res))
@@ -107,7 +108,8 @@ test_that("zmapmethod = 't.test' returns a z-map of per-pixel test statistics", 
   res <- generateCI(
     stimuli = 1:12, responses = rep(c(1, -1), 6), baseimage = "base",
     rdata = rdata, save_as_png = FALSE, zmap = TRUE, zmapmethod = "t.test",
-    zmapdecoration = FALSE, n_cores = 1
+    zmapdecoration = FALSE, n_cores = 1,
+    zmaptargetpath = file.path(tmp, "zmaps")
   )
 
   expect_equal(dim(res$zmap), c(32, 32))

--- a/tests/testthat/test-required-paths.R
+++ b/tests/testthat/test-required-paths.R
@@ -1,0 +1,263 @@
+# Every function that writes files takes its destination as a required
+# argument. The defaults these replace ('./stimuli', './cis', './zmaps',
+# 'zmaps') wrote into whatever the working directory happened to be, which CRAN
+# policy does not allow.
+#
+# Each test runs from a temporary working directory, so a guard that failed to
+# fire would create a real directory here rather than in the checkout.
+
+test_that("generateStimuli2IFC requires stimulus_path when it writes", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  withr::local_dir(dir)
+  png_path <- file.path(dir, "base.png")
+  make_square_png(png_path)
+
+  expect_error(
+    generateStimuli2IFC(base_face_files = list(base = png_path), n_trials = 2,
+                        img_size = 32, seed = 1, ncores = 1, nscales = 1),
+    "No stimulus_path"
+  )
+})
+
+test_that("generateStimuli2IFC needs no path when it writes nothing", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  withr::local_dir(dir)
+  png_path <- file.path(dir, "base.png")
+  make_square_png(png_path)
+
+  noise <- suppressWarnings(
+    generateStimuli2IFC(base_face_files = list(base = png_path), n_trials = 2,
+                        img_size = 32, seed = 1, ncores = 1, nscales = 1,
+                        return_as_dataframe = TRUE, save_as_png = FALSE,
+                        save_rdata = FALSE)
+  )
+
+  expect_equal(ncol(noise), 2) # one column of noise per trial
+  # BACKLOG.md item 24: this path used to create ./stimuli anyway.
+  expect_false(dir.exists(file.path(dir, "stimuli")))
+})
+
+test_that("generateReferenceDistribution2IFC leaves no stray stimuli directory", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  run_dir <- withr::local_tempdir()
+  withr::local_dir(run_dir)
+
+  suppressWarnings(
+    generateReferenceDistribution2IFC(rdata, iter = 3, ncores = 1)
+  )
+
+  # It re-generates the stimuli in memory only, so it must write nothing to the
+  # working directory. BACKLOG.md item 24.
+  expect_equal(list.files(run_dir), character(0))
+})
+
+test_that("generateCI requires targetpath when it saves a PNG", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  withr::local_dir(withr::local_tempdir())
+
+  expect_error(
+    generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+               baseimage = "base", rdata = rdata),
+    "no targetpath"
+  )
+
+  expect_error(
+    generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+               baseimage = "base", rdata = rdata,
+               save_as_png = FALSE, save_individual_cis = TRUE,
+               participants = rep(c("p1", "p2"), each = 3)),
+    "no targetpath"
+  )
+})
+
+test_that("generateCI requires zmaptargetpath when it draws a z-map", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  withr::local_dir(withr::local_tempdir())
+
+  expect_error(
+    generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+               baseimage = "base", rdata = rdata, save_as_png = FALSE,
+               zmap = TRUE, n_cores = 1),
+    "no zmaptargetpath"
+  )
+})
+
+test_that("generateCI computes without a path when it writes nothing", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  run_dir <- withr::local_tempdir()
+  withr::local_dir(run_dir)
+
+  ci <- generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+                   baseimage = "base", rdata = rdata, save_as_png = FALSE)
+
+  expect_equal(dim(ci$ci), c(32, 32))
+  expect_equal(list.files(run_dir), character(0))
+})
+
+test_that("generateCI2IFC requires targetpath when it saves a PNG", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  withr::local_dir(withr::local_tempdir())
+
+  expect_error(
+    generateCI2IFC(stimuli = 1:6, responses = rep(c(1, -1), 3),
+                   baseimage = "base", rdata = rdata),
+    "no targetpath"
+  )
+})
+
+test_that("the batch functions require targetpath when they save PNGs", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  withr::local_dir(withr::local_tempdir())
+
+  df <- data.frame(pid = rep(c("p1", "p2"), each = 3), stim = 1:6,
+                   resp = rep(c(1, -1), 3), stringsAsFactors = FALSE)
+
+  # The error must name the function the user called, not one it delegates to.
+  expect_error(
+    batchGenerateCI(data = df, by = "pid", stimuli = "stim",
+                    responses = "resp", baseimage = "base", rdata = rdata),
+    "no targetpath"
+  )
+  expect_error(
+    batchGenerateCI2IFC(data = df, by = "pid", stimuli = "stim",
+                        responses = "resp", baseimage = "base", rdata = rdata),
+    "no targetpath"
+  )
+})
+
+test_that("the batch functions run without a path when they write nothing", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+  run_dir <- withr::local_tempdir()
+  withr::local_dir(run_dir)
+
+  df <- data.frame(pid = rep(c("p1", "p2"), each = 3), stim = 1:6,
+                   resp = rep(c(1, -1), 3), stringsAsFactors = FALSE)
+
+  # scaling defaults to 'autoscale', so this also exercises autoscale()'s own
+  # guard through the pass-through.
+  cis <- suppressWarnings(
+    batchGenerateCI(data = df, by = "pid", stimuli = "stim",
+                    responses = "resp", baseimage = "base", rdata = rdata,
+                    save_as_png = FALSE)
+  )
+
+  expect_length(cis, 2)
+  expect_equal(list.files(run_dir), character(0))
+})
+
+test_that("autoscale requires targetpath when it saves PNGs", {
+  skip_if_not_installed("withr")
+  withr::local_dir(withr::local_tempdir())
+
+  cis <- list(
+    a = list(ci = matrix(runif(64, -0.2, 0.2), 8, 8), base = matrix(0.5, 8, 8)),
+    b = list(ci = matrix(runif(64, -0.3, 0.3), 8, 8), base = matrix(0.5, 8, 8))
+  )
+
+  expect_error(autoscale(cis), "no targetpath")
+
+  # Without save_as_pngs there is nothing to write, so no path is needed.
+  # autoscale() reports its constant on stdout, hence capture.output().
+  scaled <- NULL
+  capture.output(scaled <- autoscale(cis, save_as_pngs = FALSE))
+  expect_named(scaled, c("a", "b"))
+})
+
+# Backwards compatibility ---------------------------------------------------
+#
+# Every .Rdata file this package has ever written records the stimulus_path it
+# was generated into -- typically the old default, './stimuli', relative to a
+# working directory that no longer exists. Removing the path defaults must not
+# make those files unreadable, and the recorded path must never be used as a
+# destination: load() assigns straight into the reading function's frame.
+
+test_that("an .Rdata file recording a stale stimulus_path still computes a CI", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  # What an old file looks like: generated into './stimuli' on someone else's
+  # machine, years ago.
+  mutate_rdata(rdata, stimulus_path = "./stimuli")
+
+  run_dir <- withr::local_tempdir()
+  withr::local_dir(run_dir)
+
+  ci <- generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3),
+                   baseimage = "base", rdata = rdata, save_as_png = FALSE)
+
+  expect_equal(dim(ci$ci), c(32, 32))
+  expect_equal(list.files(run_dir), character(0))
+})
+
+test_that("a path stored in the .Rdata never overrides the one passed in", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  decoy <- withr::local_tempdir()
+  wanted <- file.path(withr::local_tempdir(), "cis")
+  wanted_zmaps <- file.path(withr::local_tempdir(), "zmaps")
+
+  # No file this package writes contains these names, but load() would let one
+  # replace the caller's argument if it did -- the hazard that made every z-map
+  # since 1.1.0 use the wrong sigma. captureArgs() is what prevents it.
+  mutate_rdata(rdata, stimulus_path = decoy, targetpath = decoy,
+               zmaptargetpath = decoy)
+
+  generateCI(stimuli = 1:6, responses = rep(c(1, -1), 3), baseimage = "base",
+             rdata = rdata, targetpath = wanted, zmap = TRUE,
+             zmaptargetpath = wanted_zmaps, zmapdecoration = FALSE, n_cores = 1)
+
+  expect_length(list.files(wanted, pattern = "\\.png$"), 1)
+  expect_length(list.files(wanted_zmaps, pattern = "\\.png$"), 1)
+  expect_equal(list.files(decoy), character(0))
+})
+
+test_that("generateReferenceDistribution2IFC ignores the recorded stimulus_path", {
+  skip_if_not_installed("withr")
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  decoy <- withr::local_tempdir()
+  mutate_rdata(rdata, stimulus_path = decoy)
+
+  run_dir <- withr::local_tempdir()
+  withr::local_dir(run_dir)
+
+  suppressWarnings(
+    generateReferenceDistribution2IFC(rdata, iter = 3, ncores = 1)
+  )
+
+  expect_equal(list.files(decoy), character(0))
+  expect_equal(list.files(run_dir), character(0))
+})
+
+test_that("plotZmap requires targetpath", {
+  skip_if_not_installed("withr")
+  withr::local_dir(withr::local_tempdir())
+
+  zmap <- withr::with_seed(1, matrix(rnorm(64, sd = 5), 8, 8))
+
+  expect_error(
+    plotZmap(zmap, sigma = 3, threshold = 3, decoration = FALSE, size = 200),
+    "No targetpath"
+  )
+})

--- a/vignettes/reverse-correlation-walkthrough.Rmd
+++ b/vignettes/reverse-correlation-walkthrough.Rmd
@@ -32,6 +32,10 @@ instruction pointed at a branch that no longer exists.
 
 ```{r setup}
 library(rcicr)
+
+# Graphical parameters are changed below to draw the images without margins;
+# this records the originals so the last chunk can put them back.
+old_par <- par(no.readonly = TRUE)
 ```
 
 One small helper, used throughout to display an image matrix:
@@ -45,11 +49,11 @@ One small helper, used throughout to display an image matrix:
 # which is what you want when only the structure matters.
 show <- function(m, title, zlim = range(m, na.rm = TRUE)) {
   op <- par(mar = c(0, 0, 1.4, 0))
-  on.exit(par(op))
   # image() takes [x, y] with y increasing upwards, so a matrix indexed
   # [row, col] has to be transposed and flipped to display the right way up.
   image(t(m[nrow(m):1, ]), col = gray.colors(256), axes = FALSE, asp = 1,
         main = title, zlim = zlim, useRaster = TRUE)
+  par(op)
 }
 ```
 
@@ -413,3 +417,7 @@ citation("rcicr")
 
 If you use the technique, cite the method papers as well as the software — see the
 package's `CITATION` file and the README for the relevant references.
+
+```{r reset-par, include = FALSE}
+par(old_par)
+```


### PR DESCRIPTION
CRAN reviewed 1.2.1 and asked for seven changes. This addresses each of them and nothing else — item 34 and the rest of the backlog stay where they are, per the standing rule that a CRAN request is answered by a version addressing exactly what was asked.

`cran-comments.md` opens with a point-by-point response to paste into the reply.

## The one with teeth: no default write paths

`stimulus_path`, `targetpath` and `zmaptargetpath` lose their defaults (`./stimuli`, `./cis`, `./zmaps`) and are required whenever the call actually writes.

**This is a breaking change** — the first this package has made — and `NEWS.md` leads with it and the one-line migration. It was chosen over defaulting the paths to `tempdir()`, which would also satisfy CRAN's letter: a researcher whose script relied on `./cis` would keep running while silently writing results into a directory deleted at session end, surfacing days later as missing output with nothing connecting it to an upgrade. An error naming the argument to supply is the kinder failure. `DECISIONS.md` records this so it is not re-litigated.

It closes **BACKLOG item 24** for free — `generateReferenceDistribution2IFC()`'s stray `./stimuli` directory was the same violation, and an empty `tests/testthat/stimuli/` was still sitting in the checkout.

## The rest of the review

- `DESCRIPTION` no longer opens with "Functions to", and cites Dotsch & Todorov (2012) and Brinkman et al. (2017) — both DOIs verified live against `doi.org`.
- All **11** bare `T`/`F` in `R/` replaced (part of item 13). `tests/` and `vignettes/` were already clean.
- **Every example now runs.** The one `\dontrun{}` and all eight `\donttest{}` wrappers are gone; the whole set takes ~9s. They already ran at 32px over six trials and were simply never revisited. `generateNoiseImage()`'s commented-out example is now working code — it would not have run as written (`p` undefined, `params` the wrong length).
- `plotZmap()` restores `par()` and closes its PNG device through `on.exit()`.
- The walkthrough vignette resets `par()` without `on.exit()`.

On `generateNoisePattern.Rd`, which the reviewer also named: its example is the single live call `generateNoisePattern(256)`, in the v1.2.1 tarball as well as here. `cran-comments.md` says so and asks for clarification rather than changing working code.

## Two bugs found while doing the above

- **`foreach` exports the free variables of its loop body**, so a missing `stimulus_path` aborted `generateStimuli2IFC()` in the parallel path even when nothing was written. Only `R CMD check` caught it — the tests pass `ncores = 1`, which takes `registerDoSEQ()` and never scans.
- **`captureArgs()`** replaces the `mget(names(formals()))` `load()` guard. It skips required-and-absent arguments, because `mget()` forces the promise and a wrapper forwarding its own missing argument aborts there. It must *not* skip defaulted ones: `missing()` reports those missing too, and doing so reopened the collision the guard exists for — the `step` guard in `computeCumulativeCICorrelation()` broke and the test caught it.

## Backwards compatibility

Old `.Rdata` files record the `stimulus_path` they were generated into, typically the old `./stimuli` default. Three new tests cover this: such a file still computes a CI with no `targetpath`; a path stored *inside* the file never overrides one passed in; and `generateReferenceDistribution2IFC()` ignores the recorded path rather than writing to it.

## Verification

- **353 tests pass, 0 failures, 0 skipped** (was 329).
- **`R CMD check --as-cran`**: 0 errors, 0 warnings, **2 NOTEs** — CRAN incoming feasibility (new submission / archived / the Medium 403) and the local sandbox clock. Same two as 1.2.1.
- **The release gate: 135 checks identical against `v1.2.1`, 0 deviations, `max|d| = 0` everywhere** including both z-map methods. No number this package computes has changed. `tools/compare-harness.R` needed no edits — it already passed every path explicitly, which is itself the evidence.
- Verified no `cis/`, `zmaps/`, `stimuli/` or `Rplots.pdf` appears anywhere under the check tree or the repo. `^Rplots\.pdf$` added to `.Rbuildignore` as structural insurance.

`DESCRIPTION` is at **1.2.2** (no `.9000`), so the reproducibility workflow will run the **full** battery on this PR rather than `--quick`.

## Still needed before submitting

win-builder and R-hub must be re-run against the 1.2.2 tarball — `cran-comments.md` carries `<!-- TODO -->` markers where those results go. R-hub needs dispatching from the Actions tab; this environment gets `403: Resource not accessible by integration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)