### PR TITLE
Record why the pkgdown site deploys from gh-pages

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -470,6 +470,18 @@ The cost of `workflow_dispatch`-only is that the workflow is invisible until it 
 **default branch** — GitHub offers no "Run workflow" button for a file that exists only on a
 feature branch. So it merges to `main` ahead of the release it is meant to check.
 
+### The pkgdown site deploys via a `gh-pages` branch, not the Actions-native route
+Pages was already configured here — `gh api repos/rdotsch/rcicr/pages` reported `status:
+built`, `build_type: legacy`, source branch `gh-pages` — and the only thing missing was that
+no such branch had ever been pushed, which is why the URL 404'd. Publishing that branch from
+a workflow therefore needed **no repository setting to change**. The Actions-native deploy
+would have been the more modern choice and was rejected on one fact: it requires flipping
+`build_type`, a repo-settings write that agents here cannot make (`Resource not accessible by
+integration`), turning a self-contained PR into one that stalls on the maintainer.
+
+`docs/` is the built site and is **git-ignored as well as `.Rbuildignore`d** — the two are not
+interchangeable, and a locally built site has already been committed by accident once.
+
 ---
 
 ## Releases and git


### PR DESCRIPTION
`DECISIONS.md` records *why* the package is the way it is, and #203 made a choice that is
invisible from the merged workflow: it deploys the site by pushing a `gh-pages` branch
rather than using the Actions-native Pages deploy, which is the more modern route.

The reason is a permission, not a preference. Pages was **already** configured —
`gh api repos/rdotsch/rcicr/pages` reported `status: built`, `build_type: legacy`, source
`gh-pages` — and the only thing missing was that no such branch had ever been pushed, which
is why the URL 404'd. Publishing it from a workflow needed no repository setting changed.
The Actions-native route needs `build_type` flipped, a repo-settings write agents here
cannot make (`Resource not accessible by integration`), which would have turned a
self-contained PR into one that stalls waiting on the maintainer.

The entry also records that `docs/` is git-ignored **as well as** `.Rbuildignore`d. The two
are not interchangeable, and on the branch that followed #203 a locally built `docs/` was
committed by accident — 163,377 lines on top of a five-line documentation change.

One entry under "Packaging, CI and tooling", 12 lines. No code, no `NEWS.md` entry: nothing
user-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)