### PR TITLE
Validate base images up front and name the entry that is wrong (#180)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -127,6 +127,23 @@ ci$base) / 2`, which is what `save_as_pngs = TRUE` writes.
 **What kept this cheap to undo:** the change was filed under its own "Behaviour change"
 heading rather than slipped in with unambiguous bug fixes. When a fix is debatable, say so.
 
+### `base_face_files` validation rejects two inputs that used to run
+Duplicate names, and a list element that is not a single file name, now stop the call. Both
+ran before, so this is a considered exception to the constraint above rather than a plain bug
+fix — and it is allowed because neither ever produced what the call asked for. `list(face =
+'a.png', face = 'b.png')` looks each name up by string, so it wrote **one** set of stimuli,
+from `a.png`, and nothing from `b.png`; verified against the pre-fix code, four files for two
+trials. A script that "worked" this way was generating stimuli for a base image it never
+named. Every other new check rejects input that already failed, just further downstream —
+inside a parallel worker, as `attempt to select less than one element in get1index`.
+
+**Readability is checked by attempting the read, not by `file.access()`.** The obvious version
+— `file.access(filename, 4)` — is documented as unreliable on Windows and on networked
+filesystems, so it can reject a file that reads fine. `png::readPNG()` / `jpeg::readJPEG()`
+inside `tryCatch()` cannot be wrong about it, and keeping the reader's own message means the
+distinction between "not a PNG" and "permission denied" survives instead of being flattened
+into one guess.
+
 ### `_R_CHECK_LIMIT_CORES_` handling caps cores under check only
 `default_ncores()` returns 2 when that variable is set and `detectCores() - 1` otherwise. Only
 the checker ever sets it, so CRAN's two-core policy is met and behaviour at the console is

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,52 @@
 # rcicr (development version)
 
+## Behaviour changes
+
+- **`generateStimuli2IFC()` now checks `base_face_files` before it generates anything,
+  and names the entry it cannot use.** Four inputs used to get past the old check and
+  fail from inside a parallel worker with `attempt to select less than one element in
+  get1index`, which names neither the argument nor the file: a list with no names, a
+  list with some names missing, an empty list, and an element that is not a single file
+  name. They now stop immediately with a message saying which entry is wrong and why.
+
+  One of them could previously appear to work. **A `base_face_files` with two entries
+  under the same name silently dropped all but the first** — the loop looked each name
+  up by string, so `list(face = 'a.png', face = 'b.png')` produced one set of stimuli,
+  from `a.png`, and nothing at all from `b.png`. That is now an error naming the
+  duplicated name. If you have a script that relies on it, the stimuli it produced were
+  never what the call asked for; give each base image its own name.
+
+- **The PNG-or-JPEG test now looks at the file extension rather than anywhere in the
+  path.** It was `grepl('png|PNG', filename)` against the whole path, so a JPEG stored
+  under a directory called `png` was handed to `png::readPNG()` and died with `file is
+  not in PNG format`, blaming the file for a choice the package had made. Files are now
+  recognised by a `.png`, `.jpg` or `.jpeg` extension, case-insensitively. A base image
+  whose *extension* does not say what it is is rejected up front, by name, instead of
+  reaching a reader that cannot parse it.
+
+## Bug fixes
+
+- **The `base_face_files` type check raises an error you can actually read.** It wrote
+  its explanation to `stderr()` and then called `stop()` with no arguments, so the
+  condition it raised carried an empty message: `conditionMessage()` returned `""`, and
+  anything wrapping the call — a Shiny app, a batch script, knitr — caught an error it
+  could not report. Under `sink()` or `capture.output(type = "message")` the explanation
+  could be separated from the failure entirely. The text now travels with the condition.
+
+- **A base image that cannot be read is reported with the file it came from.** The
+  reader's own complaint (`file is not in PNG format`, and the like) is kept and
+  prefixed with the entry's name and path, and a file that does not exist is now
+  reported as missing rather than as unopenable.
+
+- **Base images are validated before the noise basis is built and before the output
+  directory is created.** A mistyped path used to cost the full noise-pattern
+  computation — appreciable at the default 512px — and left an empty stimulus directory
+  behind before reporting the problem.
+
+  No numeric output changes. Every check here either replaces an error with a clearer
+  error, or rejects input that could not have produced correct stimuli; a call that
+  succeeds today produces exactly what it did before.
+
 # rcicr 1.2.3 (2026-08-07)
 
 **Documentation only. Nothing this package computes has changed** — no function,

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -13,7 +13,7 @@
 #' @import doParallel
 #' @importFrom stats setNames runif
 #' @importFrom utils txtProgressBar setTxtProgressBar
-#' @param base_face_files List containing base face file names used as base images for stimuli. Accepts JPEG and PNG images.
+#' @param base_face_files Named list of base face file names used as base images for stimuli, e.g. \code{list(aName = 'baseface.jpg')}. Accepts JPEG and PNG images, recognised by a \code{.png}, \code{.jpg} or \code{.jpeg} extension. Each name labels that base image's stimulus files and indexes the .Rdata file that \code{\link{generateCI}} reads back, so every element must be named, and named uniquely. Each image must be square and exactly \code{img_size} by \code{img_size} pixels: rcicr does not resize base images. All of this is checked before any stimuli are generated, and the message names the offending entry.
 #' @param n_trials Number specifying how many trials the task will have (function will generate two images for each trial per base image: original and inverted/negative noise).
 #' @param img_size Number specifying the number of pixels that the stimulus image will span horizontally and vertically (will be square, so only one integer needed).
 #' @param stimulus_path String specifying the directory to save the stimuli and the .Rdata file to. Required unless both \code{save_as_png} and \code{save_rdata} are FALSE; there is no default path. It is created if it does not exist. Use \code{tempdir()} if you only want to try the function out.
@@ -55,56 +55,32 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
                 'function out.'))
   }
 
