### PR TITLE
Install a release by default, and fail CI on stale man/

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -93,5 +93,9 @@ jobs:
                   -e 'have <- as.character(packageVersion("roxygen2"))' \
                   -e 'if (have != want) stop("roxygen2 ", have, " installed, DESCRIPTION says ", want, ": update the pin in this workflow to match.")' \
                   -e 'roxygen2::roxygenise(load_code = "source")'
-          git diff --exit-code -- man NAMESPACE \
+          # Staged, because `git diff` alone ignores untracked files: a new
+          # documented *internal* function leaves NAMESPACE untouched, so its
+          # missing man/*.Rd would be invisible and the gate would pass.
+          git add -A -- man NAMESPACE
+          git diff --cached --exit-code -- man NAMESPACE \
             || { echo "::error::man/ or NAMESPACE is stale. Run roxygen2::roxygenise() and commit the result."; exit 1; }

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -66,10 +66,32 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          # roxygen2 is pinned, and to DESCRIPTION's RoxygenNote: .Rd output
+          # varies between generator versions, so `any::` would let a CRAN
+          # release of roxygen2 fail the documentation step below on formatting
+          # alone. Only that step needs it, on one job -- installing it on all
+          # four is the price of not putting a matrix conditional here.
+          extra-packages: |
+            any::rcmdcheck
+            roxygen2@7.3.1
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+      # The check above catches man/ that disagrees with a function's signature
+      # (tools::codoc). It never runs roxygen, so it cannot catch prose drift --
+      # an edited @description or @examples that was not regenerated -- which
+      # ships to the pkgdown site, built from man/. Last, so a failure here
+      # cannot cost us the check results.
+      - name: Documentation is up to date
+        if: matrix.config.os == 'ubuntu-latest' && matrix.config.r == 'release'
+        run: |
+          Rscript -e 'want <- read.dcf("DESCRIPTION", "RoxygenNote")[[1]]' \
+                  -e 'have <- as.character(packageVersion("roxygen2"))' \
+                  -e 'if (have != want) stop("roxygen2 ", have, " installed, DESCRIPTION says ", want, ": update the pin in this workflow to match.")' \
+                  -e 'roxygen2::roxygenise(load_code = "source")'
+          git diff --exit-code -- man NAMESPACE \
+            || { echo "::error::man/ or NAMESPACE is stale. Run roxygen2::roxygenise() and commit the result."; exit 1; }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,15 @@ configurations, and compares. Every release has to pass it — see **Releasing**
 ## Getting set up
 
 ```r
-devtools::install()   # not load_all() -- see below
+devtools::install()      # not load_all() -- see below
 devtools::test()
 devtools::check()
+roxygen2::roxygenise()   # after editing any roxygen comment; commit man/ and NAMESPACE
 ```
+
+`man/` and `NAMESPACE` are generated and tracked, and `ubuntu-latest (release)` regenerates
+them and fails on a difference. Use the roxygen2 version in `DESCRIPTION`'s `RoxygenNote`;
+the CI step is pinned to it and says so when they disagree.
 
 `generateStimuli2IFC()` spawns parallel workers that each call `library(rcicr)`, so anything
 touching it needs the package **actually installed**. Under `devtools::load_all()` alone the

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -472,6 +472,32 @@ integration`), turning a self-contained PR into one that stalls on the maintaine
 `docs/` is the built site and is **git-ignored as well as `.Rbuildignore`d** — the two are not
 interchangeable, and a locally built site has already been committed by accident once.
 
+### The stale-`man/` gate is a step in an existing job, and a pre-commit hook was rejected
+`R CMD check` already fails on documentation that disagrees with a function's *signature* —
+`tools::codoc()`, confirmed by renaming `deg2rad`'s formal without regenerating `man/`. What it
+cannot see is prose drift: an edited `@description` or `@examples` never regenerated. The same
+edit leaves `codoc()` silent and still reaches the pkgdown site, which builds from `man/`. So
+the gate re-runs roxygen and diffs `man/` and `NAMESPACE`.
+
+Three things about where it lives:
+
+- **A step in `ubuntu-latest (release)`, not a new job or workflow.** Required checks are
+  matched by name, and adding a name to the ruleset is a repo-settings write agents here
+  cannot make — a new job would report without ever blocking. It runs last so a failure
+  cannot cost us the check results.
+- **Not a pre-commit hook.** R hooks were kept out of `.pre-commit-config.yaml` for their own
+  reasons, but the deciding one here is that the check job already has R and every dependency
+  installed, where a hook would install them per run — and an optional local hook is not a
+  gate.
+- **roxygen2 is pinned to `RoxygenNote`, not `any::`.** `.Rd` output varies between generator
+  versions, so `any::` lets a CRAN release of roxygen2 redden a required check on formatting
+  alone — an external event breaking the gate, in an environment that cannot re-run a job. The
+  step asserts the installed version matches `DESCRIPTION` so the pin cannot silently desync;
+  bumping the generator means bumping both.
+
+Nothing rebuilds the *site* locally or in a hook — the pkgdown workflow builds it on every PR
+and deploys on push, which is what catches a vignette that no longer knits.
+
 ---
 
 ## Releases and git

--- a/NEWS.md
+++ b/NEWS.md
@@ -110,6 +110,13 @@
   so "How it works" and "Anatomy of the `.Rdata` file" are not maintained twice — and
   rebuilt by GitHub Actions on every push, so it cannot drift from the code.
 
+- **The install instructions now install a release rather than the development version.**
+  `remotes::install_github('rdotsch/rcicr')` takes the tip of `main`, which carries unreleased
+  changes; the `README.md` and walkthrough-vignette instructions now lead with
+  `@*release`, and show `@v1.2.3` for installing one specific version — worth recording in an
+  analysis script, since a classification image is only reproducible against the version that
+  computed it.
+
 # rcicr 1.2.3 (2026-08-07)
 
 **Documentation only. Nothing this package computes has changed** — no function,

--- a/README.md
+++ b/README.md
@@ -12,8 +12,23 @@ Install from GitHub:
 
 ``` r
 install.packages('remotes')
