### PR TITLE
AGENTS.md: name the "check, don't assume" rule; document the Codex review in CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,18 @@ replaced a chronological session log; do not recreate one.
 - The squash commit message is the place to preserve *why* a change was made — the per-commit
   detail on the branch disappears, so measurements, rejected alternatives and reproducibility
   impact belong in the squash message or in `NEWS.md`, not only in the branch commits.
+- **Read the bot review before merging, and answer it.** Codex
+  (`chatgpt-codex-connector[bot]`) reviews on PR open, on ready-for-review and on a
+  `@codex review` comment, posting findings as inline review comments badged `P1`–`P3`.
+  Nothing makes you notice them: it submits as `COMMENTED`, so it never blocks a merge and
+  `reviewDecision` stays empty; `gh pr checks` is green regardless; and `gh pr view
+  --comments` shows only the review wrapper, **not the findings**. The one surface that has
+  them is `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. It has been right about
+  substantive things (#170, #172, #173) — reply on each thread, fixing it or saying why not,
+  before squashing.
+- **No findings and not-reviewed-yet look identical.** The review lands a few minutes after
+  the PR opens, so an empty result right after `gh pr create` means nothing; and it names the
+  commit it reviewed, so pushing again leaves it stale. Re-check after your last push.
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,12 @@ replaced a chronological session log; do not recreate one.
 - **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
   `@codex review` comment does. The review stays pinned to the commit it names, so every fix
   pushed afterwards is unreviewed; comment `@codex review` once the branch is final.
+- **If it never answers, merge without it.** The integration is not a required check and needs
+  no approval — the ruleset requires the five checks in "Testing and CI" and
+  `required_approving_review_count` is 0 — so it can be switched off or lapse with nothing to
+  announce it. Reviews here land in a couple of minutes; neither reaction nor comment well
+  after that means treat it as unavailable and merge on the other checks. This is a habit to
+  catch cheap mistakes, not a gate, and it must never become one an outage can hold shut.
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,19 +12,16 @@ loads only `CLAUDE.md`. Keep this file under 200 lines; adherence drops above th
 
 ## Check, don't assume
 
-**Verify a claim against the thing itself before writing it down or acting on it.** Three rules
-below are scar tissue from not doing that — the branch-protection API under "Testing and CI",
-and answering CRAN from a summary and quoting this machine's clock under "Releases and
-versioning". Each produced a confident wrong answer, and each keeps its detail there, where
-someone doing that task will hit it. This is the general form, for the cases not yet listed:
+**Verify a claim against the thing itself before writing it down or acting on it.** Several
+rules below are scar tissue from not doing that — the branch-protection API, answering CRAN
+from a summary, quoting this machine's clock — and each keeps its detail where someone doing
+that task will hit it. The general form:
 
-- **Run the command, read the file, query the API.** No "should be", "presumably", "as
-  expected". If a check was not run, say so rather than predicting its result.
-- **An empty result may mean you asked the wrong question.** Nothing found can mean the thing
-  is absent *or* that the endpoint, branch, path or scope was wrong — rule out the second
-  before reporting the first.
-- **Put the evidence next to the claim** — the command, the file and line, the actual output —
-  so the next reader can recheck it instead of re-deriving it.
+- **Run the command, read the file, query the API.** No "should be" or "as expected"; if a
+  check was not run, say so rather than predicting its result.
+- **An empty result may mean you asked the wrong question** — wrong endpoint, branch, path or
+  scope. Rule that out before reporting nothing found.
+- **Put the evidence next to the claim**: the command, the file and line, the actual output.
 
 ## Common commands
 
@@ -81,30 +78,12 @@ replaced a chronological session log; do not recreate one.
 - The squash commit message is the place to preserve *why* a change was made — the per-commit
   detail on the branch disappears, so measurements, rejected alternatives and reproducibility
   impact belong in the squash message or in `NEWS.md`, not only in the branch commits.
-- **Read the bot review before merging, and answer it.** Codex
-  (`chatgpt-codex-connector[bot]`) reviews on PR open, on ready-for-review and on a
-  `@codex review` comment, posting findings as inline review comments badged `P1`–`P3`.
-  Nothing makes you notice them: it submits as `COMMENTED`, so it never blocks a merge and
-  `reviewDecision` stays empty; `gh pr checks` is green regardless; and `gh pr view
-  --comments` shows only the review wrapper, **not the findings**. The one surface that has
-  them is `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. It has been right about
-  substantive things (#170, #172, #173) — reply on each thread, fixing it or saying why not,
-  before squashing.
-- **An empty comment list is not an all-clear** — it also looks exactly like not-reviewed-yet.
-  What distinguishes them is the reaction on the PR body, via
-  `gh api repos/rdotsch/rcicr/issues/<n>/reactions`: 👀 while the review runs, replaced by 👍
-  if it finishes with nothing to say. Findings arrive as comments instead, with no 👍. The
-  reaction is replaced rather than added to, so compare its `created_at` against your last
-  commit — an older one cleared an earlier version of the branch, not this one.
-- **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
-  `@codex review` comment does. The review stays pinned to the commit it names, so every fix
-  pushed afterwards is unreviewed; comment `@codex review` once the branch is final.
-- **If it never answers, merge without it.** The integration is not a required check and needs
-  no approval — the ruleset requires the five checks in "Testing and CI" and
-  `required_approving_review_count` is 0 — so it can be switched off or lapse with nothing to
-  announce it. Reviews here land in a couple of minutes; neither reaction nor comment well
-  after that means treat it as unavailable and merge on the other checks. This is a habit to
-  catch cheap mistakes, not a gate, and it must never become one an outage can hold shut.
+- **Read the Codex review before squashing, and answer it.** It is easy to merge past: it
+  never blocks — not a required check, submits as `COMMENTED` — and neither `gh pr checks` nor
+  `gh pr view --comments` shows the findings. They are inline review comments, at
+  `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. An empty list means "not reviewed yet" as
+  often as "clean", and a push does not re-trigger the review. Mechanics, including how to
+  tell those two apart: `CONTRIBUTING.md` → "The Codex review".
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,14 @@ replaced a chronological session log; do not recreate one.
   them is `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. It has been right about
   substantive things (#170, #172, #173) — reply on each thread, fixing it or saying why not,
   before squashing.
-- **No findings and not-reviewed-yet look identical.** The review lands a few minutes after
-  the PR opens, so an empty result right after `gh pr create` means nothing; and it names the
-  commit it reviewed, so pushing again leaves it stale. Re-check after your last push.
+- **An empty comment list is not an all-clear** — it also looks exactly like not-reviewed-yet,
+  and the review lands a few minutes after the PR opens. The distinguisher is the reaction:
+  with findings it comments, without them it reacts 👍 on the PR body. Check
+  `gh api repos/rdotsch/rcicr/issues/<n>/reactions`, and compare its `created_at` against your
+  last commit — an older 👍 cleared an earlier version of the branch, not this one.
+- **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
+  `@codex review` comment does. The review stays pinned to the commit it names, so every fix
+  pushed afterwards is unreviewed; comment `@codex review` once the branch is final.
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ replaced a chronological session log; do not recreate one.
 - **Read the Codex review before squashing, and answer it.** It is easy to merge past: it
   never blocks — not a required check, submits as `COMMENTED` — and neither `gh pr checks` nor
   `gh pr view --comments` shows the findings. They are inline review comments, at
-  `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. An empty list means "not reviewed yet" as
-  often as "clean", and a push does not re-trigger the review. Mechanics, including how to
+  `gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments`. An empty list means "not reviewed
+  yet" as often as "clean", and a push does not re-trigger the review. Mechanics, including how to
   tell those two apart: `CONTRIBUTING.md` → "The Codex review".
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,22 @@ loads only `CLAUDE.md`. Keep this file under 200 lines; adherence drops above th
 
 `rcicr` is an R package (CRAN-style) implementing the **reverse correlation image classification** technique from psychophysics: generating noise-based stimuli for 2-image-forced-choice (2IFC) perceptual tasks and computing "classification images" (CIs) from participant response data to visualize internal mental representations (e.g., of faces).
 
+## Check, don't assume
+
+**Verify a claim against the thing itself before writing it down or acting on it.** Three rules
+below are scar tissue from not doing that — the branch-protection API under "Testing and CI",
+and answering CRAN from a summary and quoting this machine's clock under "Releases and
+versioning". Each produced a confident wrong answer, and each keeps its detail there, where
+someone doing that task will hit it. This is the general form, for the cases not yet listed:
+
+- **Run the command, read the file, query the API.** No "should be", "presumably", "as
+  expected". If a check was not run, say so rather than predicting its result.
+- **An empty result may mean you asked the wrong question.** Nothing found can mean the thing
+  is absent *or* that the endpoint, branch, path or scope was wrong — rule out the second
+  before reporting the first.
+- **Put the evidence next to the claim** — the command, the file and line, the actual output —
+  so the next reader can recheck it instead of re-deriving it.
+
 ## Common commands
 
 A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`, GitHub Actions CI — so the usual `roxygen2::roxygenise()` / `devtools::load_all()` / `test()` / `check()` / `install()` workflow applies unchanged, run from the package root. Two things about it are *not* standard:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,10 @@ replaced a chronological session log; do not recreate one.
   impact belong in the squash message or in `NEWS.md`, not only in the branch commits.
 - **Read the Codex review before squashing, and answer it.** It is easy to merge past: it
   never blocks — not a required check, submits as `COMMENTED` — and neither `gh pr checks` nor
-  `gh pr view --comments` shows the findings. They are inline review comments, at
-  `gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments`. An empty list means "not reviewed
-  yet" as often as "clean", and a push does not re-trigger the review. Mechanics, including how to
-  tell those two apart: `CONTRIBUTING.md` → "The Codex review".
+  `gh pr view --comments` shows its findings. Nor is reading them as simple as listing the
+  PR's comments: a push does not re-trigger the review, and the previous round's findings come
+  back looking current, so what you read has to be filtered to your head commit. Follow
+  `CONTRIBUTING.md` → "The Codex review".
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,12 @@ replaced a chronological session log; do not recreate one.
   them is `gh api repos/rdotsch/rcicr/pulls/<n>/comments`. It has been right about
   substantive things (#170, #172, #173) — reply on each thread, fixing it or saying why not,
   before squashing.
-- **An empty comment list is not an all-clear** — it also looks exactly like not-reviewed-yet,
-  and the review lands a few minutes after the PR opens. The distinguisher is the reaction:
-  with findings it comments, without them it reacts 👍 on the PR body. Check
-  `gh api repos/rdotsch/rcicr/issues/<n>/reactions`, and compare its `created_at` against your
-  last commit — an older 👍 cleared an earlier version of the branch, not this one.
+- **An empty comment list is not an all-clear** — it also looks exactly like not-reviewed-yet.
+  What distinguishes them is the reaction on the PR body, via
+  `gh api repos/rdotsch/rcicr/issues/<n>/reactions`: 👀 while the review runs, replaced by 👍
+  if it finishes with nothing to say. Findings arrive as comments instead, with no 👍. The
+  reaction is replaced rather than added to, so compare its `created_at` against your last
+  commit — an older one cleared an earlier version of the branch, not this one.
 - **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
   `@codex review` comment does. The review stays pinned to the commit it names, so every fix
   pushed afterwards is unreviewed; comment `@codex review` once the branch is final.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,28 @@ attaching a real face photo.
   measurements, rejected alternatives, reproducibility impact — in the PR description or
   `NEWS.md`, not only in individual branch commits.
 
+### The Codex review
+
+Codex reviews pull requests here and has caught real errors (#170, #172, #173). Nothing in the
+merge path makes you notice it, so read it deliberately before squashing.
+
+- **It never blocks, and must not become something that can.** It submits as `COMMENTED`, so
+  `reviewDecision` stays empty; it is not a required check; no approval is required. If it has
+  been switched off, or simply is not answering, merge on the other checks.
+- **Findings are inline review comments**, badged `P1`–`P3`. `gh pr checks` stays green
+  regardless, and `gh pr view --comments` shows only the review wrapper. One surface has them:
+  ```sh
+  gh api repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
+  ```
+- **An empty list is not an all-clear** — it is identical to not-reviewed-yet. What tells them
+  apart is the reaction on the PR body, `gh api repos/rdotsch/rcicr/issues/<n>/reactions`: 👀
+  while the review runs, replaced by 👍 when it finishes with nothing to say. It is replaced
+  rather than added to, so compare its `created_at` against your last commit.
+- **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
+  `@codex review` comment does, so it stays pinned to the commit it named and later fixes go
+  unreviewed. Comment `@codex review` once the branch is final, then answer each thread —
+  fixing it, or saying why not — before you squash.
+
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately
 **not** run: they would reformat nearly every file in one sweep and destroy `git blame`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,25 +92,34 @@ merge path makes you notice it, so read it deliberately before squashing.
 - **It never blocks, and must not become something that can.** It submits as `COMMENTED`, so
   `reviewDecision` stays empty; it is not a required check; no approval is required. If it has
   been switched off, or simply is not answering, merge on the other checks.
-- **Findings are inline review comments**, badged `P1`–`P3`. `gh pr checks` stays green
-  regardless, and `gh pr view --comments` shows only the review wrapper. One surface has them,
-  and it pages at 30 — a review-heavy PR truncates silently without `--paginate`:
-  ```sh
-  gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
-  ```
-  Keep to that streaming form: `--paginate` applies `--jq` per page, so `--jq 'length'` counts
-  each page separately instead of totalling them.
-- **An empty list is not an all-clear** — it is identical to not-reviewed-yet. What tells them
-  apart is the reaction on the PR body, `gh api repos/rdotsch/rcicr/issues/<n>/reactions`: 👀
-  while the review runs, replaced by 👍 when it finishes with nothing to say. Do not try to
-  date that against your commits: a commit timestamp is when it was authored locally, not when
-  it was pushed, and a review that began before a push can land its reaction after it. Either
-  way a stale 👍 reads as current.
-- **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
-  `@codex review` comment does, so it stays pinned to the commit it named and later fixes go
-  unreviewed. That ordering is the only dependable freshness check — push last, *then* comment
-  `@codex review`, then read the result and answer each thread, fixing it or saying why not,
-  before you squash.
+The findings are inline review comments badged `P1`–`P3`. `gh pr checks` stays green
+regardless and `gh pr view --comments` shows only the review wrapper, so neither surface tells
+you anything. What does:
+
+1. **Push everything first, then comment `@codex review`.** A push does not re-trigger the
+   review — only that comment, opening the PR, or marking a draft ready does — so anything
+   pushed afterwards goes unreviewed against a review pinned to an older commit.
+2. **Wait for a review submitted against your head.** The previous round's comments are
+   returned immediately and look exactly like a result, so an unfiltered read cannot tell a
+   finished re-review from a running one. Reviews and comments both carry `commit_id`:
+   ```sh
+   head=$(git rev-parse HEAD)
+   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/reviews |
+     jq --arg head "$head" '[.[] | select(.commit_id == $head and (.user.login|test("codex")))] | length'
+   ```
+   Zero means it has not finished. The other completion signal is the reaction on the PR body
+   (`.../issues/<n>/reactions`): 👀 while the review runs, replaced by 👍 when it finishes with
+   nothing to say. Do not try to date that reaction against a commit — a commit timestamp
+   records local authoring, not the push, so a stale 👍 can look current.
+3. **Read only the findings at that head**, then answer each thread — fixing it, or saying why
+   not — before you squash:
+   ```sh
+   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments |
+     jq -r --arg head "$head" '.[] | select(.commit_id == $head) | "\(.path):\(.line)  \(.body)"'
+   ```
+   `--paginate` matters: the endpoint pages at 30 and a review-heavy PR truncates silently
+   without it. Pipe to `jq` rather than passing `--jq`, which is applied per page — `--jq
+   'length'` counts each page separately instead of totalling them.
 
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,18 +93,24 @@ merge path makes you notice it, so read it deliberately before squashing.
   `reviewDecision` stays empty; it is not a required check; no approval is required. If it has
   been switched off, or simply is not answering, merge on the other checks.
 - **Findings are inline review comments**, badged `P1`–`P3`. `gh pr checks` stays green
-  regardless, and `gh pr view --comments` shows only the review wrapper. One surface has them:
+  regardless, and `gh pr view --comments` shows only the review wrapper. One surface has them,
+  and it pages at 30 — a review-heavy PR truncates silently without `--paginate`:
   ```sh
-  gh api repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
+  gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
   ```
+  Keep to that streaming form: `--paginate` applies `--jq` per page, so `--jq 'length'` counts
+  each page separately instead of totalling them.
 - **An empty list is not an all-clear** — it is identical to not-reviewed-yet. What tells them
   apart is the reaction on the PR body, `gh api repos/rdotsch/rcicr/issues/<n>/reactions`: 👀
-  while the review runs, replaced by 👍 when it finishes with nothing to say. It is replaced
-  rather than added to, so compare its `created_at` against your last commit.
+  while the review runs, replaced by 👍 when it finishes with nothing to say. Do not try to
+  date that against your commits: a commit timestamp is when it was authored locally, not when
+  it was pushed, and a review that began before a push can land its reaction after it. Either
+  way a stale 👍 reads as current.
 - **A push does not re-trigger it.** Only opening the PR, marking a draft ready, or an
   `@codex review` comment does, so it stays pinned to the commit it named and later fixes go
-  unreviewed. Comment `@codex review` once the branch is final, then answer each thread —
-  fixing it, or saying why not — before you squash.
+  unreviewed. That ordering is the only dependable freshness check — push last, *then* comment
+  `@codex review`, then read the result and answer each thread, fixing it or saying why not,
+  before you squash.
 
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,9 +117,15 @@ you anything. What does:
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments |
      jq -r --arg head "$head" '.[] | select(.commit_id == $head) | "\(.path):\(.line)  \(.body)"'
    ```
-   `--paginate` matters: the endpoint pages at 30 and a review-heavy PR truncates silently
-   without it. Pipe to `jq` rather than passing `--jq`, which is applied per page — `--jq
-   'length'` counts each page separately instead of totalling them.
+Both commands need `--paginate`: these endpoints page at 30, and a review-heavy PR truncates
+silently without it. Both also pipe to `jq` rather than passing `--jq`, and that distinction is
+load-bearing — `gh api`'s own filter runs once per page, so `--jq 'length'` reports a count per
+page rather than a total. **Piped output does not have that problem**, whatever `gh api --help`
+suggests when it says "Each page is a separate JSON array": that describes `--jq` and
+`--template`, and `gh` merges the pages before writing to stdout. Measured against 197 issues —
+piped, one array of 197; `--jq 'length'`, `100` then `97`. Do not "fix" these commands by adding
+`--slurp` on the strength of the help text; it would wrap the merged array in another array and
+break the filters.
 
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately


### PR DESCRIPTION
Two rules, both about verifying rather than inferring — plus four rounds of Codex review that materially changed both.

## 1. Name the "check, don't assume" rule

`AGENTS.md` carried three separate lessons that were all the same mistake:

- reading `gh api .../branches/main` as "no protection configured" when the rules live under `.../rules/branches/main`
- answering a CRAN point from a summary rather than `notes/cran-review-1.2.1.md`, dropping a filename the reviewer had named
- quoting a wall-clock number from this machine as if it held on the reader's

Stated only as instances, the rule fires only on cases already listed. This adds the general form near the top: run the probe rather than predict it, treat an empty result as possibly the wrong question, attach the evidence to the claim. The instances stay where they are — each carries a fact the general rule cannot regenerate, and the detail is most useful where someone hits that task.

## 2. Read the Codex review before squashing

Codex has caught real errors here (#170, #172, #173), but nothing in the merge path makes you notice it. Verified against #195, which merged green with an unaddressed finding:

| surface | shows the findings? |
|---|---|
| `gh pr checks` | no — all green regardless |
| `reviewDecision` | no — submits as `COMMENTED`, never blocks |
| `gh pr view --comments` | **no** — only the review wrapper |
| `gh api .../pulls/<n>/comments` | yes, filtered by `commit_id` |

`CONTRIBUTING.md` → "The Codex review" now holds a three-step procedure — push, wait for a review whose `commit_id` matches head, read the findings at that head — with a six-line pointer in `AGENTS.md`.

**It must never become a gate.** A disabled or lapsed integration produces no comment *and* no reaction, so the rule as first drafted would have waited forever. Checked against the ruleset: Codex is not a required context, `required_approving_review_count` is 0, `required_review_thread_resolution` is false.

## What the review rounds changed

The rule was wrong three times before it was right, and Codex found each one:

1. **A push does not re-trigger the review.** An early draft said "re-check after your last push". Demonstrated on this PR: a 👍 at 19:38:05Z predated commit `c41f8e5` at 19:45:00Z, so it had cleared only the first commit.
2. **Comparing the reaction's `created_at` to a commit timestamp is unsound** — a commit records local authoring, not the push, so a stale 👍 reads as current. Removed rather than repaired; freshness now rests on ordering.
3. **Ordering alone still permits squashing mid-rerun**, because `/pulls/<n>/comments` returns the previous round's findings immediately. `commit_id` settles it — at head `cae06d9`, three comments carried the old head and one carried the new. This is what made the procedure sound.
4. **One finding was wrong**, and is recorded as such: it argued from `gh api --help` that piped `--paginate` aggregates per page. It does not — piped output is merged (one array of 197), while `--jq` is per page (`100`, `97`), and the proposed `--slurp` fix breaks the filters with `Cannot index array with string "commit_id"`. The note now carries the measurement so the same wrong fix is not re-derived.

Rounds 1–3 were invisible to all five required checks.

## Housekeeping

`AGENTS.md` ends at **158 lines**, three above where it started and 21 below where this branch peaked, because the mechanics moved to `CONTRIBUTING.md` (no cap). No `NEWS.md` entry — not user-facing. Both files are already in `.Rbuildignore` and the reproducibility workflow's inert allowlist. Follow-up #197 tracks the stale backlog references that started this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)