### PR TITLE
Triage the 25 stale open issues (item 19's sweep)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -585,14 +585,13 @@ package's public health signal and it currently understates the state of the cod
       was the dominant cost, but the `ncores == 1` serial path in item 11 is still open and
       per-worker memory still scales with `img_size`. Comment with what changed and what
       did not, and leave it open, or close it explicitly scoped to the array copy.
-- [ ] **Sweep the remaining 25 open issues the same way — prerequisite for item 44.** All 25
-      date from 2016–2017 and none is a bug report — the real bugs were the batch above.
-      **Triage written, verified against the working tree, and approved by the maintainer
-      2026-08-08** — `notes/issue-triage.md` holds the verdict and the approved comment text
-      for all 25. Nine postings remain: close #43, #27, #13, #92, #52, #53, #68, #9, and a
-      corrective comment on #87. **Blocked on tooling, not on judgment** — `gh issue close`
-      and `gh issue comment` are refused by the agent permission classifier, so they need the
-      maintainer or a Bash allowlist rule for `gh issue`. Item 44 unblocks when they are out.
+- [x] **Sweep the remaining 25 open issues — done 2026-08-08.** All 25 dated from 2016–2017
+      and none was a bug report; the real bugs were the batch above. `notes/issue-triage.md`
+      holds the verdict and the posted text for each, verified against the working tree.
+      Closed #43, #27 and #13 (implemented or superseded), #92 and #52 (premise no longer
+      holds), #53 (no MDS functionality to attach it to), #68 and #9 (no actionable
+      specification); #87 got a correction — two of its checkboxes were ticked for work that
+      is not in the code — and stays open. **17 open, and item 44 is unblocked.**
 
 Best done as one batch after #131 merges, so #122 closes with it rather than by hand.
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -587,12 +587,12 @@ package's public health signal and it currently understates the state of the cod
       did not, and leave it open, or close it explicitly scoped to the array copy.
 - [ ] **Sweep the remaining 25 open issues the same way — prerequisite for item 44.** All 25
       date from 2016–2017 and none is a bug report — the real bugs were the batch above.
-      **Triage written and verified against the working tree for all 25**, in
-      `notes/issue-triage.md`: six recommended for closure (three implemented, two moot, one
-      superseded), one for a corrective comment, the rest to keep. Nothing has been posted
-      and nothing may be — comments and closes notify subscribers and are outward-facing, so
-      the maintainer approves or rejects issue by issue first. The item closes when the
-      approved set is posted, not when the triage was written.
+      **Triage written, verified against the working tree, and approved by the maintainer
+      2026-08-08** — `notes/issue-triage.md` holds the verdict and the approved comment text
+      for all 25. Nine postings remain: close #43, #27, #13, #92, #52, #53, #68, #9, and a
+      corrective comment on #87. **Blocked on tooling, not on judgment** — `gh issue close`
+      and `gh issue comment` are refused by the agent permission classifier, so they need the
+      maintainer or a Bash allowlist rule for `gh issue`. Item 44 unblocks when they are out.
 
 Best done as one batch after #131 merges, so #122 closes with it rather than by hand.
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -585,12 +585,14 @@ package's public health signal and it currently understates the state of the cod
       was the dominant cost, but the `ncores == 1` serial path in item 11 is still open and
       per-worker memory still scales with `img_size`. Comment with what changed and what
       did not, and leave it open, or close it explicitly scoped to the array copy.
-- [ ] **Sweep the remaining 25 open issues the same way — prerequisite for item 44.** Some
-      are likely stale or already resolved by earlier releases. Not done; the eight above
-      are only the ones this modernization pass touched directly. All 25 date from 2016–2017
-      and none is a bug report — the real bugs were the batch above. A partial triage exists
-      in `notes/issue-triage.md` (9 of 25 read). **Post nothing without the maintainer's
-      approval**: comments and closes notify subscribers and are outward-facing.
+- [ ] **Sweep the remaining 25 open issues the same way — prerequisite for item 44.** All 25
+      date from 2016–2017 and none is a bug report — the real bugs were the batch above.
+      **Triage written and verified against the working tree for all 25**, in
+      `notes/issue-triage.md`: six recommended for closure (three implemented, two moot, one
+      superseded), one for a corrective comment, the rest to keep. Nothing has been posted
+      and nothing may be — comments and closes notify subscribers and are outward-facing, so
+      the maintainer approves or rejects issue by issue first. The item closes when the
+      approved set is posted, not when the triage was written.
 
 Best done as one batch after #131 merges, so #122 closes with it rather than by hand.
 
