### PR TITLE
Judge the Codex review by its reaction and thread resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,17 +73,16 @@ replaced a chronological session log; do not recreate one.
 - **Merge pull requests to `main` with squash merges** (`gh pr merge <n> --squash`). One
   commit per PR keeps history readable and makes `git revert` of a whole change
   straightforward, which matters here because a PR is usually one self-contained fix plus its
-  test and its `NEWS.md` entry. This is repo convention, not enforced by GitHub settings — it
-  is on whoever merges to pick the right one.
+  test and its `NEWS.md` entry. The `main` ruleset enforces it — `allowed_merge_methods` is
+  `["squash"]`, so the other buttons are not offered.
 - The squash commit message is the place to preserve *why* a change was made — the per-commit
   detail on the branch disappears, so measurements, rejected alternatives and reproducibility
   impact belong in the squash message or in `NEWS.md`, not only in the branch commits.
 - **Read the Codex review before squashing, and answer it.** It is easy to merge past: it
   never blocks — not a required check, submits as `COMMENTED` — and neither `gh pr checks` nor
-  `gh pr view --comments` shows its findings. Nor is reading them as simple as listing the
-  PR's comments: a push does not re-trigger the review, and the previous round's findings come
-  back looking current, so what you read has to be filtered to your head commit. Follow
-  `CONTRIBUTING.md` → "The Codex review".
+  `gh pr view --comments` shows its findings. Two things clear a squash: a 👍 on the PR body
+  dated after your own `@codex review` comment, and no unresolved review threads. One command
+  each, in `CONTRIBUTING.md` → "The Codex review".
 - Delete merged branches. `--delete-branch` on `gh pr merge` handles it; `git fetch --prune`
   clears stale remote refs locally.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,12 +130,9 @@ Two conditions clear a squash.
    gate: on a PR with more it would report nothing while an unresolved thread sat on page two.
    GitHub is the gate; this is a convenience.
 
-`--paginate` on the findings listing is not optional: that endpoint pages at 30 and a
-review-heavy PR truncates silently without it. Pipe to `jq` rather than passing `--jq`, whose
-filter runs once per page. Piped output is merged into one array despite `gh api --help` saying
-"Each page is a separate JSON array" — that describes `--jq` and `--template`. Do not add
-`--slurp` on the strength of that sentence; it wraps the merged array in another array and
-breaks the filter.
+`--paginate` on the findings listing is not optional: that endpoint pages at 30, and a
+review-heavy PR truncates silently without it. The filter there is per-element, so it prints
+every finding whichever way the pages arrive.
 
 One green state, everything else not green: anything other than a 👍 newer than your trigger
 sends you to read the findings, whose worst case is a wasted look. Earlier versions of this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,15 +114,21 @@ Two conditions clear a squash.
    ```sh
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
    ```
-3. **Leave no unresolved thread.** The 👍 speaks only for the latest run, so a finding you never
-   answered from an earlier round does not reopen it. Resolution state is GraphQL-only:
+3. **Resolve every thread you have answered.** The 👍 speaks only for the latest run, so a
+   finding left unanswered from an earlier round does not stop a later clean one. This half is
+   **enforced rather than checked**: the `main` ruleset sets `required_review_thread_resolution`,
+   so an unresolved thread blocks the squash server-side and no client-side count can clear it
+   by mistake. Resolve one by passing its `id` to the `resolveReviewThread` mutation.
+
+   To read what is still open — for answering, not for deciding:
    ```sh
    gh api graphql -f query='query { repository(owner: "rdotsch", name: "rcicr") {
-     pullRequest(number: <n>) { reviewThreads(first: 100) { nodes { isResolved } } } } }' \
-     --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+     pullRequest(number: <n>) { reviewThreads(first: 100) { nodes { id isResolved path } } } } }' \
+     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
    ```
-   Zero clears it. Resolve a thread you have answered by passing its `id` (same query, add `id`
-   to the node fields) to the `resolveReviewThread` mutation.
+   That reads the first 100 threads and does not paginate, which is why it must not be the
+   gate: on a PR with more it would report nothing while an unresolved thread sat on page two.
+   GitHub is the gate; this is a convenience.
 
 `--paginate` on the findings listing is not optional: that endpoint pages at 30 and a
 review-heavy PR truncates silently without it. Pipe to `jq` rather than passing `--jq`, whose
