### PR TITLE
Repoint the stale BACKLOG.md item references (#197)

### DIFF
--- a/R/computeCumulativeCICorrelation.R
+++ b/R/computeCumulativeCICorrelation.R
@@ -47,8 +47,9 @@ computeCumulativeCICorrelation <- function(stimuli, responses, baseimage, rdata,
   # the .Rdata file silently overwrites an argument of the same name - the same
   # hazard handled in generateCI() and generateReferenceDistribution2IFC(). No
   # field written today collides with these arguments, so this changes nothing
-  # now; it is here because the collision that actually bit us (item 32) was
-  # created from the .Rdata side, by adding a field, not by adding an argument.
+  # now; it is here because the collision that actually bit us (the z-map
+  # `sigma`, fixed in #146) was created from the .Rdata side, by adding a field,
+  # not by adding an argument.
   #
   # Captured after the unlist() above, so the coerced vectors are what gets
   # restored rather than the original tibble columns.

--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -80,12 +80,12 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
   # then operate on whatever path that file happened to record.
   #
   # Keep every argument rather than the three that were known to collide: the
-  # hazard has bitten from the .Rdata side twice now (item 32 added `sigma` to
-  # the file and captured generateCI()'s z-map argument), so the guard has to
-  # hold for fields that do not exist yet. `target_ci` is the one that would
-  # hurt most here - it is read at the very end to compute the CI norm, so a
-  # file carrying that name would silently score somebody else's classification
-  # image and return a plausible number rather than an error.
+  # hazard has bitten from the .Rdata side twice now (a `sigma` field added to
+  # the file captured generateCI()'s z-map argument; fixed in #146), so the
+  # guard has to hold for fields that do not exist yet. `target_ci` is the one
+  # that would hurt most here - it is read at the very end to compute the CI
+  # norm, so a file carrying that name would silently score somebody else's
+  # classification image and return a plausible number rather than an error.
   .args <- captureArgs(environment())
   load(rdata)
   list2env(.args, envir = environment())

--- a/tests/testthat/test-error-paths.R
+++ b/tests/testthat/test-error-paths.R
@@ -78,7 +78,8 @@ test_that("generateCI reports which variable an .Rdata file is missing", {
   expect_missing("stimuli_params", "did not contain stimuli_params")
 
   # img_size is not a formal of generateCI(), so it can only come from the file
-  # -- unlike sigma, which is both, and which is what item 32 turned on.
+  # -- unlike sigma, which is both, and which is why load() could overwrite the
+  # argument with the file's field (the z-map sigma bug, fixed in #146).
   expect_missing("img_size", "did not contain img_size")
 })
 
@@ -264,7 +265,7 @@ test_that("generateStimuli2IFC rejects base_face_files that is not a list", {
   # This one calls stop() with no arguments after writing its explanation to
   # stderr(), so the condition carries an *empty* message and no regexp can
   # match it. Asserting only that it errors is the most this path allows;
-  # giving it a real message belongs to item 14.
+  # giving it a real message is the same class of work as #180.
   expect_error(
     suppressWarnings(
       generateStimuli2IFC(base_face_files = png, n_trials = 2, img_size = 32,

--- a/tests/testthat/test-load-argument-guards.R
+++ b/tests/testthat/test-load-argument-guards.R
@@ -3,8 +3,8 @@
 # overwrites an argument of the same name.
 #
 # This has bitten twice, both times from the .Rdata side: a field was added to
-# the file and captured an argument that had been there all along (item 32 added
-# the noise `sigma` and took over generateCI()'s z-map blur `sigma`). No field
+# the file and captured an argument that had been there all along (the noise
+# `sigma` took over generateCI()'s z-map blur `sigma`; fixed in #146). No field
 # written today collides with the arguments below, so these tests pass against
 # the unguarded code too if the collision is not planted -- which is exactly why
 # each one plants it explicitly.


### PR DESCRIPTION
Closes #197.

`BACKLOG.md` was retired in #195, but **five** comments still cite its item numbers. They resolve to nothing now, and the numbers actively mislead: `notes/backlog-migration.md` reuses the same integer range for its own new sequence, so "item 14" in a pre-migration comment is *not* row 14 of that table.

## Old item 32 — four of the five

All four are the same reference: the collision where a `sigma` field in the `.Rdata` captured `generateCI()`'s z-map blur argument through `load()`. Traced it to #146 (`2aeed1d`, "Keep `generateCI()`'s arguments across `load()`"), and each comment now names the mechanism and the PR instead of the item number.

- `R/computeInfoVal2IFC.R:83`
- `R/computeCumulativeCICorrelation.R:50`
- `tests/testthat/test-load-argument-guards.R:6`
- `tests/testthat/test-error-paths.R:81`

This is the same hazard `AGENTS.md` documents under "`load()` assigns into the calling function's frame", so the comments now point at the incident that proves it rather than at a dead number.

## Old item 14 — the fifth

`tests/testthat/test-error-paths.R:267`. The migration split old item 14 into #180 and #181, and **neither covers this case** — a `stop()` with no arguments in `generateStimuli2IFC()`'s `base_face_files` check, which produces an empty condition message that no regexp can match. #180 (validate base images up front, with a message naming the file) is the nearest tracked work, so the comment names it as the same *class* of problem rather than claiming it is the same item.

## Correction to #197

The issue said a fresh grep found matches "only in `test-error-paths.R`". That was wrong, and wrong in a specific way worth recording: the repo-wide grep searched for `backlog`, while the `item <n>` search was scoped to the four files the review had named. Three references saying "item 32" without the word "backlog" fell in the gap between the two. A single repo-wide `item [0-9]` grep — which is what this branch ran — finds all five.

## Verification

- `grep -rn "item [0-9]\|BACKLOG\.md"` over `R/ tests/ tools/ man/ vignettes/` → no matches
- all four modified files re-parse
- the diff contains **no executable line** — every changed line is a comment

`R/` is touched, so the reproducibility gate runs for real here rather than taking the inert-file path. No `NEWS.md` entry: nothing user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)