@@ -885,8 +887,9 @@ in `DECISIONS.md`. It was never backlog, and neither are its neighbours.
 **Preparation, in order:**
 
 - [ ] **Item 19's remaining sweep — the hard prerequisite.** Triaging 25 stale issues *after*
-      opening ~18 new ones means the tracker gets worse before it gets better. Partial work in
-      `notes/issue-triage.md`. Nothing may be posted without the maintainer's approval.
+      opening ~18 new ones means the tracker gets worse before it gets better. The triage is
+      written for all 25 in `notes/issue-triage.md`; what remains is the maintainer's
+      approval and the posting. Nothing may be posted without that approval.
 - [ ] **Create priority labels.** P0–P3 exist only as prose here; without them, priority is
       the one thing the migration would lose.
 - [ ] **Rehome items 17, 25, 27 and 30 to `DECISIONS.md`** rather than opening issues for

--- a/notes/issue-triage.md
+++ b/notes/issue-triage.md
@@ -4,9 +4,10 @@ Prerequisite for `BACKLOG.md` item 44 (move the backlog to GitHub Issues). Item 
 eight issues the modernization fixed directly; these 25 are the remainder. All date from
 2016–2017, none is a bug report.
 
-**Nothing here has been posted.** Comments and closes notify subscribers and are
-outward-facing, so this file is a proposal for the maintainer to approve, edit or reject
-issue by issue. Verified against the working tree at `1.2.3.9000`.
+**Approved by the maintainer 2026-08-08; not yet posted.** Every verdict below is approved as
+written. Posting is blocked in the agent environment — `gh issue close` and `gh issue comment`
+are denied by the permission classifier — so the nine postings need the maintainer or an
+allowlist rule. Verified against the working tree at `1.2.3.9000`.
 
 ## Summary
 
@@ -14,10 +15,14 @@ issue by issue. Verified against the working tree at `1.2.3.9000`.
 |---|---|---|
 | **Close — implemented, verified in code** | #43, #27, #13 | 3 |
 | **Close — moot, the premise no longer holds** | #92, #52 | 2 |
+| **Close — no actionable specification** | #68, #9 | 2 |
+| **Close — nothing in the package to attach it to** | #53 | 1 |
 | **Keep open, rescope** — most of it shipped | #87 | 1 |
 | **Keep open — real, specified, unimplemented** | #71, #76, #85, #15, #35, #37, #38, #46, #47, #54, #22, #69 | 12 |
-| **Keep open — no specification** (title only, empty body) | #6, #7, #68, #9, #10 | 5 |
-| **Judgment call — aspirational since 2017** | #74, #53 | 2 |
+| **Keep open — thin, but the scope is clear** | #6, #7, #10 | 3 |
+| **Keep open — aspirational, and still intended** | #74 | 1 |
+
+Eight closes and one corrective comment (#87) — nine notifications, best sent in one sitting.
 
 ---
 
@@ -201,41 +206,76 @@ Verified as genuinely absent from the code; each has enough of a specification t
 | #22 | CI database + community building | Large, unimplemented, and a scope question rather than a coding one. |
 | #69 | small tutorials | Two vignettes now ship, but neither covers the noise-only recipe in this issue's body. Narrow enough to keep as "document generating noise-only images". |
 
-## Keep open — no specification
+## The thin issues — title only, empty body, no discussion
 
-Title only, empty body, no discussion. Each names a plausible feature but nothing that can be
-verified as done or not-done. Recommend either a one-line specification from the maintainer or
-closure — carrying an unspecified issue for nine years is worse than either.
+Five issues name a plausible feature with nothing that can be verified as done or not-done.
+Split on whether the title alone is a specification:
 
-| issue | title |
-|---|---|
-| #6 | direct support for 4AFC and other variants |
-| #7 | (masked) correlations between lists of CIs |
-| #68 | adaptive reverse correlation |
-| #9 | save analysis metadata to a log file (has a one-line body) |
-| #10 | meta-reverse correlation (has a real, short specification — arguably belongs in the group above) |
+**Kept.** #6 (direct support for 4AFC and other variants) — the package is 2IFC-only end to
+end, so the scope is unambiguous even with no body. #7 ((masked) correlations between lists of
+CIs) — the title is nearly a function signature, and `mask` already exists to build on. #10
+(meta-reverse correlation) — its body does specify the function: list of CIs + weights → a
+weighted-average CI, plus an optional anti-image.
 