@@ -131,11 +137,14 @@ filter runs once per page. Piped output is merged into one array despite `gh api
 `--slurp` on the strength of that sentence; it wraps the merged array in another array and
 breaks the filter.
 
-Every state that is not "👍 after your trigger, no unresolved threads" routes to reading the
-findings, whose worst case is a wasted look. Earlier versions of this section computed
-completion from review objects and `commit_id` and were wrong five separate ways — reporting a
-clean run as unfinished, an unrelated bot comment as clean, and hiding a reply because replies
-inherit the parent thread's commit. One green state, everything else not green.
+One green state, everything else not green: anything other than a 👍 newer than your trigger
+sends you to read the findings, whose worst case is a wasted look. Earlier versions of this
+section computed completion from review objects and `commit_id` and were wrong six separate
+ways — reporting a clean run as unfinished, an unrelated bot comment as clean, and hiding a
+reply because replies inherit the parent thread's commit. The lesson each time was the same:
+a client-side predicate that answers "is this safe to merge" fails open. The reaction is the
+one signal Codex sets deliberately, and thread resolution is enforced by GitHub rather than
+counted here.
 
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,10 +107,14 @@ Two conditions clear a squash.
    no reaction at all when it has findings.
    ```sh
    gh api repos/rdotsch/rcicr/issues/<n>/reactions \
-     --jq '.[] | select(.user.login|test("codex")) | "\(.content) \(.created_at)"'
+     --jq '.[] | select(.user.id == 199175422) | "\(.user.login) \(.content) \(.created_at)"'
    ```
    Only a `+1` dated after `$trig` clears it. 👀, nothing, and an older `+1` all mean not
-   cleared — read the findings and answer each one:
+   cleared. The filter is Codex's numeric account id (`chatgpt-codex-connector[bot]`, printed
+   back so you can see whose reaction cleared the gate) because reactions are open to anyone
+   with read access: a substring match on the login would let any account containing "codex"
+   clear a review that is still running, and an id survives a rename besides. When not cleared,
+   read the findings and answer each one:
    ```sh
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,18 +112,28 @@ you anything. What does:
    trig=$(gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
      jq -r '[.[] | select((.user.type != "Bot") and (.body|test("@codex review")))] | last | .created_at')
 
-   # finished with nothing to say -> a new "Codex Review: Didn't find any major issues"
+   # finished with nothing to say -> a new "Didn't find any major issues" comment
    gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
-     jq --arg t "$trig" '[.[] | select((.user.type=="Bot") and .created_at > $t)] | length'
+     jq --arg t "$trig" '[.[] | select((.user.login|test("codex")) and .created_at > $t
+                          and (.body|test("Didn.t find any major issues")))] | length'
 
    # found something -> a new review object
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/reviews |
-     jq --arg t "$trig" '[.[] | select((.user.type=="Bot") and .submitted_at > $t)] | length'
+     jq --arg t "$trig" '[.[] | select((.user.login|test("codex")) and .submitted_at > $t)] | length'
    ```
    Non-zero on the first means clean; non-zero on the second means there are findings to read;
-   both zero means it is still running. Filter on `.user.type` rather than matching the comment
-   body alone — the bot quotes the string `@codex review` in its own help text, so a naive
-   match picks up its announcement as your trigger and dates the wait from the wrong event.
+   both zero means it is still running. Each predicate is narrow on purpose, and both ways of
+   loosening it have already produced a wrong answer here:
+
+   - **Match the trigger by author, not by body text alone.** Codex quotes the string
+     `@codex review` in its own help text, so a body match selects its announcement as your
+     trigger and dates the wait from the wrong event.
+   - **Match the response to Codex specifically, and the clean verdict to its wording.** "Any
+     bot" is too broad in both directions: `codecov.yml` enables PR comments, and Codex itself
+     posts issue comments that are not verdicts — on the PR that added this paragraph it left
+     a `### Summary` comment while a `P2` finding was open, which an "any bot comment" test
+     read as a clean run.
+
    The 👀/👍 reaction on the PR body is the same signal in glanceable form, and fine for a human
    reading the page.
 3. **Read only the findings at your head**, then answer each thread — fixing it, or saying why

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,26 +99,43 @@ you anything. What does:
 1. **Push everything first, then comment `@codex review`.** A push does not re-trigger the
    review — only that comment, opening the PR, or marking a draft ready does — so anything
    pushed afterwards goes unreviewed against a review pinned to an older commit.
