### PR TITLE
Reject a base image with no contrast instead of silently making it NaN (#176)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,19 @@
 
 ## Bug fixes
 
+- **A base image with no contrast no longer becomes an all-`NaN` base image.** Under
+  `maximize_baseimage_contrast = TRUE`, the default, `generateStimuli2IFC()` rescales
+  with `(img - min(img)) / (max(img) - min(img))` — which is 0/0 when every pixel is the
+  same value. The resulting `NaN` base face was written into the `.Rdata` with no error
+  and no warning, every classification image computed from that stimulus set inherited
+  it, and the stimuli themselves came out uniformly black, `png::writePNG()` clamping
+  `NaN` to zero. It now stops with an error naming the file.
+
+  A photograph is never uniform, so this bit synthetic and accidentally-blank base
+  images — but it failed silently, and the symptom appeared a long way from the cause.
+  The error fires only under `maximize_baseimage_contrast = TRUE`: a flat base image is
+  perfectly usable with the rescale switched off, and the message says so.
+
 - **The `base_face_files` type check raises an error you can actually read.** It wrote
   its explanation to `stderr()` and then called `stop()` with no arguments, so the
   condition it raised carried an empty message: `conditionMessage()` returned `""`, and

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -20,7 +20,7 @@
 #' @param label Label to prepend to each file for your convenience.
 #' @param use_same_parameters Boolean specifying whether for each base image the same set of parameters is used (TRUE) or a unique set is created for each base image (FALSE).
 #' @param seed Integer seeding the random number generator (for reproducibility).
-#' @param maximize_baseimage_contrast Boolean specifying whether the pixel values of the base image should be rescaled to maximize its contrast.
+#' @param maximize_baseimage_contrast Boolean specifying whether the pixel values of the base image should be rescaled to maximize its contrast. A base image with no contrast at all — every pixel the same value — has nothing to rescale, and is rejected with an error rather than silently turned into an all-\code{NaN} base image. Such an image is still usable with \code{maximize_baseimage_contrast = FALSE}.
 #' @param noise_type String specifying noise pattern type (defaults to \code{sinusoid}; other options: \code{gabor}).
 #' @param nscales Integer specifying the number of incremental spatial scales. Defaults to 5. Higher numbers will add higher spatial frequency scales.
 #' @param sigma Number specifying the sigma of the Gabor patch if noise_type is set to \code{gabor} (defaults to 25).
@@ -57,10 +57,8 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
 
   validateBaseFaceFiles(base_face_files)
 
-  # Read and check the base images before anything expensive or side-effecting
-  # runs. The noise basis below takes real time at the default 512px and the
-  # directory is created after it, so a base image that cannot be used is worth
-  # finding out about first.
+  # Before the noise basis, which is slow at the default 512px, and before the
+  # directory is created.
   base_faces <- list()
 
   for (base_face in names(base_face_files)) {
@@ -104,6 +102,19 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
 
     # If necessary, rescale to maximize contrast
     if (maximize_baseimage_contrast) {
+      # (img - min) / (max - min) is 0/0 on a uniform image, and the all-NaN
+      # base face went into the .Rdata unremarked (#176). Only an error here:
+      # with the rescale off a flat base image is usable and produces valid
+      # stimuli, so rejecting it outright would break a legitimate call.
+      if (max(img) == min(img)) {
+        stop(paste0('Base image "', base_face, '" (', filename, ') has no ',
+                    'contrast: every pixel is ', min(img), '. Contrast cannot ',
+                    'be maximized on a uniform image, and doing so would make ',
+                    'the base image entirely NaN. Use a base image with some ',
+                    'variation, or call generateStimuli2IFC() with ',
+                    'maximize_baseimage_contrast = FALSE.'))
+      }
+
       img <- (img - min(img)) / (max(img) - min(img))
     }
 
@@ -271,14 +282,10 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
   }
 }
 
-# Which reader a base image file needs, from its extension: 'png', 'jpeg', or
-# NA for anything else.
+# Which reader a base image needs: 'png', 'jpeg', or NA.
 #