-  # Initialize #
-  p <- generateNoisePattern(img_size, noise_type=noise_type, nscales=nscales, sigma=sigma)
+  validateBaseFaceFiles(base_face_files)
 
-  # Only create the directory when something is written to it.
-  # generateReferenceDistribution2IFC() calls this with both save flags FALSE
-  # and used to leave a stray ./stimuli directory behind.
-  if (writes_to_disk) {
-    dir.create(stimulus_path, recursive = TRUE, showWarnings = FALSE)
-  } else if (missing(stimulus_path)) {
-    # Bind it anyway. stimulus_path appears in the %dopar% body below, and
-    # foreach exports every free variable of that body to the workers -- which
-    # means get()ting it, and a missing argument aborts there even though the
-    # branch that uses it cannot run. Never read.
-    stimulus_path <- NA_character_
-  }
-
-  # More depends on this call than the stimuli. generateReferenceDistribution2IFC()
-  # re-generates stimuli through this function and then draws its simulated
-  # responses with runif(), *after* this set.seed() has run - which is what makes
-  # every Informational Value reproducible from the stimulus file alone, and is
-  # documented as a guarantee in ?generateReferenceDistribution2IFC.
-  #
-  # So moving or removing this line, or reseeding after it, changes every InfoVal
-  # ever computed with this package without touching computeInfoVal2IFC() at all.
-  set.seed(seed)
-
-  stimuli_params <- list()
+  # Read and check the base images before anything expensive or side-effecting
+  # runs. The noise basis below takes real time at the default 512px and the
+  # directory is created after it, so a base image that cannot be used is worth
+  # finding out about first.
   base_faces <- list()