-#10 is the borderline case: its body does specify the function (list of CIs + weights → a
-weighted-average CI, plus an optional anti-image). I would keep #10 and treat the other four
-as needing a specification.
+**Closed.** #68 and #9, below.
 
-## Judgment call — aspirational since 2017
+### #68 — adaptive reverse correlation
 
-Not stale in the sense of being done or wrong; stale in the sense that nothing has moved in
-nine years and neither is a small piece of work.
+A research direction rather than a feature: adaptive RC is a decision about the whole task
+loop — how stimuli are selected from trial to trial — not something checkable against the
+code. Nine years with no body and no discussion.
 
-- **#74 — GUI.** The maintainer wanted it in 2017 and floated a jamovi module. Closing it says
-  the package is a library, not an application; keeping it says a GUI is still intended.
-- **#53 — MDS plots with CIs on tooltip in Shiny.** A neat exploratory tool with a screenshot
-  attached, but no MDS functionality exists in the package to attach it to.
+> Draft comment:
+> Closing as unspecified. This is a title with no body and no discussion, and adaptive reverse
+> correlation is a research direction rather than a feature — it is a decision about the whole
+> task loop (how stimuli are selected from trial to trial), not something that can be checked
+> off against the code. Whatever eventually gets built will not come from this issue.
+>
+> Reopening or filing fresh with a concrete design in mind is welcome.
 
-Both call for the maintainer's intent, not a code check.
+### #9 — save analysis metadata to a log file?
+
+Asked as a question ("Such as scaling method, scaling factor?"), and answered by the design
+that shipped: `generateCI()` returns the scaling method and constant, and the `.Rdata` carries
+the generation parameters. A log file would duplicate state already travelling with the
+results.
+
+> Draft comment:
+> Closing: the question has been answered elsewhere in the design. `generateCI()` returns the
+> scaling method and the scaling constant it used as part of its return value, and the
+> `.Rdata` file written at stimulus-generation time records the generation parameters —
+> including the seed, the number of scales, and the generator version. A separate log file
+> would duplicate state that is already carried with the results, and would be one more thing
+> to keep in sync.
+>
+> If there is specific metadata that is *not* recoverable from either of those, that is worth a
+> fresh issue naming it.
+
+## Aspirational since 2017
+
+Neither is stale in the sense of being done or wrong; stale in the sense that nothing moved in
+nine years. Both were the maintainer's call, not a code check.
+
+- **#74 — GUI. Kept.** Wanted in 2017, with a jamovi module floated. Still intended.
+- **#53 — MDS plots with CIs on tooltip in Shiny. Closed.** A neat exploratory tool with a
+  screenshot attached, but no MDS functionality exists in the package to attach it to.
+
+> Draft comment for #53:
+> Closing. The package has no MDS functionality for this to attach to, and adding one is a
+> larger question than the viewer itself — rcicr computes classification images and leaves the
+> downstream analysis to the user's own tooling, where `ggplot2`/`plotly` already do image
+> tooltips well. The screenshot is still a good demonstration of the idea for anyone building
+> it outside the package.
 
 ---
 
 ## Sequencing note for item 44
 
-Six issues carry a recommended close and one a corrective comment; that is seven notifications
-to subscribers, all on issues those people filed or followed years ago. Worth doing in one
-sitting rather than spread across days, and worth doing **before** ~18 new issues are opened
-from `BACKLOG.md`, per item 44's prerequisite.
+Nine postings — eight closes and the #87 correction — all to people who filed or followed
+these years ago. Worth doing in one sitting rather than spread across days, and **before** ~18
+new issues are opened from `BACKLOG.md`, per item 44's prerequisite.
+
+The comment bodies are approved as written above. They were not posted from the agent
+environment: `gh issue close` and `gh issue comment` are both refused by the permission
+classifier, so this needs the maintainer running them, or a Bash allowlist rule for `gh issue`
+in `.claude/settings.json`.

--- a/notes/issue-triage.md
+++ b/notes/issue-triage.md
@@ -4,10 +4,10 @@ Prerequisite for `BACKLOG.md` item 44 (move the backlog to GitHub Issues). Item 
 eight issues the modernization fixed directly; these 25 are the remainder. All date from
 2016–2017, none is a bug report.
 
