### PR TITLE
Say plainly that comments should be few and only where needed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,7 @@ of the `.RData` file live in `README.md` — sections "How it works" and "Anatom
 
 ### Notes on conventions in this codebase
 
+- **Comment sparingly.** Only where the reason would otherwise have to be re-derived, never to narrate the next line. This is the convention most often broken here — full rule in `CONTRIBUTING.md` → "Code conventions".
 - Functions use `save_as_png=TRUE` / `save_rdata=TRUE`-style side-effecting defaults — most analysis functions write PNGs to disk in addition to returning data structures. **The destination is always a required argument** (`stimulus_path`, `targetpath`, `zmaptargetpath`): none has a default, because a default path writes to the user's filespace uninvited and CRAN policy forbids it. Never reintroduce one — not even `tempdir()`; [`DECISIONS.md`](DECISIONS.md#write-paths-are-required-arguments-not-defaults-of-tempdir) records why.
 - Scaling of CI pixel intensities (`none`, `constant`, `matched`, `independent`) is a key user-facing decision, documented at length in `generateCI.R`'s roxygen header — read it before changing scaling logic.
 - `computeInfoVal2IFC()`'s `ref_lookup` tibble looks like a cache and is not one: **it has been empty since 2018**, its rows having been measured under the pre-erratum infoVal formula. Every lookup misses and the reference distribution is always regenerated. Do not describe it as a working cache; the matching machinery is kept only so the table can be repopulated cheaply.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,14 @@ outside the package can call them:
 Line length is not enforced; 35 lines in `R/` already exceed 100 characters. Wrap new code
 at something reasonable rather than reflowing what is there.
 
+**Comments: as few as will do, and only where the code cannot speak for itself.** Write one
+when the reason would otherwise have to be re-derived — a rejected alternative, a constraint,
+a measured number, a trap. Never narrate what the next line does, restate the error message
+below it, or re-tell an issue's history. The long comments already in `R/` are the first kind
+and earn their length; the test is whether a reader would otherwise get it wrong, not whether
+the code looks bare. Where the explanation is about the package rather than about the line, it
+belongs in [`DECISIONS.md`](DECISIONS.md).
+
 Two rules that are about this package rather than about R:
 
 - **Add new names loaded from an `.Rdata` file to `R/zzz.R`'s `globalVariables()`**, or


### PR DESCRIPTION
Maintainer feedback, twice in one session: the comments I was writing were too long for what they explain.

Nothing in `AGENTS.md` or `CONTRIBUTING.md` said otherwise, so this writes it down.

## The rule

In `CONTRIBUTING.md` → "Code conventions", next to the other style rules:

> **Comments: as few as will do, and only where the code cannot speak for itself.** Write one when the reason would otherwise have to be re-derived — a rejected alternative, a constraint, a measured number, a trap. Never narrate what the next line does, restate the error message below it, or re-tell an issue's history. The long comments already in `R/` are the first kind and earn their length; the test is whether a reader would otherwise get it wrong, not whether the code looks bare. Where the explanation is about the package rather than about the line, it belongs in `DECISIONS.md`.

`AGENTS.md` gets one line pointing at it — the same shape as the Codex review rule, and it keeps the file at 158 of its 200-line budget.

## Why it is worded that way

A blunter version ("keep comments short") would invite stripping the long comments in `R/` that are the whole point — the `set.seed()` note explaining that it governs every InfoVal ever computed, the `foreach` note on the 1.5 GB array that was exported to every worker, the `biOps` history behind the `img_size` check. Those record a reason someone would otherwise re-derive or get wrong. So the rule names both kinds and gives the test that separates them.

The concrete case: three blocks in `generateStimuli2IFC()` came to 34 lines and are cut to 13 in #201.

No new top-level file, so no `.Rbuildignore` entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)