-
-  if (!is.list(base_face_files)) {
-    write("Please provide base face file name as named list, e.g. base_face_files=list(aName='baseface.jpg')", stderr())
-    stop()
-  }
 
   for (base_face in names(base_face_files)) {
     # Read base face
     filename <- base_face_files[[base_face]]
-    if (grepl('png|PNG', filename)) {
-      img <- png::readPNG(filename)
-    } else if (grepl('jpeg|JPEG|jpg|JPG', filename)) {
-      img <- jpeg::readJPEG(filename)
-    } else {
-      stop(paste0('Error in reading base image file ',
-                  filename, ': must be a PNG or JPEG file.'))
-    }
+    img_format <- baseImageFormat(filename)
+
+    img <- tryCatch(
+      if (img_format == 'png') png::readPNG(filename) else jpeg::readJPEG(filename),
+      error = function(e) {
+        stop(paste0('Base image "', base_face, '" (', filename, ') could not ',
+                    'be read as ', img_format, ': ', conditionMessage(e)),
+             call. = FALSE)
+      })
 
     # Check if base face is square. If not, throw an error
     if (dim(img)[1] != dim(img)[2]) {
-      stop(paste0('Base face is not square! It\'s ', dim(img)[1], ' by ',
-                  dim(img)[2], ' pixels. Please use a square base face.'))
+      stop(paste0('Base image "', base_face, '" (', filename, ') is not ',
+                  'square! It\'s ', dim(img)[1], ' by ', dim(img)[2],
+                  ' pixels. Please use a square base face.'))
     }
 
     # Change base face to greyscale if necessary
@@ -134,6 +110,34 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
     # Save base image to list
     base_faces[[base_face]] <- img
   }
+
+  # Initialize #
+  p <- generateNoisePattern(img_size, noise_type=noise_type, nscales=nscales, sigma=sigma)
+
+  # Only create the directory when something is written to it.
+  # generateReferenceDistribution2IFC() calls this with both save flags FALSE
+  # and used to leave a stray ./stimuli directory behind.
+  if (writes_to_disk) {
+    dir.create(stimulus_path, recursive = TRUE, showWarnings = FALSE)
+  } else if (missing(stimulus_path)) {
+    # Bind it anyway. stimulus_path appears in the %dopar% body below, and
+    # foreach exports every free variable of that body to the workers -- which
+    # means get()ting it, and a missing argument aborts there even though the
+    # branch that uses it cannot run. Never read.
+    stimulus_path <- NA_character_
+  }
+
+  # More depends on this call than the stimuli. generateReferenceDistribution2IFC()
+  # re-generates stimuli through this function and then draws its simulated
+  # responses with runif(), *after* this set.seed() has run - which is what makes
+  # every Informational Value reproducible from the stimulus file alone, and is
+  # documented as a guarantee in ?generateReferenceDistribution2IFC.
+  #
+  # So moving or removing this line, or reseeding after it, changes every InfoVal
+  # ever computed with this package without touching computeInfoVal2IFC() at all.
+  set.seed(seed)
+
+  stimuli_params <- list()
 
   # Compute number of parameters needed  #
   nparams <- sum(6*2*(2^(0:(nscales-1)))^2)
@@ -265,4 +269,89 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
   if (return_as_dataframe) {
     return(stims)
   }