-2. **Wait for a review submitted against your head.** The previous round's comments are
-   returned immediately and look exactly like a result, so an unfiltered read cannot tell a
-   finished re-review from a running one. Reviews and comments both carry `commit_id`:
+2. **Wait for a result newer than your own trigger comment.** On a PR reviewed once already —
+   the normal case, since you only ask again after fixing something — the previous round's
+   findings, 👍 and announcement are all still sitting there, and a re-review that has not
+   started yet looks exactly like one that finished clean. Two things make that hard to get
+   right. **Codex creates a review object only when it finds something**, so counting reviews
+   can never confirm a clean run; and **no timestamp on the review side can be compared to a
+   commit's**, because a commit records local authoring rather than the push. Your trigger
+   comment solves both: it is a server-side timestamp on the same clock as the bot's, and it
+   necessarily postdates your push.
+   ```sh
+   trig=$(gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
+     jq -r '[.[] | select((.user.type != "Bot") and (.body|test("@codex review")))] | last | .created_at')
+
+   # finished with nothing to say -> a new "Codex Review: Didn't find any major issues"
+   gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
+     jq --arg t "$trig" '[.[] | select((.user.type=="Bot") and .created_at > $t)] | length'
+
+   # found something -> a new review object
+   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/reviews |
+     jq --arg t "$trig" '[.[] | select((.user.type=="Bot") and .submitted_at > $t)] | length'
+   ```
+   Non-zero on the first means clean; non-zero on the second means there are findings to read;
+   both zero means it is still running. Filter on `.user.type` rather than matching the comment
+   body alone — the bot quotes the string `@codex review` in its own help text, so a naive
+   match picks up its announcement as your trigger and dates the wait from the wrong event.
+   The 👀/👍 reaction on the PR body is the same signal in glanceable form, and fine for a human
+   reading the page.
+3. **Read only the findings at your head**, then answer each thread — fixing it, or saying why
+   not — before you squash. The findings carry `commit_id`, so the earlier rounds' comments
+   filter themselves out:
    ```sh
    head=$(git rev-parse HEAD)
-   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/reviews |
-     jq --arg head "$head" '[.[] | select(.commit_id == $head and (.user.login|test("codex")))] | length'
-   ```
-   Zero means it has not finished. The other completion signal is the reaction on the PR body
-   (`.../issues/<n>/reactions`): 👀 while the review runs, replaced by 👍 when it finishes with
-   nothing to say. Do not try to date that reaction against a commit — a commit timestamp
-   records local authoring, not the push, so a stale 👍 can look current.
-3. **Read only the findings at that head**, then answer each thread — fixing it, or saying why
-   not — before you squash:
-   ```sh
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments |
      jq -r --arg head "$head" '.[] | select(.commit_id == $head) | "\(.path):\(.line)  \(.body)"'
    ```
-Both commands need `--paginate`: these endpoints page at 30, and a review-heavy PR truncates
-silently without it. Both also pipe to `jq` rather than passing `--jq`, and that distinction is
+All of these need `--paginate`: these endpoints page at 30, and a review-heavy PR truncates
+silently without it. They also all pipe to `jq` rather than passing `--jq`, and that distinction is
 load-bearing — `gh api`'s own filter runs once per page, so `--jq 'length'` reports a count per
 page rather than a total. **Piped output does not have that problem**, whatever `gh api --help`
 suggests when it says "Each page is a separate JSON array": that describes `--jq` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,73 +86,56 @@ attaching a real face photo.
 
 ### The Codex review
 
