### PR TITLE
Move five contributor rules from DECISIONS.md to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,27 @@ attaching a real face photo.
   measurements, rejected alternatives, reproducibility impact — in the PR description or
   `NEWS.md`, not only in individual branch commits.
 
+### Testing
+
+- **Proving a test fails without its fix: use `cp` backups in a scratchpad, not git.**
+  `git checkout <file>` discards unstaged work and has destroyed an in-progress
+  implementation here. Guard each mutation with a `grep -q MUTANT` check as well — a mutation
+  that silently failed to apply looks exactly like a surviving mutant.
+- **When a test reads pixels back from a graphics device, assert only relationships between
+  renders.** Every absolute property of those pixels belongs to the device: the channel count
+  (cairo writes RGB, macOS quartz writes RGBA) and the values alike (quartz renders a 0.5
+  background at roughly 0.573 where cairo gives 0.502). Render onto a *uniform* background so
+  "drew nothing" becomes "the image is one flat value", count distinct values over the colour
+  channels only, and compare two renders rather than pinning a number.
+  [`DECISIONS.md`](DECISIONS.md#pixel-assertions-have-measured-the-graphics-device-twice) has
+  the two failures that taught this.
+- **Check figures by looking at them.** Three problems in the walkthrough vignette were
+  invisible to every assertion and obvious on sight; they are listed in
+  [`DECISIONS.md`](DECISIONS.md#three-vignette-figures-were-wrong-in-ways-only-viewing-them-showed).
+- **Base images in tests and vignettes are always synthetic**, never a real photograph.
+  Avoiding licensing and consent questions entirely is worth more than a realistic-looking
+  figure.
+
 ### The Codex review
 
 Codex reviews pull requests here and has caught real errors (#170, #172, #173, and three on the
@@ -191,6 +212,10 @@ below it, or re-tell an issue's history. The long comments already in `R/` are t
 and earn their length; the test is whether a reader would otherwise get it wrong, not whether
 the code looks bare. Where the explanation is about the package rather than about the line, it
 belongs in [`DECISIONS.md`](DECISIONS.md).
+
+**If the package is ever run through `styler`, it goes in as a commit of its own** — never as
+a side effect of other work, so `git blame` survives it. Why the pre-commit hooks stay minimal
+and language-agnostic is above.
 
 Two rules that are about this package rather than about R:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,12 @@ attaching a real face photo.
 
 ### Testing
 
-- **Proving a test fails without its fix: use `cp` backups in a scratchpad, not git.**
-  `git checkout <file>` discards unstaged work and has destroyed an in-progress
-  implementation here. Guard each mutation with a `grep -q MUTANT` check as well — a mutation
-  that silently failed to apply looks exactly like a surviving mutant.
+- **Going beyond the one-off check above — mutating the code repeatedly — keep `cp` backups
+  in a scratchpad, and never restore with `git checkout <file>`.** The `git stash push -- R/`
+  in the checklist is right for proving a single fix; it is the *restore* step that bites,
+  because `git checkout <file>` discards unstaged work and has destroyed an in-progress
+  implementation here. Guard each mutation with a `grep -q MUTANT` check too — one that
+  silently failed to apply looks exactly like a surviving mutant.
 - **When a test reads pixels back from a graphics device, assert only relationships between
   renders.** Every absolute property of those pixels belongs to the device: the channel count
   (cairo writes RGB, macOS quartz writes RGBA) and the values alike (quartz renders a 0.5

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -188,13 +188,6 @@ intending to re-measure and the feature becomes unrecoverable rather than merely
 
 ## Testing
 
-### Mutation testing: `cp` backups, and check the mutant applied
-`CONTRIBUTING.md` covers the basic check (`git stash push -- R/`, not a plain `git stash`).
-Beyond it: prefer `cp` backups in a scratchpad over git, because `git checkout <file>`
-discards unstaged work and has destroyed an in-progress implementation here. Guard each
-mutation with a `grep -q MUTANT` check — one that silently failed to apply looks exactly like
-a surviving mutant.
-
 ### Vacuous assertions have shipped here twice, and both looked fine on the page
 Two `batchGenerateCI*` tests titled "computes one CI per group" asserted only length, names
 and `dim`: **grouping was never checked**, and a bug feeding all trials to every group passed
@@ -225,10 +218,11 @@ is in `test-generateNoiseImage.R`. If it is ever revisited, the replacement is a
 from the paper or a hand-computed 2×2 CI with a known reference vector, not a tidier
 restatement of the same expression.
 
-### To test a rendered image, render onto a uniform background
-Then "drew nothing" is "the image is one flat value" — a comparison rather than an eyeball.
-`plotZmap`'s tests were three-quarters `file.exists()` before this; a function writing a
-uniformly blank PNG passed them all.
+### Pixel assertions have measured the graphics device twice
+The practice this produced — uniform backgrounds, colour channels only, comparisons rather
+than pinned values — is in `CONTRIBUTING.md`. Here is what it cost to learn, twice in the same
+fix. (`plotZmap`'s tests were three-quarters `file.exists()` before any of it; a function
+writing a uniformly blank PNG passed them all.)
 
 Count distinct values over the **colour channels only**, never the raw array. Whether a PNG
 device writes an alpha channel is a property of the graphics backend, not of what was drawn:
@@ -392,10 +386,6 @@ exists for: a default is the value the function goes on to use, and is exactly a
 replaceable by a field in the `.Rdata` as one passed explicitly. Dropping them removed the
 `step` guard in `computeCumulativeCICorrelation()` and the test caught it. The predicate is
 therefore *required* (no default in `formals()`) **and** absent — not absent alone.
-
-### If the package is ever run through `styler`, it goes in as a commit of its own
-Never as a side effect of other work. (Why the hooks stay minimal and language-agnostic is in
-`CONTRIBUTING.md`.)
 
 ### `fail_ci_if_error: false` on the coverage workflow
 Chosen over getting a Codecov token or deleting the workflow. **This does not make coverage
@@ -641,8 +631,9 @@ premise proved itself during the port: two of the post's lines no longer worked 
 "development")`, a branch that does not exist. The post stays published for nine years of
 inbound links; this moves the canonical copy, it is not a takedown.
 
-### Figures must be checked by looking at them
-Three problems in the walkthrough vignette were caught only by viewing the output:
+### Three vignette figures were wrong in ways only viewing them showed
+The rule this stands behind is in `CONTRIBUTING.md`. What it caught, none of it visible to an
+assertion:
 
 - **`image()` auto-stretches its input across the palette**, so every linear rescaling of the
   same image renders *identically* — which made a four-way scaling comparison meaningless
@@ -682,9 +673,6 @@ feature on the grounds that it was never built.
 **The generalisable part:** "this changes rendered output" is not by itself an argument for
 leaving something broken. Ask who is currently *relying* on the broken output. Here the answer
 was nobody, and the entry sat open a day longer than it needed to.
-
-### Base images in tests and vignettes are always synthetic
-Avoiding licensing and consent questions entirely is worth more than a realistic-looking figure.
 
 ### The `.Rdata` anatomy belongs in `README.md`
 It is the only link between the two halves of the package, and nothing about a stimulus set is

--- a/notes/backlog-migration.md
+++ b/notes/backlog-migration.md
@@ -31,9 +31,9 @@ the file is. The four settled non-fixes went to `DECISIONS.md` in PR #173 and ar
 
 ## Drop — a decision, already recorded
 
-**`styler`.** [`DECISIONS.md`](../DECISIONS.md#if-the-package-is-ever-run-through-styler-it-goes-in-as-a-commit-of-its-own)
-already says that if it ever happens it goes in as a commit of its own. An issue would invite
-someone to do the thing the decision defers.
+**`styler`.** [`CONTRIBUTING.md`](../CONTRIBUTING.md) → "Code conventions" already says that if
+it ever happens it goes in as a commit of its own. An issue would invite someone to do the
+thing that defers.
 
 ## Fold together
 


### PR DESCRIPTION
`DECISIONS.md` answers *why is the package like this*; `CONTRIBUTING.md` answers *what should
I do*. Five entries had drifted onto the wrong side, and **two were exactly inverted** — the
instruction sat in `DECISIONS.md` while its rationale sat in `CONTRIBUTING.md`, so someone
working from the checklist never met the rule.

## Moved whole, being pure procedure

| entry | why it belongs in CONTRIBUTING.md |
|---|---|
| `styler` goes in as a commit of its own | Two lines, entirely imperative, and it pointed at `CONTRIBUTING.md` for the why. |
| Mutation testing: `cp` backups, `grep -q MUTANT` guard | Opened by deferring to `CONTRIBUTING.md` for the basic check, then added procedure documented nowhere else. Someone proving a test fails without its fix would never find it. |
| Base images in tests and vignettes are always synthetic | A one-line rule. `CONTRIBUTING.md` already tells bug reporters the same thing. |

## Split, keeping the evidence where it belongs

- **Rendered-image assertions.** The rule — uniform backgrounds, colour channels only,
  compare renders rather than pin values — moves. The two failures that taught it stay, under
  a title that describes the finding instead of commanding: *"Pixel assertions have measured
  the graphics device twice"*.
- **Vignette figures checked by eye.** Same shape — three measured findings under an
  imperative title, now *"Three vignette figures were wrong in ways only viewing them
  showed"*.

## What made these five identifiable

The rest of `DECISIONS.md` already follows a consistent pattern, and naming it is what made
the outliers obvious: an entry **states that the rule lives in `AGENTS.md` or
`CONTRIBUTING.md`, then spends its length on the measurement**. "Claims must survive on
someone else's machine" literally opens that way and is staying exactly where it is.

## One broken link, found by checking rather than by reading

`notes/backlog-migration.md` linked the `styler` anchor and now points at `CONTRIBUTING.md`.
Every `DECISIONS.md#anchor` in the repo was re-resolved against the current headings — eight
of them, one broken:

```
BROKEN if-the-package-is-ever-run-through-styler-it-goes-in-as-a-commit-of-its-own
OK     pixel-assertions-have-measured-the-graphics-device-twice
OK     three-vignette-figures-were-wrong-in-ways-only-viewing-them-showed
...
```

Documentation only — no `R/`, no tests, no `NEWS.md` entry. Independent of #209; if that lands
first this rebases cleanly, the two touching different parts of `CONTRIBUTING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)