+}
+
+# Which reader a base image file needs, from its extension: 'png', 'jpeg', or
+# NA for anything else.
+#
+# Anchored to the extension deliberately. This test used to be
+# grepl('png|PNG', filename) against the whole path, which matches anywhere in
+# it -- so a JPEG under a directory named "png" was handed to png::readPNG() and
+# failed with a format error that named neither the real problem nor the choice
+# this code had made on the user's behalf.
+baseImageFormat <- function(filename) {
+  if (grepl('\\.png$', filename, ignore.case = TRUE)) {
+    return('png')
+  }
+  if (grepl('\\.jpe?g$', filename, ignore.case = TRUE)) {
+    return('jpeg')
+  }
+  NA_character_
+}
+
+# Check base_face_files before generateStimuli2IFC() does any expensive or
+# side-effecting work, and name the offending entry when something is wrong.
+#
+# Every branch here used to surface far from its cause. A non-list wrote its
+# explanation to stderr() and then called a bare stop(), so the condition it
+# raised carried an *empty* message: anything wrapping the call -- a Shiny app,
+# a batch script, knitr -- caught an error it could not report, and under sink()
+# or capture.output(type = 'message') the explanation could be separated from
+# the failure entirely. An unnamed or empty list passed that check and got as
+# far as the parallel workers, failing there with "attempt to select less than
+# one element in get1index", which names neither the argument nor the file.
+# See issues #124 and #180.
+validateBaseFaceFiles <- function(base_face_files) {
+  example <- 'e.g. base_face_files = list(aName = "baseface.jpg")'
+
+  if (!is.list(base_face_files)) {
+    stop(paste0('base_face_files must be a named list, ', example,
+                '. It is of class ',
+                paste(class(base_face_files), collapse = '/'), '.'))
+  }
+
+  if (length(base_face_files) == 0) {
+    stop(paste0('base_face_files is empty. Supply at least one base image, ',
+                example, '.'))
+  }
+
+  nms <- names(base_face_files)
+  if (is.null(nms) || any(is.na(nms) | nms == '')) {
+    stop(paste0('Every element of base_face_files must be named. The names ',
+                'label the stimulus files and index the .Rdata file that ',
+                'generateCI() reads back, so they cannot be left off: ',
+                example, '.'))
+  }
+
+  if (anyDuplicated(nms)) {
+    stop(paste0('base_face_files has duplicate names (',
+                paste(unique(nms[duplicated(nms)]), collapse = ', '),
+                '). Only the first entry under each name would be used, and ',
+                'the rest would be silently skipped, so give every base image ',
+                'its own name.'))
+  }
+
+  for (base_face in nms) {
+    filename <- base_face_files[[base_face]]
+
+    if (!is.character(filename) || length(filename) != 1 || is.na(filename)) {
+      stop(paste0('Base image "', base_face, '" must be a single file name, ',
+                  'but it is of class ', paste(class(filename), collapse = '/'),
+                  ' and length ', length(filename), '. ', example, '.'))
+    }
+
+    if (is.na(baseImageFormat(filename))) {
+      stop(paste0('Base image "', base_face, '" (', filename, ') must be a ',
+                  'PNG or JPEG file, named with a .png, .jpg or .jpeg ',
+                  'extension.'))
+    }
+
+    if (!file.exists(filename)) {
+      stop(paste0('Base image "', base_face, '" does not exist: ', filename,
+                  '. Paths are resolved relative to the working directory, ',
+                  getwd(), '.'))
+    }
+  }
+
+  invisible(TRUE)
 }

