### PR TITLE
Two conventions from this session's reviews: write for the final state, skip only on Suggests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,11 @@ attaching a real face photo.
 - PRs are merged to `main` with **squash merges**, so put anything a future reader needs —
   measurements, rejected alternatives, reproducibility impact — in the PR description or
   `NEWS.md`, not only in individual branch commits.
+- **Write for the state the change ends in, not the route you took to it.** Commit messages,
+  PR comments and code comments describe what the change is and why it is right. How many
+  attempts it took, and what each one got wrong, is invisible in the squashed history and in
+  the merged code — nobody arrives at the file that way. Keep a rejected alternative only
+  when someone would otherwise retry it, and give it a line, not a chronology.
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,11 @@ attaching a real face photo.
 
 ### Testing
 
+- **`skip_if_not_installed()` is for `Suggests` only.** `withr` may genuinely be absent, so
+  skipping on it is honest. A package in `Imports` — `png`, `jpeg`, `matlab` — cannot be:
+  the package will not load without it. The skip can never fire for a real reason, and if it
+  somehow did it would hide the test rather than fail it. A skip reads as "this passed" at a
+  glance, which is the opposite of what you want to know.
 - **Going beyond the one-off check above — mutating the code repeatedly — keep `cp` backups
   in a scratchpad, and never restore with `git checkout <file>`.** The `git stash push -- R/`
   in the checklist is right for proving a single fix; it is the *restore* step that bites,

--- a/tests/testthat/test-error-paths.R
+++ b/tests/testthat/test-error-paths.R
@@ -376,7 +376,6 @@ test_that("generateStimuli2IFC saves a base image the CI pipeline can use", {
 
 test_that("generateStimuli2IFC picks the reader from the extension, not the path", {
   skip_if_not_installed("withr")
-  skip_if_not_installed("jpeg")
 
   dir <- withr::local_tempdir()
 


### PR DESCRIPTION
Two rules for `CONTRIBUTING.md`, both from things that went wrong in #209, plus the one place
the second is violated.

## Write for the state a change ends in, not the route to it

Commit messages, PR comments and code comments here have been carrying the iteration history:
how many attempts a fix took, and what each earlier version got wrong. None of it survives the
squash, and none of it is visible in the merged code — nobody arrives at the file that way.

It goes next to the squash-merge bullet because that bullet is what invites the padding. It
asks for rejected alternatives in the PR description, and the qualifier it was missing is that
one earns **a line**, when someone would otherwise retry it — not a chronology. Measurements,
reproducibility impact and load-bearing constraints are unaffected: the brevity is about
narrative, not evidence.

## `skip_if_not_installed()` is for `Suggests` only

Raised by Ron on #209: *should the tests really skip if `png` is not installed — wouldn't we
rather fail so we know it was not tested?* Right, and the suite splits cleanly along the
`DESCRIPTION` line:

| package | where | verdict |
|---|---|---|
| `withr` | `Suggests` | fair skip — it may genuinely be absent |
| `png`, `jpeg` | `Imports` | the package does not load without them, so the skip can never fire for a real reason |

A skip on a hard dependency would hide the test rather than fail it, and reads as "this
passed" at a glance. The `png` one was mine and was removed in #209; **this PR removes the
`jpeg` one**, which predates it, leaving every remaining skip in the suite on `withr`.

Full suite: 372 assertions, 0 failures, 0 errors, **0 skips**.