-# Anchored to the extension deliberately. This test used to be
-# grepl('png|PNG', filename) against the whole path, which matches anywhere in
-# it -- so a JPEG under a directory named "png" was handed to png::readPNG() and
-# failed with a format error that named neither the real problem nor the choice
-# this code had made on the user's behalf.
+# Anchored to the extension. The old grepl('png|PNG', filename) matched anywhere
+# in the path, so a JPEG under a directory named "png" went to png::readPNG().
 baseImageFormat <- function(filename) {
   if (grepl('\\.png$', filename, ignore.case = TRUE)) {
     return('png')
@@ -289,18 +296,11 @@ baseImageFormat <- function(filename) {
   NA_character_
 }
 
-# Check base_face_files before generateStimuli2IFC() does any expensive or
-# side-effecting work, and name the offending entry when something is wrong.
+# Check base_face_files up front and name the offending entry.
 #
-# Every branch here used to surface far from its cause. A non-list wrote its
-# explanation to stderr() and then called a bare stop(), so the condition it
-# raised carried an *empty* message: anything wrapping the call -- a Shiny app,
-# a batch script, knitr -- caught an error it could not report, and under sink()
-# or capture.output(type = 'message') the explanation could be separated from
-# the failure entirely. An unnamed or empty list passed that check and got as
-# far as the parallel workers, failing there with "attempt to select less than
-# one element in get1index", which names neither the argument nor the file.
-# See issues #124 and #180.
+# Each of these used to surface far from its cause: a bare stop() carrying an
+# empty message, or "attempt to select less than one element in get1index" from
+# inside a parallel worker. See issues #124 and #180.
 validateBaseFaceFiles <- function(base_face_files) {
   example <- 'e.g. base_face_files = list(aName = "baseface.jpg")'
 

--- a/man/generateStimuli2IFC.Rd
+++ b/man/generateStimuli2IFC.Rd
@@ -37,7 +37,7 @@ generateStimuli2IFC(
 
 \item{seed}{Integer seeding the random number generator (for reproducibility).}
 
-\item{maximize_baseimage_contrast}{Boolean specifying whether the pixel values of the base image should be rescaled to maximize its contrast.}
+\item{maximize_baseimage_contrast}{Boolean specifying whether the pixel values of the base image should be rescaled to maximize its contrast. A base image with no contrast at all — every pixel the same value — has nothing to rescale, and is rejected with an error rather than silently turned into an all-\code{NaN} base image. Such an image is still usable with \code{maximize_baseimage_contrast = FALSE}.}
 
 \item{noise_type}{String specifying noise pattern type (defaults to \code{sinusoid}; other options: \code{gabor}).}
 

--- a/tests/testthat/test-error-paths.R
+++ b/tests/testthat/test-error-paths.R
@@ -330,6 +330,50 @@ test_that("generateStimuli2IFC names the base image it cannot use", {
   expect_match(conditionMessage(err), "not in PNG format")
 })
 
+test_that("generateStimuli2IFC rejects a base image with no contrast", {
+  skip_if_not_installed("withr")
+
+  dir <- withr::local_tempdir()
+  flat <- file.path(dir, "flat.png")
+  png::writePNG(matrix(0.5, 32, 32), flat)
+
+  # (img - min) / (max - min) is 0/0 on a uniform image. The all-NaN base face
+  # used to be saved into the .Rdata and inherited by every CI computed from
+  # the set, with no error and no warning (#176).
+  err <- expect_error(
+    generateStimuli2IFC(base_face_files = list(flat = flat), n_trials = 2,
+                        img_size = 32, stimulus_path = dir, ncores = 1,
+                        save_as_png = FALSE, save_rdata = FALSE),
+    "no contrast"
+  )
+  expect_match(conditionMessage(err), "maximize_baseimage_contrast = FALSE")
+
+  # The way out named in the message has to actually work: with the rescale
+  # off, a flat base image is usable and its stimuli are finite.
+  stims <- expect_no_error(
+    generateStimuli2IFC(base_face_files = list(flat = flat), n_trials = 2,
+                        img_size = 32, stimulus_path = dir, ncores = 1,
+                        maximize_baseimage_contrast = FALSE,
+                        return_as_dataframe = TRUE,
+                        save_as_png = FALSE, save_rdata = FALSE)
+  )
+  expect_true(all(is.finite(as.matrix(stims))))
+})
+
+test_that("generateStimuli2IFC saves a base image the CI pipeline can use", {
+  skip_if_not_installed("withr")
+
+  # The NaN in #176 was invisible at generation time and surfaced only in the
+  # saved .Rdata, so assert on what was actually written rather than on the
+  # error alone.
+  dir <- withr::local_tempdir()
+  rdata <- make_fixture_rdata(dir)
+
+  env <- new.env()
+  load(rdata, envir = env)
+  expect_true(all(is.finite(env$base_faces[["base"]])))
+})
+
 test_that("generateStimuli2IFC picks the reader from the extension, not the path", {
   skip_if_not_installed("withr")
   skip_if_not_installed("jpeg")
@@ -342,7 +386,9 @@ test_that("generateStimuli2IFC picks the reader from the extension, not the path
   sub <- file.path(dir, "png")
   dir.create(sub)
   path <- file.path(sub, "face.jpg")
-  jpeg::writeJPEG(matrix(0.5, 32, 32), path)
+  # A ramp, not a flat field: a uniform base image is rejected for having no
+  # contrast to maximize (#176), which would fail this test for the wrong reason.
+  jpeg::writeJPEG(matrix(rep(seq(0, 1, length.out = 32), each = 32), 32, 32), path)
 
   expect_no_error(
     generateStimuli2IFC(base_face_files = list(base = path), n_trials = 2,


### PR DESCRIPTION
Closes #176.

`maximize_baseimage_contrast = TRUE`, the default, rescales with
`(img - min(img)) / (max(img) - min(img))` — 0/0 when every pixel is the same value. The
all-`NaN` base face went into the `.Rdata` with no error and no warning, and every
classification image computed from that stimulus set inherited it.

Measured, not assumed — the symptom is worse than the issue records. The stimuli written
to disk come out **uniformly black**, because `png::writePNG()` clamps `NaN` to zero:

| `maximize_baseimage_contrast` | base image | written stimulus range |
|---|---|---|
| `TRUE` (default) | all `NaN` | `[0.000, 0.000]` |
| `FALSE` | fine | `[0.318, 0.643]` |

## One departure from the issue

It asks for an error whenever `max(img) == min(img)`. The table above is why this errors
only under `maximize_baseimage_contrast = TRUE`: with the rescale off, a flat base image
is perfectly usable — it is how you would look at the noise on its own — so an
unconditional error would break a legitimate call. The message names that way out, and
the test exercises it rather than trusting it, asserting the resulting stimuli are finite.

A second test asserts on what lands in the saved `.Rdata`, since that is where the `NaN`
actually surfaced.

## It caught one of ours

The extension-anchoring test added in #200 built its JPEG as `matrix(0.5, 32, 32)` — a
uniform image — so the new check fired on it. Switched to a ramp; its subject is the
extension, not the contrast. Worth noting my earlier sweep for uniform base images missed
this one: I truncated the grep output with `head -30` and the line fell past the cut.

Nothing else uses a flat base image — the examples and `getting-started.Rmd` use
`runif()`, the walkthrough builds a synthetic face from Gaussians, and the release gate's
`make_base()` builds gradients.

## Comment trim

Also trims the comments added in #200 in this function — the two helper headers and the
loop preamble — from 34 lines to 13, on maintainer feedback that they were too long for
what they explain. Same facts, less prose. A convention for this is going in
`CONTRIBUTING.md` separately.

## Reproducibility

No numeric output changes: this adds an error on input that previously produced `NaN`,
and touches nothing on the path a valid call takes. 370 tests pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