-**Approved by the maintainer 2026-08-08; not yet posted.** Every verdict below is approved as
-written. Posting is blocked in the agent environment — `gh issue close` and `gh issue comment`
-are denied by the permission classifier — so the nine postings need the maintainer or an
-allowlist rule. Verified against the working tree at `1.2.3.9000`.
+**Approved and posted 2026-08-08.** Every comment below went out as written: eight closes and
+the correction on #87, which stays open. 17 issues remain open, and item 44's prerequisite is
+met. Verdicts were verified against the working tree at `1.2.3.9000`; this file is the record
+of what was posted and why, not a live view of the tracker.
 
 ## Summary
 
@@ -271,11 +271,8 @@ nine years. Both were the maintainer's call, not a code check.
 
 ## Sequencing note for item 44
 
-Nine postings — eight closes and the #87 correction — all to people who filed or followed
-these years ago. Worth doing in one sitting rather than spread across days, and **before** ~18
-new issues are opened from `BACKLOG.md`, per item 44's prerequisite.
+All nine postings went out together on 2026-08-08 — one sitting, as intended, and **before**
+the ~18 new issues item 44 opens from `BACKLOG.md`. That prerequisite is now met.
 
-The comment bodies are approved as written above. They were not posted from the agent
-environment: `gh issue close` and `gh issue comment` are both refused by the permission
-classifier, so this needs the maintainer running them, or a Bash allowlist rule for `gh issue`
-in `.claude/settings.json`.
+The tracker afterwards: **17 open** — #6, #7, #10, #15, #22, #35, #37, #38, #46, #47, #54,
+#69, #71, #74, #76, #85, #87.

