### PR TITLE
Make a reviewed plan the first commit when behaviour or numbers change

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ replaced a chronological session log; do not recreate one.
   memory.** Its steps fail by producing silence rather than an error, so a half-remembered
   version looks like it worked. Two of them have now been re-learned the hard way, after
   being written down.
+- **Plan first when a change touches behaviour, numbers or a contract** — `R/` behaviour,
+  numeric output, the `.Rdata` contract, fixtures, or the release and CI machinery. The plan is
+  the branch's first commit, reviewed as a **draft** PR before any of the change is written,
+  then deleted on that same branch so the squash leaves `main` one commit and no plan file.
+  Full procedure in `CONTRIBUTING.md` → "Plan first, in the same pull request"; read it there.
+  Prose, `man/`, `NEWS.md` wording and comment-only edits are exempt.
 - **Merge pull requests to `main` with squash merges** (`gh pr merge <n> --squash`). One
   commit per PR keeps history readable and makes `git revert` of a whole change
   straightforward, which matters here because a PR is usually one self-contained fix plus its

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -443,6 +443,33 @@ before you begin so the work is not duplicated.
 look like bugs and are intentional and must not be "fixed"**. Check it before changing
 something that looks wrong.
 
+### Plan first, in the same pull request
+
+**When a change touches behaviour, numbers or a contract, the first commit on the branch is a
+plan, and it gets reviewed before any of the change is written.** That means anything altering
+`R/` behaviour, numeric output, the `.Rdata` contract, test fixtures, or the release and CI
+machinery. It does *not* mean prose, `man/`, `NEWS.md` wording or comment-only edits — roughly
+the inert set `.github/workflows/reproducibility.yaml` already allowlists.
+
+1. Branch from `main` and commit the plan to `notes/plan-<topic>.md`. `notes/` is already
+   `.Rbuildignore`d via `^notes$` and on that same inert allowlist, so a plan-only diff needs no
+   `.Rbuildignore` entry and the gate reports green without doing work.
+2. **Open the PR as a draft** and request the review, exactly as in "The Codex review" above.
+   The same two conditions clear it.
+3. Implement on that same branch, and **delete the plan file there** as part of the work.
+4. **Mark the draft ready**, which re-triggers the review on the full diff — a push alone does
+   not.
+5. Squash as usual.
+
+Because the plan file is added and deleted within the branch, the squash gives `main` one
+commit — the change itself, carrying no plan file — while the plan and both review rounds stay
+on the PR thread. The plan does not outlive the work and cannot become a second, drifting
+source of status; `NEWS.md`, `DECISIONS.md` and the tracker hold what survives.
+
+A plan is worth reviewing only if it can be wrong. State what you verified and how, name the
+step most likely to fail, and where the change rests on a claim about behaviour, measure it
+rather than asserting it — an issue's proposed fix is a hypothesis until it has been run.
+
 ## Code of conduct
 
 Be decent to each other. Problems can be raised privately with the maintainer at the address


### PR DESCRIPTION
Standard procedure, requested after PR #225 did it once by hand: work that touches behaviour,
numbers or a contract opens as a **draft** PR whose first commit is a plan, and the plan is
reviewed before any of the change is written.

Review is cheapest against the approach. A wrong approach caught in a plan costs a paragraph;
caught in a finished branch it costs the branch.

## The shape

The plan is deleted on the same branch as part of the work, so the squash leaves `main` **one
commit — the change, carrying no plan file** — while the plan and both review rounds stay on the
PR thread.

```
branch
  c1  add notes/plan-<topic>.md     <- reviewed here, as a draft
  c2  implement
  c3  delete notes/plan-<topic>.md
  --> squash to main = 1 commit, no plan file
```

That keeps `main`'s history to actual changes, and stops the plan outliving the work to become a
second, drifting source of status alongside `NEWS.md`, `DECISIONS.md` and the tracker — which is
what `BACKLOG.md` did before it was retired.

Marking the draft ready is what re-triggers the review on the full diff; a push does not, per the
existing "The Codex review" section.

## The threshold

`R/` behaviour, numeric output, the `.Rdata` contract, fixtures, or the release and CI machinery.
Exempt: prose, `man/`, `NEWS.md` wording, comment-only edits — reusing the inert allowlist
`.github/workflows/reproducibility.yaml` already applies, so the boundary is one the repo already
draws rather than a fresh judgement call each time.

**This PR is itself exempt under that threshold**, which is why it has no plan.

## Notes

- `notes/` is already `.Rbuildignore`d via `^notes$` and on that inert allowlist, so a plan-only
  diff needs no `.Rbuildignore` entry and the reproducibility gate reports green without doing
  work. Verified, not assumed.
- `AGENTS.md` carries a pointer rather than a copy, and is 168 lines against its 200-line target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)