### PR TITLE
Paste cran-comments.md from the tag, not from main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,6 +357,10 @@ Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-co
 into the "Optional comment" field — that file is `.Rbuildignore`d and reaches CRAN only this
 way, never inside the tarball. `devtools::submit_cran()` does the same thing.
 
+**Paste the tag's copy, not `main`'s** — `git show vX.Y.Z:cran-comments.md`. Submission can
+trail tagging by weeks, and `main` moves in between; its copy would describe check results
+from a tree that is not the tarball, and nothing in the submission would contradict it.
+
 **Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
 package archived over an undeliverable address, that confirmation *is* the point of the
 resubmission.


### PR DESCRIPTION
`cran-comments.md` is `.Rbuildignore`d, so it never ships in the tarball — it reaches the
reviewer only by being pasted into the submission form's "Optional comment" field. But it is
read from the *working tree*, which is `main`, while the tarball is built from the tag. The
checklist already insists on the second half and says nothing about the first.

The gap is live right now: **1.2.3 is tagged and not yet submitted** — CRAN is not accepting
submissions during holiday leave — and `main` has moved five commits since. Whenever the
submission happens, `main`'s `cran-comments.md` will describe a tree that is not the tarball.

Nothing catches this. The reviewer sees one file and one tarball, neither of which states its
own provenance, so a mismatch reads as an ordinary set of check results.

```sh
git show vX.Y.Z:cran-comments.md
```

Four lines in "Releasing" → step 4, next to the `git switch --detach` line it belongs with.
No code, no `NEWS.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)