--- a/notes/issue-triage.md
+++ b/notes/issue-triage.md
@@ -1,0 +1,241 @@
+# Issue triage — the 25 open issues not touched by the modernization pass
+
+Prerequisite for `BACKLOG.md` item 44 (move the backlog to GitHub Issues). Item 19 closed the
+eight issues the modernization fixed directly; these 25 are the remainder. All date from
+2016–2017, none is a bug report.
+
+**Nothing here has been posted.** Comments and closes notify subscribers and are
+outward-facing, so this file is a proposal for the maintainer to approve, edit or reject
+issue by issue. Verified against the working tree at `1.2.3.9000`.
+
+## Summary
+
+| verdict | issues | n |
+|---|---|---|
+| **Close — implemented, verified in code** | #43, #27, #13 | 3 |
+| **Close — moot, the premise no longer holds** | #92, #52 | 2 |
+| **Keep open, rescope** — most of it shipped | #87 | 1 |
+| **Keep open — real, specified, unimplemented** | #71, #76, #85, #15, #35, #37, #38, #46, #47, #54, #22, #69 | 12 |
+| **Keep open — no specification** (title only, empty body) | #6, #7, #68, #9, #10 | 5 |
+| **Judgment call — aspirational since 2017** | #74, #53 | 2 |
+
+---
+
+## Close — implemented, verified in code
+
+### #43 — save single-subject CIs alongside group CIs
+
+**Done.** [`generateCI.R:83`](../R/generateCI.R#L83) takes `save_individual_cis=FALSE`, and
+[`generateCI.R:259-269`](../R/generateCI.R#L259-L269) writes each participant's CI to
+`<targetpath>/individual_cis`, scaled by its own `individual_scaling` /
+`individual_scaling_constant` arguments — exactly the "one single command for single subjects
+as well as the group level" the issue asked for.
+
+> Draft comment:
+> Done. `generateCI(..., participants = <col>, save_individual_cis = TRUE)` writes each
+> participant's CI to an `individual_cis` subfolder of `targetpath` in the same call that
+> produces the group CI, and scales them independently via `individual_scaling` and
+> `individual_scaling_constant`. As this issue anticipated, they were already being computed —
+> the group CI is their average — so this only added the saving.
+
+### #27 — group CIs in which every participant has equal weight
+
+**Done, and both of the follow-up checkboxes with it.** When `participants` is supplied,
+[`generateCI.R:229-282`](../R/generateCI.R#L229-L282) computes one CI per participant and then
+takes the *unweighted* mean across participants
+([`generateCI.R:282`](../R/generateCI.R#L282)) — so trial count no longer confers weight. It
+arrived as the `participants` argument rather than as a separate flag.
+
+The two checkboxes in the thread are also satisfied:
+- `stimuli_params$gender_neutral` is gone; the code uses the generic `params`
+  ([`generateCI.R:189`](../R/generateCI.R#L189), [`:321`](../R/generateCI.R#L321)).
+- The `t.test` z-map path uses `pid.cis` — the per-participant CIs — rather than per-trial
+  noise images when `participants` is given ([`generateCI.R:349`](../R/generateCI.R#L349)).
+
+**One checkbox is genuinely not done**, and I suggest saying so rather than closing over it:
+`generateCI2IFC()` and `batchGenerateCI2IFC()` still do not accept `participants`
+([`generateCI2IFC.R:61`](../R/generateCI2IFC.R#L61),
+[`batchGenerateCI2IFC.R:51`](../R/batchGenerateCI2IFC.R#L51)). Both are the legacy 2IFC-named
+wrappers, so the honest resolution is "use `generateCI()`", not a backport.
+
+> Draft comment:
+> Implemented, as the `participants` argument rather than a separate flag: with
+> `participants` supplied, `generateCI()` computes one CI per participant and averages those
+> unweighted, so a participant with fewer trials no longer carries less weight.
+>
+> Both follow-ups in this thread came with it — the hard-coded `gender_neutral` label is gone
+> in favour of the generic `params`, and the `t.test` z-map path operates on the
+> per-participant CIs (`pid.cis`) rather than on per-trial noise images when `participants` is
+> given.
+>
+> Not done, deliberately: `generateCI2IFC()` and `batchGenerateCI2IFC()` still don't take
+> `participants`. They are the legacy wrappers; `generateCI()` is the supported entry point
+> and has taken `participants` for some time. Closing on that basis.
+
+### #13 — "Update documentation" (2016, empty body)
+
+**Superseded.** Every one of the 17 exported functions has a roxygen block and a generated
+`.Rd`; two vignettes ship (`getting-started.Rmd`, `reverse-correlation-walkthrough.Rmd`); the
+README carries the architecture walkthrough and the `.Rdata` anatomy; and the docs have since
+been through a CRAN review. A 2016 issue with no body cannot be checked off against any of
+that.
+
+> Draft comment:
+> Closing as superseded. The package now has roxygen documentation for every exported
+> function, two vignettes (`getting-started`, `reverse-correlation-walkthrough`), a README
+> covering the architecture and the `.Rdata` format, and it has been through CRAN review since.
+> This issue has no body, so there is nothing left in it that is specific enough to act on —
+> anything still missing is better filed fresh.
+
+---
+
+## Close — moot, the premise no longer holds
+
+### #92 — add reference datasets
+
+Both reasons this was *reopened* in 2017 are gone: there is **no `inst/extdata` directory at
+all**, so the 60.5 Mb `installed size` NOTE cannot occur, and the undistributable `MNES.jpg`
+is not in the package.
+
+The original motivation — "standardize testing of new features" — is now met by other means:
+`tests/testthat/helper-fixtures.R` builds synthetic base images on the fly (never a real
+photo, so no licensing exposure), `test-regression-baseline.R` pins the numeric output of the
+default pipeline, and `tools/compare-release-output.R` diffs the working tree against a
+released version. That is a stronger guarantee than a shipped dataset would give, and it costs
+nothing in tarball size.
+
+What is *not* covered is a dataset for **user** convenience — a worked example someone can run
+without generating stimuli first. That is a real want, but it is a different issue from this
+one, and it collides with the same size and licensing constraints.
+
+> Draft comment:
+> Closing: both reasons this was reopened are resolved. There is no `inst/extdata` in the
+> package any more, so the 60.5 Mb installed-size NOTE is gone, and the undistributable
+> `MNES.jpg` is no longer shipped.
+>
+> The testing motivation is met a different way — the test suite generates synthetic base
+> images on the fly, a golden-master test pins the numeric output of the default pipeline, and
+> a release gate diffs every output against a released version before each release. That
+> catches more than a bundled reference dataset would, without adding to the tarball.
+>
+> A small dataset for *users* to run examples against is still a reasonable idea, but it is a
+> different request with the same size and licensing constraints attached. Worth a fresh issue
+> if it is wanted.
+
+### #52 — should we use random seeds? (question)
+
+**Answered by the design that shipped.** `generateStimuli2IFC()` takes `seed = 1`
+([`generateStimuli2IFC.R:46`](../R/generateStimuli2IFC.R#L46)) — a documented, fixed default
+that the user can vary. That takes the "con" (no recovery for a user who lost the `.Rdata`,
+reduced comparability) as the default, while leaving the "pro" (avoiding stimulus-set
+monoculture) one argument away. The `.Rdata` file also records the seed, so a set is
+reproducible even when a non-default one was used.
+
+Note there is a **separate, live** defect nearby — `set.seed(seed)` is never undone, so the
+user's RNG stream is left where stimulus generation put it (`BACKLOG.md` item 41). That should
+be its own issue under item 44; it is not what this one asks.
+
+> Draft comment:
+> Closing as answered by what shipped. `generateStimuli2IFC()` has a documented `seed`
+> argument defaulting to `1`: reproducible by default — which is the side this issue's "cons"
+> argue for — and one argument away from a random set for anyone who wants to avoid stimulus-set
+> monoculture. The seed is also stored in the `.Rdata` file, so a non-default set stays
+> recoverable.
+>
+> Unrelated but nearby, and tracked separately: the seed is set and never restored, so the
+> user's RNG stream is left where stimulus generation put it.
+
+---
+
+## Keep open, rescope
+
+### #87 — refactor batch CI generation (deprecates `batchGenerateCI`)
+
+Three of the four things in this thread shipped; the checkboxes are stale in both directions.
+
+| item | state |
+|---|---|
+| `autoscaling` parameter on `generateCI` for use with `participants` | **Done** — and named `individual_scaling`, the rename asked for in the 2017-08-10 comment ([`generateCI.R:85`](../R/generateCI.R#L85)) |
+| the target line of code `generateCI(..., participants=, individual_scaling=, save_individual_cis=)` | **Valid today**, argument for argument |
+| single function vs `generateCI` + `scaleCI` | **Settled** — 2017-09-25, stick with `generateCI()`, matching the European Review specification |
+| rewrite `batchGenerateCI` as a wrapper around `generateCI` | ticked in 2017, but it is **not** a wrapper today — [`batchGenerateCI.R:51`](../R/batchGenerateCI.R#L51) has its own loop |
+| "function deprecated" warning on `batchGenerateCI` | ticked in 2017, but **there is no such warning in the code today** |
+| `condition` argument, participants nested in condition | **Not done** |
+
+So the residue is: no deprecation warning, no `condition` argument, and `batchGenerateCI` is
+still a parallel implementation rather than a wrapper. Worth keeping, with the checkboxes
+corrected — the two ticked-but-absent items are the sort of thing that makes a tracker
+untrustworthy.
+
+> Draft comment:
+> Updating rather than closing — most of this shipped, and two checkboxes are ticked for work
+> that is not in the code.
+>
+> Done: `generateCI()` takes `participants`, `save_individual_cis`, `individual_scaling` and
+> `individual_scaling_constant`, so the target call in the first comment is valid today, with
+> `individual_scaling` being the rename of `autoscale` asked for there. The
+> one-function-vs-several question was settled in favour of `generateCI()` doing both.
+>
+> Still open, contrary to the ticked boxes: `batchGenerateCI()` is not a wrapper around
+> `generateCI()` — it still has its own loop — and it emits no deprecation warning. The
+> `condition` argument (participants nested in condition, group CIs per condition) was never
+> implemented.
+
+---
+
+## Keep open — real, specified, unimplemented
+
+Verified as genuinely absent from the code; each has enough of a specification to act on.
+
+| issue | what | note |
+|---|---|---|
+| #71 | z-map comparing **two** CIs | Today's z-maps test one CI against zero — `quick` scales the blurred CI, `t.test` tests per-pixel across trials or participants ([`generateCI.R:303-356`](../R/generateCI.R#L303-L356)). A two-CI contrast is new work. |
+| #15 | smoothing option on `generateCI` | `sigma` exists but smooths only the **z-map** ([`generateCI.R:307`](../R/generateCI.R#L307)); the CI itself is never blurred. The issue's exact proposal — `generateCI(smoothing = ...)` — is unimplemented. Overlaps #37 and #38. |
+| #85 | infoVals for many CIs at once | `computeInfoVal2IFC()` takes a single `target_ci` ([`computeInfoVal2IFC.R:68`](../R/computeInfoVal2IFC.R#L68)). Cheap to add and it would amortise the reference distribution across CIs, which is the expensive part. |
+| #76 | oblong base images | Still square-only. The maintainer's 2017 caveat stands: white noise is easy, sinusoid noise needs rework to avoid stretching. |
+| #47 | ROI analysis + small-volume correction | The `mask` argument gets partway (restrict the CI to a region) but does no ROI statistics or correction. |
+| #46 / #38 | cluster-based permutation test / Random Field Theory | The two competing routes to the same end: valid statistics on smooth CIs. Neither implemented. #38 carries the better reference material; #46 is likelier to be tractable. Worth deciding between them rather than carrying both. |
+| #37 | blurring optimized to the base image's spatial frequency composition | Unimplemented. Related to #15. |
+| #54 | 2IFC with randomly paired stimuli rather than ori+inv | The only one of these with a **methodological** claim behind it (the simulations in the thread: noise/anti-noise recovers the sign of a pixel deviation but not its magnitude). If that holds it also affects significance testing. Highest scientific value in this group. |
+| #35 | CI timelapses | Unimplemented. The thread already contains the answer to its own difficulty: dump frames, make video assembly optional. |
+| #22 | CI database + community building | Large, unimplemented, and a scope question rather than a coding one. |
+| #69 | small tutorials | Two vignettes now ship, but neither covers the noise-only recipe in this issue's body. Narrow enough to keep as "document generating noise-only images". |
+
+## Keep open — no specification
+
+Title only, empty body, no discussion. Each names a plausible feature but nothing that can be
+verified as done or not-done. Recommend either a one-line specification from the maintainer or
+closure — carrying an unspecified issue for nine years is worse than either.
+
+| issue | title |
+|---|---|
+| #6 | direct support for 4AFC and other variants |
+| #7 | (masked) correlations between lists of CIs |
+| #68 | adaptive reverse correlation |
+| #9 | save analysis metadata to a log file (has a one-line body) |
+| #10 | meta-reverse correlation (has a real, short specification — arguably belongs in the group above) |
+
+#10 is the borderline case: its body does specify the function (list of CIs + weights → a
+weighted-average CI, plus an optional anti-image). I would keep #10 and treat the other four
+as needing a specification.
+
+## Judgment call — aspirational since 2017
+
+Not stale in the sense of being done or wrong; stale in the sense that nothing has moved in
+nine years and neither is a small piece of work.
+
+- **#74 — GUI.** The maintainer wanted it in 2017 and floated a jamovi module. Closing it says
+  the package is a library, not an application; keeping it says a GUI is still intended.
+- **#53 — MDS plots with CIs on tooltip in Shiny.** A neat exploratory tool with a screenshot
+  attached, but no MDS functionality exists in the package to attach it to.
+
+Both call for the maintainer's intent, not a code check.
+
+---
+
+## Sequencing note for item 44
+
+Six issues carry a recommended close and one a corrective comment; that is seven notifications
+to subscribers, all on issues those people filed or followed years ago. Worth doing in one
+sitting rather than spread across days, and worth doing **before** ~18 new issues are opened
+from `BACKLOG.md`, per item 44's prerequisite.


### PR DESCRIPTION
Completes item 19's remaining sweep — the hard prerequisite for item 44 (moving the backlog to GitHub Issues). All 25 issues dated from 2016–2017 and none was a bug report; the real bugs were the batch item 19 already closed.

**The tracker changes are already live** — this PR is the record of what was posted and why. Each verdict was verified against the working tree at `1.2.3.9000` with file:line evidence, and the maintainer approved the set issue by issue before anything went out.

Closed (8):

| issue | reason |
|---|---|
| #43, #27, #13 | implemented or superseded — verified in code |
| #92, #52 | the premise no longer holds |
| #53 | no MDS functionality in the package to attach a Shiny viewer to |
| #68, #9 | no actionable specification after nine years |

#87 stays open with a correction: two of its checkboxes are ticked for work that is not in the code — `batchGenerateCI()` is still not a wrapper around `generateCI()`, and emits no deprecation warning. Ticked-but-absent boxes are what make a tracker untrustworthy, so they are called out rather than quietly re-opened.

Also kept, deliberately: #6, #7 and #10, where the title alone is specification enough to act on, and #74, where a GUI is still intended.

**17 issues open afterwards**, and item 44 is unblocked.

No code, tests or documentation change — `notes/` is `.Rbuildignore`d, so the built package is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)