-Codex reviews pull requests here and has caught real errors (#170, #172, #173). Nothing in the
-merge path makes you notice it, so read it deliberately before squashing.
+Codex reviews pull requests here and has caught real errors (#170, #172, #173, and three on the
+PR that wrote this section). Nothing in the merge path makes you notice it: it submits as
+`COMMENTED`, so it never blocks and `reviewDecision` stays empty; `gh pr checks` is green
+regardless; and `gh pr view --comments` shows only the review wrapper, never the findings.
 
-- **It never blocks, and must not become something that can.** It submits as `COMMENTED`, so
-  `reviewDecision` stays empty; it is not a required check; no approval is required. If it has
-  been switched off, or simply is not answering, merge on the other checks.
-The findings are inline review comments badged `P1`–`P3`. `gh pr checks` stays green
-regardless and `gh pr view --comments` shows only the review wrapper, so neither surface tells
-you anything. What does:
+**It must not become something that can block.** If it has been switched off, or simply is not
+answering, merge on the other checks.
 
-1. **Push everything first, then comment `@codex review`.** A push does not re-trigger the
-   review — only that comment, opening the PR, or marking a draft ready does — so anything
-   pushed afterwards goes unreviewed against a review pinned to an older commit.
-2. **Wait for a result newer than your own trigger comment.** On a PR reviewed once already —
-   the normal case, since you only ask again after fixing something — the previous round's
-   findings, 👍 and announcement are all still sitting there, and a re-review that has not
-   started yet looks exactly like one that finished clean. Two things make that hard to get
-   right. **Codex creates a review object only when it finds something**, so counting reviews
-   can never confirm a clean run; and **no timestamp on the review side can be compared to a
-   commit's**, because a commit records local authoring rather than the push. Your trigger
-   comment solves both: it is a server-side timestamp on the same clock as the bot's, and it
-   necessarily postdates your push.
+Two conditions clear a squash.
+
+1. **Push everything, then trigger, keeping the timestamp.** A push does not re-trigger the
+   review — only this comment, opening the PR, or marking a draft ready does. Posting it
+   returns the anchor you need:
    ```sh
-   trig=$(gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
-     jq -r '[.[] | select((.user.type != "Bot") and (.body|test("@codex review")))] | last | .created_at')
-
-   # finished with nothing to say -> a new "Didn't find any major issues" comment
-   gh api --paginate repos/rdotsch/rcicr/issues/<n>/comments |
-     jq --arg t "$trig" '[.[] | select((.user.login|test("codex")) and .created_at > $t
-                          and (.body|test("Didn.t find any major issues")))] | length'
-
-   # found something -> a new review object
-   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/reviews |
-     jq --arg t "$trig" '[.[] | select((.user.login|test("codex")) and .submitted_at > $t)] | length'
+   trig=$(gh api repos/rdotsch/rcicr/issues/<n>/comments -f body='@codex review' --jq '.created_at')
    ```
-   Non-zero on the first means clean; non-zero on the second means there are findings to read;
-   both zero means it is still running. Each predicate is narrow on purpose, and both ways of
-   loosening it have already produced a wrong answer here:
-
-   - **Match the trigger by author, not by body text alone.** Codex quotes the string
-     `@codex review` in its own help text, so a body match selects its announcement as your
-     trigger and dates the wait from the wrong event.
-   - **Match the response to Codex specifically, and the clean verdict to its wording.** "Any
-     bot" is too broad in both directions: `codecov.yml` enables PR comments, and Codex itself
-     posts issue comments that are not verdicts — on the PR that added this paragraph it left
-     a `### Summary` comment while a `P2` finding was open, which an "any bot comment" test
-     read as a clean run.
-
-   The 👀/👍 reaction on the PR body is the same signal in glanceable form, and fine for a human
-   reading the page.
-3. **Read only the findings at your head**, then answer each thread — fixing it, or saying why
-   not — before you squash. The findings carry `commit_id`, so the earlier rounds' comments
-   filter themselves out:
+2. **Wait for a 👍 newer than `$trig`.** The reaction on the PR body tracks the *latest run*
+   rather than the PR's history: 👀 while it runs, 👍 when it finishes with nothing to say, and
+   no reaction at all when it has findings.
    ```sh
-   head=$(git rev-parse HEAD)
-   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments |
-     jq -r --arg head "$head" '.[] | select(.commit_id == $head) | "\(.path):\(.line)  \(.body)"'
+   gh api repos/rdotsch/rcicr/issues/<n>/reactions \
+     --jq '.[] | select(.user.login|test("codex")) | "\(.content) \(.created_at)"'
    ```
-All of these need `--paginate`: these endpoints page at 30, and a review-heavy PR truncates
-silently without it. They also all pipe to `jq` rather than passing `--jq`, and that distinction is
-load-bearing — `gh api`'s own filter runs once per page, so `--jq 'length'` reports a count per
-page rather than a total. **Piped output does not have that problem**, whatever `gh api --help`
-suggests when it says "Each page is a separate JSON array": that describes `--jq` and
-`--template`, and `gh` merges the pages before writing to stdout. Measured against 197 issues —
-piped, one array of 197; `--jq 'length'`, `100` then `97`. Do not "fix" these commands by adding
-`--slurp` on the strength of the help text; it would wrap the merged array in another array and
-break the filters.
+   Only a `+1` dated after `$trig` clears it. 👀, nothing, and an older `+1` all mean not
+   cleared — read the findings and answer each one:
+   ```sh
+   gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
+   ```
+3. **Leave no unresolved thread.** The 👍 speaks only for the latest run, so a finding you never
+   answered from an earlier round does not reopen it. Resolution state is GraphQL-only:
+   ```sh
+   gh api graphql -f query='query { repository(owner: "rdotsch", name: "rcicr") {
+     pullRequest(number: <n>) { reviewThreads(first: 100) { nodes { isResolved } } } } }' \
+     --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length'
+   ```
+   Zero clears it. Resolve a thread you have answered by passing its `id` (same query, add `id`
+   to the node fields) to the `resolveReviewThread` mutation.
+
+`--paginate` on the findings listing is not optional: that endpoint pages at 30 and a
+review-heavy PR truncates silently without it. Pipe to `jq` rather than passing `--jq`, whose
+filter runs once per page. Piped output is merged into one array despite `gh api --help` saying
+"Each page is a separate JSON array" — that describes `--jq` and `--template`. Do not add
+`--slurp` on the strength of that sentence; it wraps the merged array in another array and
+breaks the filter.
+
+Every state that is not "👍 after your trigger, no unresolved threads" routes to reading the
+findings, whose worst case is a wasted look. Earlier versions of this section computed
+completion from review objects and `commit_id` and were wrong five separate ways — reporting a
+clean run as unfinished, an unrelated bot comment as clean, and hiding a reply because replies
+inherit the parent thread's commit. One green state, everything else not green.
 
 CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
 runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately


### PR DESCRIPTION
Replaces #196's scripted completion logic entirely, rather than patching it a sixth time.

## Why not patch

Computing "has it finished" from review objects and `commit_id` was wrong in **six** distinct ways, each found by the next round of review:

1. a push does not re-trigger the review
2. a reaction timestamp cannot be compared to a commit timestamp (commits record local authoring, not the push)
3. a mid-rerun read returns the previous round's findings, indistinguishable from a fresh result
4. **a clean run creates no review object at all** — so "zero reviews at head" read a clean review as unfinished
5. "any bot comment" counted an unrelated bot as a clean verdict (`codecov.yml:11-13` enables PR comments; Codex also posts non-verdict comments — it left a `### Summary` while its own P2 was open)
6. filtering findings by `commit_id` **hides replies**, which inherit the parent thread's commit and never match the current head

## What replaces it

The reaction already encodes the answer, and tracks the *latest run* rather than the PR's history:

| PR | findings | reaction |
|---|---|---|
| #171 | 0 | 👍 |
| #198 | 0 | 👍 |
| #195 | 1 | none |
| #196 | 5 | none |
| **#199** | **2, since fixed** | **👍, dated after the trigger** |

Two conditions clear a squash, one command each:

- **A 👍 dated after your trigger.** The trigger is posted with `gh api ... -f body='@codex review' --jq '.created_at'`, which returns the anchor — no body-matching, which is what picked up Codex's own help text quoting `@codex review`.
- **No unresolved review thread.** This covers what the reaction cannot: an earlier finding left unanswered does not prevent a later clean run. Resolution state is GraphQL-only.

Every other state — 👀, no reaction, an older 👍, any unresolved thread — routes to reading the findings, whose worst case is a wasted look. The old version's worst case was a false clean.

Both queries were run verbatim against #199 before committing, and the trigger command's response shape was verified by using it to request this PR's own review.

## Also

Corrects a stale claim: squash merges **are** enforced by the `main` ruleset (`allowed_merge_methods: ["squash"]`), not left to whoever merges. `AGENTS.md` said the opposite.

## Optional follow-up, needs a maintainer

`required_review_thread_resolution` is `false` on ruleset "Protect main" (`19791793`). Turning it on makes condition 2 enforced rather than documented, and it is **outage-safe**: if Codex is switched off it posts no threads, so there is nothing to resolve and nothing blocks. The gate only engages when findings actually exist. Not done here — it is a repo settings change.

`CONTRIBUTING.md` and `AGENTS.md` only (now 157 lines). No `NEWS.md` entry — not user-facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)