### PR TITLE
Require re-reading CONTRIBUTING.md when opening a PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,10 +71,9 @@ replaced a chronological session log; do not recreate one.
 ## Git and merge strategy
 
 - **Re-read `CONTRIBUTING.md` → "Pull requests" when opening a PR, every time — not from
-  memory.** That section carries steps whose absence is silent: a push does **not** re-trigger
-  the Codex review (only opening the PR, marking a draft ready, or an `@codex review` comment
-  does), and its 👀 means the review is still running while 👍 means it finished clean. Both
-  have now been re-learned after being written down.
+  memory.** Its steps fail by producing silence rather than an error, so a half-remembered
+  version looks like it worked. Two of them have now been re-learned the hard way, after
+  being written down.
 - **Merge pull requests to `main` with squash merges** (`gh pr merge <n> --squash`). One
   commit per PR keeps history readable and makes `git revert` of a whole change
   straightforward, which matters here because a PR is usually one self-contained fix plus its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,11 @@ replaced a chronological session log; do not recreate one.
 
 ## Git and merge strategy
 
+- **Re-read `CONTRIBUTING.md` → "Pull requests" when opening a PR, every time — not from
+  memory.** That section carries steps whose absence is silent: a push does **not** re-trigger
+  the Codex review (only opening the PR, marking a draft ready, or an `@codex review` comment
+  does), and its 👀 means the review is still running while 👍 means it finished clean. Both
+  have now been re-learned after being written down.
 - **Merge pull requests to `main` with squash merges** (`gh pr merge <n> --squash`). One
   commit per PR keeps history readable and makes `git revert` of a whole change
   straightforward, which matters here because a PR is usually one self-contained fix plus its


### PR DESCRIPTION
The Codex review procedure lives in `CONTRIBUTING.md` → "Pull requests" precisely because its steps are invisible when skipped. It has now been skipped twice **by the agent that wrote it**, both times working from memory rather than reopening the file.

Both misses share a shape: a step whose absence produces *silence* rather than an error.

- **A push does not re-trigger the review.** Only opening the PR, marking a draft ready, or an explicit `@codex review` comment does. So after pushing a fix, waiting for a fresh verdict waits forever. Ron caught this one on #203 — "You will need to trigger the review I think?" — after I had pushed fixes and armed a watcher.
- **👀 is not 👍.** The eyes reaction means the review is *running*; the thumbs-up means it finished clean. A watcher matching any reaction reports a verdict that has not arrived, which is exactly what mine did minutes later.

## What this adds

One bullet at the top of `AGENTS.md` → "Git and merge strategy", pointing at the section rather than restating it — the duplication rule applies, and a copied procedure drifts.

## What it does not do

**Nothing enforces this and nothing can.** Codex submits as `COMMENTED`, so it is not a required check and is invisible to GitHub's ruleset; `required_review_thread_resolution` only covers threads that exist. Preferring an enforced gate over documented policy is the standing instinct here, and this is a case where the gate is unavailable, so it stays discipline. Making the instruction explicit at the moment it applies is the most that is on offer.

`AGENTS.md` is at 163 of its 200-line budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)