--- a/man/generateStimuli2IFC.Rd
+++ b/man/generateStimuli2IFC.Rd
@@ -23,7 +23,7 @@ generateStimuli2IFC(
 )
 }
 \arguments{
-\item{base_face_files}{List containing base face file names used as base images for stimuli. Accepts JPEG and PNG images.}
+\item{base_face_files}{Named list of base face file names used as base images for stimuli, e.g. \code{list(aName = 'baseface.jpg')}. Accepts JPEG and PNG images, recognised by a \code{.png}, \code{.jpg} or \code{.jpeg} extension. Each name labels that base image's stimulus files and indexes the .Rdata file that \code{\link{generateCI}} reads back, so every element must be named, and named uniquely. Each image must be square and exactly \code{img_size} by \code{img_size} pixels: rcicr does not resize base images. All of this is checked before any stimuli are generated, and the message names the offending entry.}
 
 \item{n_trials}{Number specifying how many trials the task will have (function will generate two images for each trial per base image: original and inverted/negative noise).}
 

--- a/tests/testthat/test-error-paths.R
+++ b/tests/testthat/test-error-paths.R
@@ -262,16 +262,92 @@ test_that("generateStimuli2IFC rejects base_face_files that is not a list", {
   dir <- withr::local_tempdir()
   png <- make_square_png(file.path(dir, "base.png"), size = 32)
 
-  # This one calls stop() with no arguments after writing its explanation to
-  # stderr(), so the condition carries an *empty* message and no regexp can
-  # match it. Asserting only that it errors is the most this path allows;
-  # giving it a real message is the same class of work as #180.
-  expect_error(
-    suppressWarnings(
-      generateStimuli2IFC(base_face_files = png, n_trials = 2, img_size = 32,
-                          stimulus_path = dir, ncores = 1,
-                          save_as_png = FALSE, save_rdata = FALSE)
-    )
+  # This used to write its explanation to stderr() and then call stop() with no
+  # arguments, so the condition carried an *empty* message: a caller could not
+  # report why it failed, and this test could assert nothing beyond "it errors".
+  # Match on the message, not just the failure -- an unpatterned expect_error()
+  # passes when the function breaks for an entirely unrelated reason (#180).
+  err <- expect_error(
+    generateStimuli2IFC(base_face_files = png, n_trials = 2, img_size = 32,
+                        stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE),
+    "base_face_files must be a named list"
+  )
+  expect_match(conditionMessage(err), "character")
+})
+
+test_that("generateStimuli2IFC rejects an unnamed or empty base_face_files", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  png <- make_square_png(file.path(dir, "base.png"), size = 32)
+
+  gen <- function(files) {
+    generateStimuli2IFC(base_face_files = files, n_trials = 2, img_size = 32,
+                        stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE)
+  }
+
+  # All three used to get past the type check and fail inside the parallel
+  # workers with "attempt to select less than one element in get1index", naming
+  # neither the argument nor the file -- issue #124's shape.
+  expect_error(gen(list()), "base_face_files is empty")
+  expect_error(gen(list(png)), "must be named")
+  expect_error(gen(list(base = png, png)), "must be named")
+
+  # A duplicate name silently dropped every entry after the first.
+  expect_error(gen(list(base = png, base = png)), "duplicate names")
+})
+
+test_that("generateStimuli2IFC names the base image it cannot use", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  ok <- make_square_png(file.path(dir, "base.png"), size = 32)
+
+  gen <- function(files) {
+    generateStimuli2IFC(base_face_files = files, n_trials = 2, img_size = 32,
+                        stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE)
+  }
+
+  # Every message identifies the offending entry by its name, so a run over
+  # several base images says which one is wrong.
+  expect_error(gen(list(good = ok, oblong = 42)),
+               'Base image "oblong" must be a single file name')
+
+  missing <- file.path(dir, "absent.png")
+  err <- expect_error(gen(list(good = ok, gone = missing)),
+                      'Base image "gone" does not exist')
+  expect_match(conditionMessage(err), "absent\\.png")
+
+  # Present, correctly named, and not actually a PNG: the reader's own
+  # complaint is kept, with the file it came from attached.
+  corrupt <- file.path(dir, "corrupt.png")
+  writeLines("not a PNG", corrupt)
+  err <- expect_error(gen(list(bad = corrupt)), 'Base image "bad"')
+  expect_match(conditionMessage(err), "could not be read")
+  expect_match(conditionMessage(err), "not in PNG format")
+})
+
+test_that("generateStimuli2IFC picks the reader from the extension, not the path", {
+  skip_if_not_installed("withr")
+  skip_if_not_installed("jpeg")
+
+  dir <- withr::local_tempdir()
+
+  # A JPEG under a directory called "png". The old test was
+  # grepl('png|PNG', filename) against the whole path, so this file was handed
+  # to png::readPNG() and died with "file is not in PNG format".
+  sub <- file.path(dir, "png")
+  dir.create(sub)
+  path <- file.path(sub, "face.jpg")
+  jpeg::writeJPEG(matrix(0.5, 32, 32), path)
+
+  expect_no_error(
+    generateStimuli2IFC(base_face_files = list(base = path), n_trials = 2,
+                        img_size = 32, stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE)
   )
 })
 


### PR DESCRIPTION
Closes #180 — both checkboxes.

`generateStimuli2IFC()` now checks `base_face_files` before it builds the noise basis
or creates the output directory, and every message names the offending entry and its
path.

## The bare `stop()`

The type check wrote its explanation to `stderr()` and then called `stop()` with no
arguments, so the condition carried an **empty** message — `conditionMessage()` returned
`""`. Anything wrapping the call caught an error it could not report, and under `sink()`
or `capture.output(type = "message")` the explanation could be separated from the failure
entirely. This was the only bare `stop()` and the only `stderr()` write in `R/`.

`tests/testthat/test-error-paths.R` can now match on the message. It previously had a
bare `expect_error()`, which passes when the function breaks for any unrelated reason.

## What the old code actually did

Probed rather than assumed. Four inputs got past the old `is.list()` check and failed
inside a parallel worker with `attempt to select less than one element in get1index`,
naming neither the argument nor the file — #124's shape exactly.

| input | before | now |
|---|---|---|
| `list(p)` — unnamed | worker: `get1index` | "Every element of `base_face_files` must be named" |
| `list(a = p, p)` — partly named | worker: `get1index` | same |
| `list()` | worker: `get1index` | "`base_face_files` is empty" |
| `list(a = 42)` | worker: `get1index` | names the entry, its class and its length |
| `c(a = p)` — not a list | empty message | names the class it got |
| missing file | `unable to open <path>` | names the entry, the path and `getwd()` |
| corrupt file | `file is not in PNG format` | same text, prefixed with entry and path |

## One behaviour change worth review

`list(face = 'a.png', face = 'b.png')` used to *appear* to work. The loop looks each name
up by string, so it wrote **one** set of stimuli, from `a.png`, and nothing from `b.png`.
Verified against the pre-fix code with `git stash push -- R/`: four files for two trials,
and the surviving image is `a`'s ramp, not `b`'s.

It is now an error naming the duplicated name. A script relying on it was generating
stimuli for a base image it never named, so this sits within the guiding constraint
rather than against it — but it is filed under its own "Behaviour changes" heading in
`NEWS.md` with the migration spelled out, per the `autoscale()` precedent in
`DECISIONS.md`.

## Two fixes not on the checklist, in the lines this touches

- **The format test looked at the whole path.** `grepl('png|PNG', filename)` matches
  anywhere in it, so a JPEG under a directory called `png` was handed to
  `png::readPNG()` and died with `file is not in PNG format` — blaming the file for a
  choice the package had made. Confirmed, then anchored to the extension
  (`.png`/`.jpg`/`.jpeg`, case-insensitive).
- **Validation now runs before the expensive work.** A mistyped path used to cost the
  full noise-pattern computation — appreciable at the default 512px — and left an empty
  stimulus directory behind before reporting the problem.

## Rejected alternative

`file.access(filename, 4)` for the readability check. It is documented as unreliable on
Windows and on networked filesystems, so it can reject a file that reads fine.
Attempting the read inside `tryCatch()` cannot be wrong about it, and keeping the
reader's own message means "not a PNG" stays distinguishable from "permission denied".
Recorded in `DECISIONS.md` alongside the duplicate-name reasoning.

## Reproducibility

**No numeric output changes.** `set.seed()` and both `%dopar%` loops are untouched, and
the base-image loop that now runs before them consumes no random numbers — so the RNG
state at the first `runif()` is identical. The golden master in
`test-regression-baseline.R` passes unchanged, which is the evidence for that rather
than the argument.

Full suite: 365 tests, 0 failures, 0 warnings, 0 skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
