### PR TITLE
Reopen development after 1.2.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rcicr
 Type: Package
 Title: Reverse-Correlation Image-Classification Toolbox
-Version: 1.2.3
+Version: 1.2.3.9000
 URL: https://github.com/rdotsch/rcicr
 BugReports: https://github.com/rdotsch/rcicr/issues
 Authors@R:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# rcicr (development version)
+
 # rcicr 1.2.3 (2026-08-07)
 
 **Documentation only. Nothing this package computes has changed** — no function,


### PR DESCRIPTION
Step 4 of CONTRIBUTING.md → Releasing. v1.2.3 is tagged at 48dd796 and the GitHub release is published. DESCRIPTION → 1.2.3.9000; NEWS.md gains a development-version heading, which switches the reproducibility gate back to --quick on ordinary PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)