+
+# The most recent release -- start here
+remotes::install_github('rdotsch/rcicr@*release')
+
+# A specific release, by tag -- to reproduce an analysis run under that version
+remotes::install_github('rdotsch/rcicr@v1.2.3')
+
+# The development version at the tip of main -- unreleased, may change under you
 remotes::install_github('rdotsch/rcicr')
 ```
+
+Every release is tagged, and the tags are listed on the
+[releases page](https://github.com/rdotsch/rcicr/releases). Record the version you ran in
+your analysis script, and install it by tag when you come back to that analysis: a
+classification image is only reproducible against the version that computed it, and any
+release that changes numeric output says so in [`NEWS.md`](NEWS.md) under "Reproducibility
+impact".
 
 > **`install.packages('rcicr')` does not currently work.** The package was archived on
 > CRAN on 2021-06-08 because email to the maintainer had become undeliverable — an old

--- a/vignettes/reverse-correlation-walkthrough.Rmd
+++ b/vignettes/reverse-correlation-walkthrough.Rmd
@@ -64,8 +64,12 @@ problem with the package), so install it from GitHub:
 
 ```{r install, eval = FALSE}
 # install.packages("remotes")
-remotes::install_github("rdotsch/rcicr")
+remotes::install_github("rdotsch/rcicr@*release")   # or @v1.2.3 for one specific release
 ```
+
+Install a tagged release rather than the tip of `main`, and note the version in your
+analysis script: a classification image is only reproducible against the version that
+computed it.
 
 ## 2. What the method does
 


### PR DESCRIPTION
Two documentation-integrity changes, on disjoint files.

## Install a release, not the development version

`remotes::install_github('rdotsch/rcicr')` installs the tip of `main`. The README and the walkthrough vignette now lead with `@*release`, then show `@v1.2.3` for pinning one version, then name the bare form as the development tip. A classification image is only reproducible against the version that computed it, so the version belongs in the analysis script.

`@*release` is valid `remotes` syntax (`?remotes::install_github`), so the recommended line never goes stale as releases land; the `v1.2.3` example ages harmlessly beside it.

## Fail `ubuntu-latest (release)` on stale `man/`

`man/` and `NAMESPACE` are generated and tracked. `R CMD check` catches only the half of the drift that reaches a function signature — `tools::codoc()` — because it never runs roxygen. An edited `@description` or `@examples` leaves it silent and still ships to the pkgdown site, which builds from `man/`. The new step re-runs roxygen and diffs the result.

Verified both directions rather than reasoned about:

- clean tree → passes, and `man/`/`NAMESPACE` are in sync at `main`;
- retitling `deg2rad`'s roxygen block, prose only → `codoc()` reports **nothing**, and the step fails printing the `man/deg2rad.Rd` diff.
- a new `@keywords internal` helper, so `NAMESPACE` is untouched → its `man/*.Rd` arrives untracked, which `git diff` alone ignores. The step stages `man/` and `NAMESPACE` before diffing so a missing generated page counts (Codex finding, fixed in c029cae).

Three choices, with the reasoning in `DECISIONS.md`:

- **A step in an existing required job, not a new job or workflow.** Required checks are matched by name, and adding a name to the ruleset is a repo-settings write agents here cannot make — a new job would report without ever blocking. It runs last, so a stale-docs failure cannot cost us the check results.
- **Not a pre-commit hook.** The check job already has R and every dependency installed, where a hook would install them per run — and an optional local hook is not a gate.
- **roxygen2 pinned to `DESCRIPTION`'s `RoxygenNote`, not `any::`.** `.Rd` output varies between generator versions, so `any::` would let a CRAN release of roxygen2 redden a required check on formatting alone — an outside event breaking merges, in an environment that cannot re-run a job. The step asserts the installed version matches `DESCRIPTION`, so the pin cannot silently desync; bumping the generator means bumping both.

The cost of the pin is roxygen2 installing on all four matrix jobs. Scoping it to the one job that uses it needs a matrix conditional inside the `extra-packages` list, which reads worse than the extra install.

Nothing here rebuilds the pkgdown site locally or in a hook: the pkgdown workflow builds it on every PR and deploys on push, and `docs/` stays git-ignored.

## Notes

- No test changes: the CI step is itself the check, and it is exercised above.
- `NEWS.md` gets the install-instructions entry under Documentation. The CI step is not user-facing and is recorded in `DECISIONS.md` instead.
- Happy to split this into two PRs if you would rather the install docs and the CI gate revert independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
