### PR TITLE
Split the repository's housekeeping out of DECISIONS.md

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -19,3 +19,6 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^RELEASING\.md$
+^MAINTENANCE\.md$
+^SECURITY\.md$

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 
 # Covers GitHub Actions only. Dependabot has no CRAN ecosystem, so the R
 # dependencies in DESCRIPTION are not watched here and cannot be -- see
-# DECISIONS.md, "Dependabot watches the actions, not the R packages", for why
+# SECURITY.md, "Dependency posture", for why
 # that gap is left open rather than filled with a scanner.
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -70,7 +70,7 @@ jobs:
             base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
             changed=$(git diff --name-only "$base" HEAD)
             echo "changed files:"; echo "$changed" | sed 's/^/  /'
-            inert='^(man/|vignettes/|tests/|notes/|\.claude/|\.github/ISSUE_|README\.md$|AGENTS\.md$|CLAUDE\.md$|DECISIONS\.md$|CONTRIBUTING\.md$|ChangeLog$|cran-comments\.md$|codecov\.yml$|\.pre-commit-config\.yaml$|\.gitignore$|\.Rbuildignore$|LICENSE|.*\.Rproj$)'
+            inert='^(man/|vignettes/|tests/|notes/|\.claude/|\.github/ISSUE_|README\.md$|AGENTS\.md$|CLAUDE\.md$|DECISIONS\.md$|CONTRIBUTING\.md$|RELEASING\.md$|MAINTENANCE\.md$|SECURITY\.md$|ChangeLog$|cran-comments\.md$|codecov\.yml$|\.pre-commit-config\.yaml$|\.gitignore$|\.Rbuildignore$|LICENSE|.*\.Rproj$)'
             # Deliberately no `grep -qv`: ugrep and GNU grep disagree on its
             # exit status, so the emptiness of the list is tested instead. It
             # also lets the log name the file that forced the run.

--- a/.github/workflows/reproducibility.yaml
+++ b/.github/workflows/reproducibility.yaml
@@ -1,8 +1,8 @@
 # Does this tree still produce the numbers the published versions produced?
 #
-# See tools/compare-release-output.R for what is compared and CONTRIBUTING.md
-# ("Releasing") for where this sits in the release checklist. A release must not
-# go out while this is red.
+# See tools/compare-release-output.R for what is compared and RELEASING.md for
+# where this sits in the release checklist. A release must not go out while this
+# is red.
 #
 # Two comparisons, and they answer different questions: v1.0.1 is the version
 # the literature was produced with and stays pinned, while the previous release

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -45,7 +45,7 @@ jobs:
           # on pushes to main, so every merge turned the main branch red for a
           # reason unrelated to the code. Coverage is still computed and printed in
           # the step above; only the upload is allowed to fail. If a token is added
-          # later this can go back to true. See DECISIONS.md, fail_ci_if_error.
+          # later this can go back to true. See MAINTENANCE.md, fail_ci_if_error.
           fail_ci_if_error: false
           files: ./cobertura.xml
           plugins: noop

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`
 - `tests/testthat/helper-fixtures.R` provides shared fixtures: `make_square_png()` (synthetic base face — never a real photo), `make_fixture_rdata()` (runs a tiny `generateStimuli2IFC()` and returns the `.Rdata` path), `seed_reference_norms()` (pre-seeds a `reference_norms` vector so `computeInfoVal2IFC()` skips the expensive/interactive reference-distribution path).
 - `tests/testthat/test-fixed-bugs.R` holds regression tests for the P0 bugs found in the modernization pass. They assert *intended* behaviour — never the buggy output they replaced. If one fails, that is a regression; do **not** "fix" it by asserting the broken result, which locks the bug back in.
 - `tests/testthat/test-regression-baseline.R` is a golden master pinning the numeric output of the default pipeline — noise basis, classification image, scaling, infoVal — to the values produced *before* the P0 fixes. **If a change turns it red, that change alters researchers' results** and must be documented in `NEWS.md` under "Reproducibility impact" before merging. It is not a test to casually update.
-- `tools/compare-release-output.R` is the **release gate**: it installs a released version from its own commit (default `v1.0.1`, tagged retroactively at `b6ab269`) into a temporary library, runs it and the working tree through `tools/compare-harness.R`, and compares every output. It answers what the golden master cannot — that test pins values *this repo computed for itself*, whereas the gate runs the actual old code. A difference is allowed only with an `EXPECTED` entry in the script **and** a matching `NEWS.md` "Reproducibility impact" entry; both are checked, and a stale `EXPECTED` entry fails too. Use `--quick` (~2 min, skips 512px) while iterating. Full checklist in `CONTRIBUTING.md` → "Releasing".
+- `tools/compare-release-output.R` is the **release gate**: it installs a released version from its own commit (default `v1.0.1`, tagged retroactively at `b6ab269`) into a temporary library, runs it and the working tree through `tools/compare-harness.R`, and compares every output. It answers what the golden master cannot — that test pins values *this repo computed for itself*, whereas the gate runs the actual old code. A difference is allowed only with an `EXPECTED` entry in the script **and** a matching `NEWS.md` "Reproducibility impact" entry; both are checked, and a stale `EXPECTED` entry fails too. Use `--quick` (~2 min, skips 512px) while iterating. Full checklist in `RELEASING.md`.
   - The battery is chosen by the **reference** version, not the current one (`RCICR_COMPARE_REF_VERSION`): calls that used to crash — `mask`, z-maps below 512px, undecorated z-maps — have no old value to compare against. Before adding a configuration, check the reference version can execute it; a crash on the reference side aborts the whole gate.
   - It needs ~1.5 GB of RAM at 512px and the reference version's own dependencies — `--install-deps` puts them in a throwaway library rather than the user's.
 - Both `devtools::test()` and `testthat::test_local()` set `NOT_CRAN=true` themselves, so neither can be used to verify that a `skip_on_cran()` actually fires.
@@ -47,26 +47,38 @@ A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`
 - **The workflows only trigger on PRs targeting `main`**, so a stacked PR based on another branch gets pre-commit and nothing else — no `R CMD check`. Retargeting an existing PR does *not* re-fire them; close and reopen it.
 - `.github/workflows/test-coverage.yaml` uploads to Codecov (needs a `CODECOV_TOKEN` secret); `codecov.yml` sets lenient thresholds because coverage is deliberately partial. `.pre-commit-config.yaml` drives pre-commit.ci with minimal language-agnostic hooks only — `styler`/`lintr`/`roxygenize` were left out because `styler` would reformat nearly every file and destroy `git blame`.
 - **Any new top-level file must be added to `.Rbuildignore`** unless it genuinely belongs in the built package, or `R CMD check` NOTEs "non-standard file/directory found at top level" (and a separate NOTE for dotfiles). Add it in the same commit as the file. It is a set of *regexes anchored with `^`*, not globs (e.g. `^DECISIONS\.md$`); read the file for the current list.
-  - `^\.git$` is **not** redundant with `R CMD build`'s own exclusion — see [`DECISIONS.md`](DECISIONS.md#git-is-in-rbuildignore-because-a-worktrees-git-is-a-file). Build the release tarball at the repo root, not in a `git worktree`.
+  - `^\.git$` is **not** redundant with `R CMD build`'s own exclusion — see [`MAINTENANCE.md`](MAINTENANCE.md#git-is-in-rbuildignore-because-a-worktrees-git-is-a-file). Build the release tarball at the repo root, not in a `git worktree`.
   - `.Rbuildignore` and `.gitignore` are **not** interchangeable. `R CMD build` works from the *working directory*, not from git, so a file that is git-ignored but present on disk still ships in the tarball unless `.Rbuildignore` also excludes it. Untracking a file is never a substitute for `.Rbuildignore`ing it.
 
-## DECISIONS.md
+## Which file a thing goes in
 
-`DECISIONS.md` records **why** the package is the way it is: the measurement that ruled an
-option out, the alternative that looked obvious and was wrong, the thing that looks like a
-bug and is deliberate. It is tracked in git and organised **by theme, not by date**. It
-replaced a chronological session log; do not recreate one.
+Each doc has one job, and **every one carries a line budget** — over it, something comes out
+before something goes in. Put a fact in exactly one of them and reference it from the others; a
+duplicated rule drifts, and the copy a reader hits first is then wrong.
+
+| file | its job |
+|---|---|
+| `AGENTS.md` | conventions for agents (this file) |
+| `CONTRIBUTING.md` | how to contribute: setup, tests, PRs, code conventions |
+| `RELEASING.md` | the release checklist and why it is ordered that way |
+| `MAINTENANCE.md` | how the repo's CI, gates and generated files are wired |
+| `SECURITY.md` | vulnerability reporting and dependency posture |
+| `DECISIONS.md` | why the **package** behaves as it does |
+| `NEWS.md` | what changed for users |
+
+`DECISIONS.md` is the one most often misfiled into. Its subject is what `generateCI()` returns
+and why a number cannot change — **not** how CI is wired or how a release is cut. The test:
+would this still matter if the package were maintained somewhere else entirely?
 
 - **Update it as decisions are made**, not in a sweep at the end — the reasoning and the
   numbers are only cheap to write down while they are still to hand.
 - **Add an entry when a decision was not obvious.** Rejecting a plausible alternative,
   measuring something surprising, or deliberately *not* fixing something all qualify. Routine
   changes do not.
-- **Edit entries in place** when they stop being true. It is not an append-only log, and it
-  carries no dates, state or next-steps sections — the issue tracker holds what is left to do
-  and `NEWS.md` holds what changed for users.
-- **Do not restate in `DECISIONS.md` what this file or `CONTRIBUTING.md` already says.** Reference it instead. A duplicated rule drifts, and the copy a reader
-  happens to hit first is then wrong.
+- **Edit entries in place** when they stop being true. It is organised by theme, carries no
+  dates, state or next-steps sections, and replaced a chronological session log — do not
+  recreate one.
+- **An edge case in a third-party tool is not a decision.** Work it out again if it recurs.
 
 ## Git and merge strategy
 
@@ -103,7 +115,7 @@ there should not be one: CRAN has no concept of it, this is a single-maintainer 
 it would add a permanent second merge direction for no gain. Feature branches → PR → squash
 onto `main`, and releases are marked by tags.
 
-- **The reproducibility gate is a release blocker.** `CONTRIBUTING.md` → "Releasing" holds the
+- **The reproducibility gate is a release blocker.** `RELEASING.md` holds the
   full checklist. The v1.0.1 reference is **pinned and does not advance** with each release —
   see [`DECISIONS.md`](DECISIONS.md#the-v101-reference-is-pinned-the-previous-release-is-a-second-run-not-a-replacement).
 - **`main` carries a `.9000` development version between releases.** Right after a release,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@ This file provides guidance to AI coding agents when working with code in this r
 It is the single source of truth for them; put conventions here.
 
 **Do not delete `CLAUDE.md`** — it is a stub that `@`-imports this file, and Claude Code
-loads only `CLAUDE.md`. Keep this file under 200 lines; adherence drops above that.
+loads only `CLAUDE.md`. **Keep this file under 2800 words** — counted in words, not lines,
+because a line budget is defeated by longer lines and this file has been the worst offender.
 
 ## What this is
 
@@ -32,6 +33,10 @@ A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`
 
 ## Testing and CI
 
+**The workflow inventory, the five required check names, and the two rules for editing them
+(never rename a job, never convert the gate to a `paths:` filter) are in `MAINTENANCE.md`.** Read
+it before touching `.github/workflows/`.
+
 - `tests/testthat/` has unit tests for every pure/deterministic function (`deg2rad`, `generateSinusoid`, `generateGabor`, `generateNoisePattern`, `generateNoiseImage`, `generateCINoise`), light/targeted tests for the I/O-heavy ones, and an end-to-end smoke test (`test-smoke-pipeline.R`).
 - `tests/testthat/helper-fixtures.R` provides shared fixtures: `make_square_png()` (synthetic base face — never a real photo), `make_fixture_rdata()` (runs a tiny `generateStimuli2IFC()` and returns the `.Rdata` path), `seed_reference_norms()` (pre-seeds a `reference_norms` vector so `computeInfoVal2IFC()` skips the expensive/interactive reference-distribution path).
 - `tests/testthat/test-fixed-bugs.R` holds regression tests for the P0 bugs found in the modernization pass. They assert *intended* behaviour — never the buggy output they replaced. If one fails, that is a regression; do **not** "fix" it by asserting the broken result, which locks the bug back in.
@@ -40,31 +45,31 @@ A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`
   - The battery is chosen by the **reference** version, not the current one (`RCICR_COMPARE_REF_VERSION`): calls that used to crash — `mask`, z-maps below 512px, undecorated z-maps — have no old value to compare against. Before adding a configuration, check the reference version can execute it; a crash on the reference side aborts the whole gate.
   - It needs ~1.5 GB of RAM at 512px and the reference version's own dependencies — `--install-deps` puts them in a throwaway library rather than the user's.
 - Both `devtools::test()` and `testthat::test_local()` set `NOT_CRAN=true` themselves, so neither can be used to verify that a `skip_on_cran()` actually fires.
-- `.github/workflows/reproducibility.yaml` runs the gate: `--quick` on every PR to `main`, full on release PRs, `v*` tags and manual dispatch. It tells them apart from `DESCRIPTION` — a version without the `.9000` suffix *is* a release — so the version bump turns the full gate on by itself. On a PR touching only inert files (prose, `man/`, `vignettes/`, `tests/`) the job runs, reports green and does no work; the allowlist is in the workflow, and anything unrecognised runs the gate. **Never convert this to a `paths:` filter** — a skipped required check never reports at all, which GitHub reads as pending forever, making every docs-only PR unmergeable.
-- **Five required status checks on `main`**: `compare`, `ubuntu-latest (release)`, `ubuntu-latest (devel)`, `macos-latest (release)`, `windows-latest (release)`. They are enforced by a **ruleset**, not classic branch protection, so `gh api repos/rdotsch/rcicr/branches/main` reports no required contexts and looks unconfigured. Query `gh api repos/rdotsch/rcicr/rules/branches/main` instead.
-- `.github/workflows/R-CMD-check.yaml` runs `R CMD check` over four jobs: `ubuntu-latest` on R `release` and `devel`, plus `macos-latest` and `windows-latest` on `release`. macOS and Windows are the two platforms CRAN gates on, and each has caught a failure that was green on Linux for months. **The job names are required checks matched by name** — add rows to the matrix freely, but never rename one, or the renamed check reads as pending forever and blocks every PR.
 - Because the checks are required, an infrastructure flake blocks a merge. **This environment cannot re-run one** — `gh run rerun` returns `Resource not accessible by integration`, as does dispatching R-hub — so re-runs and workflow dispatches need the maintainer and the Actions tab.
 - **The workflows only trigger on PRs targeting `main`**, so a stacked PR based on another branch gets pre-commit and nothing else — no `R CMD check`. Retargeting an existing PR does *not* re-fire them; close and reopen it.
-- `.github/workflows/test-coverage.yaml` uploads to Codecov (needs a `CODECOV_TOKEN` secret); `codecov.yml` sets lenient thresholds because coverage is deliberately partial. `.pre-commit-config.yaml` drives pre-commit.ci with minimal language-agnostic hooks only — `styler`/`lintr`/`roxygenize` were left out because `styler` would reformat nearly every file and destroy `git blame`.
 - **Any new top-level file must be added to `.Rbuildignore`** unless it genuinely belongs in the built package, or `R CMD check` NOTEs "non-standard file/directory found at top level" (and a separate NOTE for dotfiles). Add it in the same commit as the file. It is a set of *regexes anchored with `^`*, not globs (e.g. `^DECISIONS\.md$`); read the file for the current list.
   - `^\.git$` is **not** redundant with `R CMD build`'s own exclusion — see [`MAINTENANCE.md`](MAINTENANCE.md#git-is-in-rbuildignore-because-a-worktrees-git-is-a-file). Build the release tarball at the repo root, not in a `git worktree`.
   - `.Rbuildignore` and `.gitignore` are **not** interchangeable. `R CMD build` works from the *working directory*, not from git, so a file that is git-ignored but present on disk still ships in the tarball unless `.Rbuildignore` also excludes it. Untracking a file is never a substitute for `.Rbuildignore`ing it.
 
 ## Which file a thing goes in
 
-Each doc has one job, and **every one carries a line budget** — over it, something comes out
-before something goes in. Put a fact in exactly one of them and reference it from the others; a
+Each doc has one job, and **each states a word budget** — over it, something comes out before
+something goes in. Put a fact in exactly one of them and reference it from the others; a
 duplicated rule drifts, and the copy a reader hits first is then wrong.
 
-| file | its job |
-|---|---|
-| `AGENTS.md` | conventions for agents (this file) |
-| `CONTRIBUTING.md` | how to contribute: setup, tests, PRs, code conventions |
-| `RELEASING.md` | the release checklist and why it is ordered that way |
-| `MAINTENANCE.md` | how the repo's CI, gates and generated files are wired |
-| `SECURITY.md` | vulnerability reporting and dependency posture |
-| `DECISIONS.md` | why the **package** behaves as it does |
-| `NEWS.md` | what changed for users |
+| file | its job | budget |
+|---|---|---|
+| `AGENTS.md` | conventions for agents (this file) | 2800 |
+| `CONTRIBUTING.md` | how to contribute: setup, tests, PRs, code conventions | 2800 |
+| `RELEASING.md` | the release checklist and why it is ordered that way | 1600 |
+| `MAINTENANCE.md` | how the repo's CI, gates and generated files are wired | 1800 |
+| `SECURITY.md` | vulnerability reporting and dependency posture | 600 |
+| `DECISIONS.md` | why the **package** behaves as it does | 5200 |
+| `NEWS.md` | what changed for users | none — trimmed at each release |
+
+Budgets are in **words, not lines**: a line budget is defeated by writing longer lines, which
+is exactly how this file grew to hold more words than `CONTRIBUTING.md` in two-thirds the lines.
+`wc -w` is the check.
 
 `DECISIONS.md` is the one most often misfiled into. Its subject is what `generateCI()` returns
 and why a number cannot change — **not** how CI is wired or how a release is cut. The test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ that are specific to this package — the rest is ordinary R package practice. R
 `RELEASING.md`, the repository's automation in `MAINTENANCE.md`, and why the package behaves
 as it does in `DECISIONS.md`.
 
-**Keep this file under 320 lines.** A convention nobody reaches is not a convention; over
+**Keep this file under 2800 words.** A convention nobody reaches is not a convention; over
 budget, something comes out before something goes in.
 
 ## The one constraint that shapes everything else
@@ -55,9 +55,8 @@ _R_CHECK_CRAN_INCOMING_=TRUE _R_CHECK_CRAN_INCOMING_REMOTE_=TRUE \
   R CMD check --as-cran rcicr_X.Y.Z.tar.gz
 ```
 
-Without the toolchain a run here reported 1 ERROR + 1 WARNING + 4 NOTEs that were entirely
-the sandbox — no `pdflatex`, no `tidy`, and a leftover `rcicr-manual.tex` from the failed PDF
-build. Installing it was the only change needed to reach 2 NOTEs. **Do not reach for
+Without the toolchain a run here reported 1 ERROR + 1 WARNING + 4 NOTEs that were entirely the
+sandbox; installing it was the only change needed to reach 2. **Do not reach for
 `--no-manual` to make the manual checks go away**: it skips them rather than passing them,
 and a note here once recorded that as the problem being *resolved*. A clean run shows
 `checking PDF version of manual ... OK` and `checking HTML version of manual ... OK` — if
@@ -129,70 +128,41 @@ attaching a real face photo.
 
 ### The Codex review
 
-Codex reviews pull requests here and has caught real errors (#170, #172, #173, and three on the
-PR that wrote this section). Nothing in the merge path makes you notice it: it submits as
-`COMMENTED`, so it never blocks and `reviewDecision` stays empty; `gh pr checks` is green
-regardless; and `gh pr view --comments` shows only the review wrapper, never the findings.
+Codex reviews pull requests here and has caught real errors. Nothing in the merge path makes
+you notice it: it submits as `COMMENTED`, so `gh pr checks` stays green and
+`gh pr view --comments` shows only the wrapper, never the findings.
 
-**It must not become something that can block.** If it has been switched off, or simply is not
+**It must not become something that can block.** If it is switched off, erroring, or simply not
 answering, merge on the other checks.
+
+Push everything first — a push does not re-trigger the review; only this comment, opening the
+PR, or marking a draft ready does. Keep the timestamp it returns:
+
+```sh
+trig=$(gh api repos/rdotsch/rcicr/issues/<n>/comments -f body='@codex review' --jq '.created_at')
+```
 
 Two conditions clear a squash.
 
-1. **Push everything, then trigger, keeping the timestamp.** A push does not re-trigger the
-   review — only this comment, opening the PR, or marking a draft ready does. Posting it
-   returns the anchor you need:
-   ```sh
-   trig=$(gh api repos/rdotsch/rcicr/issues/<n>/comments -f body='@codex review' --jq '.created_at')
-   ```
-2. **Wait for a 👍 newer than `$trig`.** The reaction on the PR body tracks the *latest run*
-   rather than the PR's history: 👀 while it runs, 👍 when it finishes with nothing to say, and
-   no reaction at all when it has findings.
+1. **A 👍 newer than `$trig`.** The reaction tracks the latest run: 👀 running, 👍 clean, none
+   when it has findings. Filter on the numeric account id — reactions are open to anyone with
+   read access, and an id survives a rename.
    ```sh
    gh api repos/rdotsch/rcicr/issues/<n>/reactions \
-     --jq '.[] | select(.user.id == 199175422) | "\(.user.login) \(.content) \(.created_at)"'
+     --jq '.[] | select(.user.id == 199175422) | "\(.content) \(.created_at)"'
    ```
-   Only a `+1` dated after `$trig` clears it. 👀, nothing, and an older `+1` all mean not
-   cleared. The filter is Codex's numeric account id (`chatgpt-codex-connector[bot]`, printed
-   back so you can see whose reaction cleared the gate) because reactions are open to anyone
-   with read access: a substring match on the login would let any account containing "codex"
-   clear a review that is still running, and an id survives a rename besides. When not cleared,
-   read the findings and answer each one:
+   Anything else — 👀, nothing, an older `+1` — means read the findings and answer each.
+   `--paginate` is not optional; that endpoint pages at 30 and truncates silently.
    ```sh
    gh api --paginate repos/rdotsch/rcicr/pulls/<n>/comments --jq '.[] | "\(.path): \(.body)"'
    ```
-3. **Resolve every thread you have answered.** The 👍 speaks only for the latest run, so a
-   finding left unanswered from an earlier round does not stop a later clean one. This half is
+2. **Every answered thread resolved**, via the `resolveReviewThread` mutation. This half is
    **enforced rather than checked**: the `main` ruleset sets `required_review_thread_resolution`,
-   so an unresolved thread blocks the squash server-side and no client-side count can clear it
-   by mistake. Resolve one by passing its `id` to the `resolveReviewThread` mutation.
+   so an unresolved thread blocks the squash server-side.
 
-   To read what is still open — for answering, not for deciding:
-   ```sh
-   gh api graphql -f query='query { repository(owner: "rdotsch", name: "rcicr") {
-     pullRequest(number: <n>) { reviewThreads(first: 100) { nodes { id isResolved path } } } } }' \
-     --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
-   ```
-   That reads the first 100 threads and does not paginate, which is why it must not be the
-   gate: on a PR with more it would report nothing while an unresolved thread sat on page two.
-   GitHub is the gate; this is a convenience.
-
-`--paginate` on the findings listing is not optional: that endpoint pages at 30, and a
-review-heavy PR truncates silently without it. The filter there is per-element, so it prints
-every finding whichever way the pages arrive.
-
-One green state, everything else not green: anything other than a 👍 newer than your trigger
-sends you to read the findings, whose worst case is a wasted look. Earlier versions of this
-section computed completion from review objects and `commit_id` and were wrong six separate
-ways — reporting a clean run as unfinished, an unrelated bot comment as clean, and hiding a
-reply because replies inherit the parent thread's commit. The lesson each time was the same:
-a client-side predicate that answers "is this safe to merge" fails open. The reaction is the
-one signal Codex sets deliberately, and thread resolution is enforced by GitHub rather than
-counted here.
-
-CI runs `R CMD check` on the current R release and devel, reports coverage to Codecov, and
-runs a small set of whitespace/YAML pre-commit hooks. `styler` and `lintr` are deliberately
-**not** run: they would reformat nearly every file in one sweep and destroy `git blame`.
+Do not compute "is this safe to merge" client-side. Earlier versions of this section derived it
+from review objects and `commit_id` and were wrong six separate ways, each failing *open*. The
+reaction is the one signal Codex sets deliberately; thread resolution is GitHub's to enforce.
 
 ## Code conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,12 @@
 # Contributing to rcicr
 
 Contributions, thoughts and criticisms are welcome. This file records the few conventions
-that are specific to this package — the rest is ordinary R package practice.
+that are specific to this package — the rest is ordinary R package practice. Releases are in
+`RELEASING.md`, the repository's automation in `MAINTENANCE.md`, and why the package behaves
+as it does in `DECISIONS.md`.
+
+**Keep this file under 320 lines.** A convention nobody reaches is not a convention; over
+budget, something comes out before something goes in.
 
 ## The one constraint that shapes everything else
 
@@ -23,7 +28,7 @@ Document it; do not update the baseline to match.
 
 `tools/compare-release-output.R` asks the same question from the outside: it installs a
 released version of the package from its own commit, runs both versions over a battery of
-configurations, and compares. Every release has to pass it — see **Releasing** below.
+configurations, and compares. Every release has to pass it — see `RELEASING.md`.
 
 ## Getting set up
 
@@ -253,183 +258,6 @@ Three rules that are about this package rather than about R:
   collision silently overwrites the argument — this has caused three separate bugs, most
   recently a saved `sigma` capturing `generateCI()`'s z-map blur `sigma`. [`DECISIONS.md`](DECISIONS.md#load-assigns-into-the-calling-frame--check-every-new-argument-against-saved-names) has
   the details.
-
-## Releasing
-
-Releases are squash-merged onto `main` and marked with a tag; there is no `develop` branch.
-The version in `DESCRIPTION` carries a `.9000` suffix between releases, and the release
-commit is the one that drops it.
-
-**Step 1 is the reproducibility gate, and a release does not go out while it is red.**
-
-```sh
-Rscript tools/compare-release-output.R                 # vs v1.0.1 -- the published baseline
-Rscript tools/compare-release-output.R --ref=v1.1.0    # vs the last release
-```
-
-Both runs are required, and they answer different questions. The first asks whether this
-tree still produces the numbers that are *in the literature* — it stays pinned at v1.0.1,
-the last version on CRAN, and never advances, because a reference that moves forward with
-each release lets a tree drift away from those numbers one tolerated epsilon at a time. The
-second asks whether anything broke since the last release, and covers more ground: calls
-that used to crash (masks, small z-maps, undecorated z-maps) have a comparable value in
-v1.1.0 and none at all in v1.0.1.
-
-Exit status is `0` for a clean run, `1` for a difference that is not accounted for, and `2`
-if the comparison could not be run at all. On a difference there are exactly two honest
-outcomes:
-
-- **it was not intended** — fix it; or
-- **it was intended** — write it up in `NEWS.md` under "Reproducibility impact", saying who
-  is affected and what to do, and add an entry to `EXPECTED` in the script naming the
-  reference, the affected output, the reason, and that `NEWS.md` heading. The script fails
-  if an `EXPECTED` entry stops firing (so the list cannot rot) and if it fires while
-  `NEWS.md` says nothing (so a deviation cannot be quiet).
-
-Silently widening a tolerance, deleting a configuration from the battery, or skipping the
-run is none of those things. The whole point is that a change to researchers' numbers can
-only get out deliberately and loudly.
-
-### 1. Prepare the release PR
-
-Branch from `main` (`release-X.Y.Z` by convention) and make these five edits together:
-
-```sh
-Rscript tools/compare-release-output.R              # both gate runs green
-Rscript tools/compare-release-output.R --ref=vA.B.C # the previous release
-R CMD build . && R CMD check --as-cran rcicr_*.tar.gz
-```
-
-- **`NEWS.md`**: rename `# rcicr (development version)` to `# rcicr X.Y.Z (YYYY-MM-DD)`.
-  Until you do, none of this release's entries are in the news database at all — R indexes
-  only sections under a heading it can read a version from. Keep version numbers *out* of
-  `##` section headings, or the whole file stops parsing and `R CMD check` NOTEs.
-- **`DESCRIPTION`**: drop the `.9000`. This is also what switches CI from the everyday
-  `--quick` gate to the full battery, so it has to happen **before** the PR is opened, not
-  after review.
-- **`ChangeLog`**: add a dated pointer entry deferring to `NEWS.md` — not a duplicate. See
-  [`DECISIONS.md`](DECISIONS.md#changelog-gets-a-pointer-entry-not-a-duplicate) for why.
-- **`CITATION.cff`**: regenerate it, after the `DESCRIPTION` edit above, with
-  `cffr::cff_write("DESCRIPTION", dependencies = FALSE, gh_keywords = FALSE)` — it carries the
-  version. `ubuntu-latest (release)` regenerates and compares, so it fails until you do.
-- **`cran-comments.md`**: re-read every claim in it rather than trusting it. It has gone
-  stale *within a single day* before, by describing a URL reference that another PR had
-  just removed, one step short of a CRAN reviewer reading it. Leave the test-environment
-  results for step 2; everything else is written now.
-
-Open the PR. The full battery runs on it, takes ~20 minutes, and is a required check.
-
-### 2. Run the external checks — on the release branch, before merging
-
-win-builder and R-hub run against the release branch, and their results go into
-`cran-comments.md` **in the same PR**, so the release commit carries its own evidence.
-
-```sh
-R CMD build .                                # at the repo root, never in a worktree
-R CMD check --as-cran rcicr_X.Y.Z.tar.gz
-curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-devel/
-curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-release/
-```
-
-Then trigger R-hub from the Actions tab against the release branch. Two NOTEs are expected
-locally and explained in `cran-comments.md` — CRAN incoming feasibility (new submission of
-an archived package) and future file timestamps (no network clock in a sandbox).
-
-This ordering works because **`cran-comments.md` is `.Rbuildignore`d and never reaches the
-tarball**, so writing the results into it cannot invalidate the checks those results
-describe — the tarball is unchanged. And `DESCRIPTION` on the release branch already carries
-the clean version, so the checks see the exact version string that will be submitted.
-
-Neither check is run casually: win-builder mails the maintainer, and both put the tarball in
-front of a third party.
-
-- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()` do the
-  same thing as the `curl` lines above. Each FTPs the tarball to `win-builder.r-project.org`
-  and mails a check log to the maintainer address within the hour; `226` means the transfer
-  completed. The server **will not overwrite an existing upload**: a second attempt at the
-  same filename fails with a bare `Failed FTP upload: 550`, which means "already queued", not
-  "rejected". Confirm with `curl --list-only ftp://win-builder.r-project.org/R-devel/` before
-  re-uploading, or you will conclude the upload failed when it succeeded. The mail carries a
-  result URL; `curl -s https://win-builder.r-project.org/<key>/00check.log` fetches the full
-  log, which beats transcribing the one-line summary. The pages expire after ~72 hours, so
-  `cran-comments.md` is the durable copy.
-- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
-  on this repository's own Actions rather than uploading anywhere. Trigger it from the
-  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
-  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
-  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
-  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
-  **default branch** before it can be triggered at all, and R-hub wants the file on the
-  default branch *and* on whichever branch is being checked.
-
-  To read the results, **download the artifacts — do not use `gh run view --log`**, which
-  truncates long jobs: at 1.2.1 the 38-minute macOS job returned 1548 lines ending four
-  minutes in, with no `Status:` line anywhere. `gh run download <run-id> -D <dir>` and read
-  `*/rcicr.Rcheck/00check.log`. Expect `Status: OK` where win-builder reports 1 NOTE — R-hub
-  does not run the CRAN incoming feasibility check, so that is agreement, not a discrepancy.
-
-  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
-  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
-  optional slot for your own PAT to reach private repositories — not a credential R-hub
-  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
-  any step. This package is public; an unset secret expands to an empty string and the jobs
-  run normally.
-
-### 3. Merge and tag
-
-```sh
-gh pr merge <n> --squash --delete-branch
-git checkout main && git pull && git fetch --prune
-git tag -a vX.Y.Z -m "rcicr X.Y.Z" && git push origin vX.Y.Z
-gh release create vX.Y.Z --title "rcicr X.Y.Z" --notes-file <(...)   # NEWS section
-```
-
-The tag push re-runs the full gate against the released tree, which is the copy that
-matters. Squash-merge, always: one commit per PR on `main`, and the squash message is where
-measurements and rejected alternatives have to live, because the branch commits disappear.
-
-**Confirm the squash did not change the tree** the external checks ran on:
-
-```sh
-git diff <pr-head-sha> vX.Y.Z --stat    # must be empty
-```
-
-Empty output is what lets step 2's results stand for the tagged tree.
-
-### 4. Submit to CRAN
-
-```sh
-git switch --detach vX.Y.Z      # never build from main HEAD, never in a worktree
-R CMD build .
-R CMD check --as-cran rcicr_X.Y.Z.tar.gz
-git switch -                    # back to where you were
-```
-
-Building from the tag is what keeps the development suffix out of the submitted version:
-`Version contains large components` is only a CRAN blocker if the *tarball* carries it.
-
-Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-comments.md`
-into the "Optional comment" field — that file is `.Rbuildignore`d and reaches CRAN only this
-way, never inside the tarball. `devtools::submit_cran()` does the same thing.
-
-**Paste the tag's copy, not `main`'s** — `git show vX.Y.Z:cran-comments.md`. Submission can
-trail tagging by weeks, and `main` moves in between; its copy would describe check results
-from a tree that is not the tarball, and nothing in the submission would contradict it.
-
-**Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
-package archived over an undeliverable address, that confirmation *is* the point of the
-resubmission.
-
-### 5. Reopen development
-
-Bump `DESCRIPTION` to `X.Y.Z.9000` and start a fresh `# rcicr (development version)` heading
-in `NEWS.md`. `main` is protected, so this goes through a small PR like anything else.
-
-`.github/workflows/reproducibility.yaml` runs the gate on every PR to `main` (`--quick`,
-which skips the 512px configuration) and in full on release PRs, version tags and manual
-dispatch. The `compare` job is a **required status check** on `main`, alongside
-`R CMD check` on release and devel, so a red gate blocks the merge rather than merely
-reporting. That is a repository ruleset, not something the workflow can enforce on itself.
 
 ## Larger changes
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,13 +1,23 @@
 # Decisions
 
-Why `rcicr` is the way it is: the measurement that ruled an option out, the alternative that
-looked obvious and was wrong, the thing that looks like a bug and is not. `NEWS.md` holds what
-changed for users, the issue tracker what is left, `AGENTS.md` and `CONTRIBUTING.md` the
-conventions — none of them has room for *why*.
+Why `rcicr` behaves as it does: the measurement that ruled an option out, the alternative that
+looked obvious and was wrong, the thing that looks like a bug and is not.
+
+**This file is about the package, not about the repository.** Its subject is what
+`generateCI()` returns and why a number cannot change — not how CI is wired, how a release is
+cut, or which documents exist. Those are `MAINTENANCE.md`, `RELEASING.md` and `SECURITY.md`;
+`CONTRIBUTING.md` holds the conventions and `NEWS.md` what changed for users. A decision that
+would still matter if this package were maintained somewhere else entirely belongs here.
 
 **Add an entry when a decision was not obvious**: a plausible alternative rejected, something
 surprising measured, something deliberately not fixed. Entries are grouped by theme, not by
 date, and are edited in place when they stop being true.
+
+**Keep this file under 550 lines.** It is read to answer "why is this like this", and a file
+long enough to skim is one whose answer is never found. Over budget, something comes out before
+something goes in. Write the decision and the evidence, not the route taken to it: an entry
+earns its length from a measurement or a rejected alternative, never from narrating how it was
+reached.
 
 > This was a chronological session log (`.session-log.md`) until 2026-07-27. The original
 > narrative, with dates and intermediate states, is in git history up to `887aea4`.
@@ -273,33 +283,22 @@ from the paper or a hand-computed 2×2 CI with a known reference vector, not a t
 restatement of the same expression.
 
 ### Pixel assertions have measured the graphics device twice
-The practice this produced — uniform backgrounds, colour channels only, comparisons rather
-than pinned values — is in `CONTRIBUTING.md`. Here is what it cost to learn, twice in the same
-fix. (`plotZmap`'s tests were three-quarters `file.exists()` before any of it; a function
-writing a uniformly blank PNG passed them all.)
+The practice — uniform backgrounds, colour channels only, comparisons rather than pinned
+values — is in `CONTRIBUTING.md`. Here are the two measurements behind it, made one line apart
+in the same fix.
 
-Count distinct values over the **colour channels only**, never the raw array. Whether a PNG
-device writes an alpha channel is a property of the graphics backend, not of what was drawn:
-cairo (Linux, Windows) writes RGB, macOS quartz writes RGBA. An opaque alpha plane is a solid
-block of 1s, so it adds a second distinct value to the array while nothing has been painted.
-The original `expect_length(unique(as.vector(png)), 1)` therefore measured the backend as much
-as the drawing, and `test-plotZmap.R` now drops any alpha plane before counting.
+**Channel count belongs to the backend.** cairo (Linux, Windows) writes RGB, macOS quartz writes
+RGBA, and an opaque alpha plane is a solid block of 1s — so it adds a distinct value while
+nothing has been painted. `expect_length(unique(as.vector(png)), 1)` measured the backend as
+much as the drawing. It was the only assertion in the suite counting distinct values rather than
+comparing two renders, and so the only one that failed when the suite first ran on macOS: an
+image-to-image comparison stays green because both sides gain the same plane.
 
-It was the *only* assertion in the suite counting distinct values rather than comparing two
-renders, which is why it was also the only one that failed when the suite first ran on macOS:
-every image-to-image comparison stays green because both sides gain the same plane. Prefer
-the comparison form for new tests.
-
-**The absolute pixel value is device-dependent too, and must not be asserted.** The first
-attempt at this fix pinned the flat value to the background grey — and failed on macOS, which
-renders `bgimage` 0.5 at ~0.573 where cairo gives 0.502. That is colour management, and
-precisely the same mistake the alpha fix was correcting, made one line below it. The check is
-now an *ordering*: the same render over a darker background must come out darker, which
-survives any monotone transfer function.
-
-**The general form:** when a test reads pixels back from a graphics device, every absolute
-property of those pixels belongs to the device — channel count and value alike. Only
-relationships between renders are portable.
+**So does the absolute value.** The first attempt at that fix pinned the flat value to the
+background grey and failed on macOS, which renders `bgimage` 0.5 at ~0.573 where cairo gives
+0.502 — colour management, the same mistake being corrected one line above. The check is now an
+*ordering*: the same render over a darker background must come out darker, which survives any
+monotone transfer function.
 
 ### The recovery test uses a permutation null, not a parametric one
 `test-recovery.R` gives a simulated observer a known template and asserts `generateCI()`
@@ -339,20 +338,22 @@ version still computes what old versions computed; `test-legacy-rdata.R` checks 
 still *read* what they wrote, which no other test can, because every other fixture is built by
 the current generator.
 
-Generating those files needs the old version installed — each one builds a cluster whose
-workers call `library(rcicr)`, so sourcing its R files is not enough, and v1.0.1 additionally
-needs `raster`, dropped in #186. Doing that at test time would put a package install and a
-network round trip inside the suite. Instead `tools/make-legacy-rdata.R` installs each tag into
-a throwaway library once and the resulting files are committed: 205 KB for 1.0.1 and 45 KB for
-1.1.0 at 32px — 1.0.1 is the larger because it is generated at `nscales = 5`, the historical
-default, so its missing-`nscales` fallback lands on the right noise basis. The safeguard runs
-in every CI job, on every platform, with no network. Regenerating is a deliberate act, as with
-the `released-formals` fixtures — a red test here means this version can no longer read a file
-a researcher already has, which is the failure, not the fixture.
+Generating them needs the old version *installed* — each builds a cluster whose workers call
+`library(rcicr)`, so sourcing its R files is not enough, and v1.0.1 additionally needs `raster`,
+dropped in #186. At test time that would put a package install and a network round trip inside
+the suite. Instead `tools/make-legacy-rdata.R` installs each tag into a throwaway library once
+and the files are committed, so the safeguard runs in every CI job, on every platform, with no
+network. Regenerating is a deliberate act: a red test here means this version can no longer read
+a file a researcher already has, which is the failure, not the fixture.
 
-Writing them also settled the `generator_version` question with data rather than documentation:
-the 1.0.1 and 1.1.0 files really do carry a top-level `'0.4.0'` while `p$generator_version`
-holds `'1.0.1'` and `'1.1.0'`.
+Each is generated at the era's **defaults** — `nscales = 5`, `sigma = 25` for 1.0.1 — so its
+missing-field fallbacks land on the right noise basis, which is the situation a returning
+researcher is actually in. Any other value would enshrine a wrong null. The gabor row exists
+because `sigma` reaches the basis through `generateGabor()` alone: sinusoidal norms are
+identical at `sigma` 25 and 10, so no sinusoidal fixture can exercise that fallback at all.
+
+Writing them also settled the `generator_version` question with data: the 1.0.1 and 1.1.0 files
+really do carry a top-level `'0.4.0'` while `p$generator_version` holds the truth.
 
 ### The v1.0.1 reference is pinned; the previous release is a *second* run, not a replacement
 The obvious move once a release is green is to make it the new reference. It is wrong. Each
@@ -432,22 +433,18 @@ trial's noise.
 
 ---
 
-## Packaging, CI and tooling
+## Arguments and internal guards
 
 ### Write paths are required arguments, not defaults of `tempdir()`
-CRAN's review of 1.2.1 asked us to "omit any default path in writing functions". Two answers
-would satisfy the letter of that: default the paths to `tempdir()`, or remove the defaults.
-We removed them.
+CRAN's review of 1.2.1 asked us to "omit any default path in writing functions". Defaulting to
+`tempdir()` would satisfy the letter and was **rejected as the more dangerous option**: a script
+relying on `./cis` would keep running, silently writing classification images into a directory
+deleted when the session ends, surfacing days later as missing output with nothing connecting it
+to an upgrade. Removing the default turns the same script into an immediate error naming the
+argument. A breaking change that announces itself beats a silent relocation of someone's results.
 
-`tempdir()` was rejected because it is the more dangerous of the two for this package's
-users. A researcher whose script relied on `./cis` would keep running, silently writing
-classification images into a directory that is deleted when the session ends — the failure
-surfaces days later as missing output, with nothing to connect it to an upgrade. Removing
-the default turns the same script into an immediate error naming the argument to supply. A
-breaking change that announces itself beats a silent relocation of somebody's results.
-
-It also cost nothing to verify: the release gate reports `max|d| = 0` across 135 checks
-against v1.2.1, because `tools/compare-harness.R` already passed every path explicitly.
+Cost nothing to verify: the gate reports `max|d| = 0` across 135 checks, because
+`tools/compare-harness.R` already passed every path explicitly.
 
 ### `captureArgs()` skips required-and-absent arguments, but never defaulted ones
 The `load()` guard snapshots a function's arguments and restores them after reading an
@@ -461,296 +458,6 @@ exists for: a default is the value the function goes on to use, and is exactly a
 replaceable by a field in the `.Rdata` as one passed explicitly. Dropping them removed the
 `step` guard in `computeCumulativeCICorrelation()` and the test caught it. The predicate is
 therefore *required* (no default in `formals()`) **and** absent — not absent alone.
-
-### `fail_ci_if_error: false` on the coverage workflow
-Chosen over getting a Codecov token or deleting the workflow. **This does not make coverage
-reporting work** — no token means no badge, no per-PR comments, and `codecov.yml`'s thresholds
-stay inert. What it buys is narrower and more useful: a red `main` now means the package is
-broken. The `token:` input is left wired so adding the secret later restores reporting.
-
-### `^\.git$` is in `.Rbuildignore` because a worktree's `.git` is a *file*
-`R CMD build` drops `.git` on its own, so the entry looks redundant. It is not: the built-in
-exclusion matches a **directory** named `.git`, and in a `git worktree` checkout `.git` is a
-49-byte text file holding a `gitdir:` pointer. It ships. The tarball then draws
-`checking for hidden files and directories ... NOTE`, naming `.git`, from a tree that looks
-identical to a clean one.
-
-This is not hypothetical — it reached win-builder. Building the tag in a worktree (the
-obvious way to honour "never build from `main` HEAD") returned 2 NOTEs where the same commit
-built at the repo root returned 1. Reproduced both ways before believing it: worktree tarball
-contains `rcicr/.git`, repo-root tarball contains no match.
-
-Separately: `.Rbuildignore` was itself listed in `.gitignore` from 2016 until 2026, an
-RStudio-template leftover, so it never reached CI or other contributors. Do not re-add it.
-
-### Dependabot watches the actions, not the R packages
-`.github/dependabot.yml` covers `github-actions` and nothing else. That is not an oversight,
-and the asymmetry is the point.
-
-**The R dependencies cannot be watched, and pretending otherwise is worse than the gap.**
-Dependabot has no CRAN ecosystem, and **CRAN publishes no security advisory database** — there
-is no `npm audit` equivalent for R. The nearest thing is Sonatype's OSS Index via `oysteR`,
-which as of 2026-07-29 returns **401 to anonymous requests** and so needs an account to run at
-all. Weighed and rejected: a scanner whose CRAN coverage is thin reports "clean" because its
-database is empty, not because the tree is safe, and a green badge that means nothing is worse
-than a known gap. The realistic dependency failure — an import getting archived — is already
-caught by `R CMD check` on four platforms on every push.
-
-Where the actual CVE surface lives is worth stating, because it is not in R code at all: 29 of
-the 53 packages in the recursive tree need compilation, and their vulnerabilities belong to the
-C libraries they bind to — **libpng** (`png`), **libjpeg** (`jpeg`), **GDAL/GEOS/PROJ**
-(`terra` ← `raster`). Those are patched by the user's operating system, not by CRAN, and
-nothing this package does can affect them. Dropping `raster` (issue #186) is the only
-lever that shrinks it.
-
-**The actions genuinely needed watching.** Twelve of the thirteen in use were on floating
-major tags, so whoever controls those repositories could change what runs in CI at any time —
-the one supply-chain surface here with real incident history, and the one Dependabot supports.
-Updates are **grouped into a single PR**, because `.github/workflows/` is deliberately not on
-the gate's inert allowlist, so ungrouped bumps would each spend a full CI round.
-
-### R-hub runs on `workflow_dispatch` only, never on push
-The R-hub v2 workflow is the stock file `rhub::rhub_setup()` writes, kept unmodified so it can
-be refreshed from upstream. It is left trigger-on-demand because R-hub answers a question that
-only arises at release time — does this build under CRAN's own compiler flags and on the
-odd platforms nobody develops on — and running it per-PR would spend a matrix of platforms on
-a question nobody asked yet, competing with the ~11-minute reproducibility gate that *is*
-required on every code PR.
-
-**R-hub does not stand in for per-platform coverage, and once wrongly appeared to.** This
-entry used to justify the per-PR gap by saying the everyday answer was "already covered by
-`R-CMD-check.yaml` on release and devel". That matrix varied only the *R version* against a
-pinned `ubuntu-latest` — one platform twice. The hole stayed invisible until the first R-hub
-dispatch failed a `plotZmap()` test on macOS that had been green on Linux for months (see
-the alpha-channel entry under Testing); CRAN builds on macOS, so it would have landed as a
-submission ERROR. **The lesson generalises: "already covered by X" is a claim about what X
-runs, and worth reading X to check rather than repeating.**
-
-Both platforms CRAN gates on are now in the everyday matrix. Windows was added on different
-grounds from macOS, and the distinction is the useful part: macOS had never been run, whereas
-Windows had passed on R-hub and win-builder — it was not an untested hole but a *late* one,
-checked only at release.
-
-The cost of `workflow_dispatch`-only is that the workflow is invisible until it reaches the
-**default branch** — GitHub offers no "Run workflow" button for a file that exists only on a
-feature branch. So it merges to `main` ahead of the release it is meant to check.
-
-### The pkgdown site deploys via a `gh-pages` branch, not the Actions-native route
-Pages was already configured here — `gh api repos/rdotsch/rcicr/pages` reported `status:
-built`, `build_type: legacy`, source branch `gh-pages` — and the only thing missing was that
-no such branch had ever been pushed, which is why the URL 404'd. Publishing that branch from
-a workflow therefore needed **no repository setting to change**. The Actions-native deploy
-would have been the more modern choice and was rejected on one fact: it requires flipping
-`build_type`, a repo-settings write that agents here cannot make (`Resource not accessible by
-integration`), turning a self-contained PR into one that stalls on the maintainer.
-
-`docs/` is the built site and is **git-ignored as well as `.Rbuildignore`d** — the two are not
-interchangeable, and a locally built site has already been committed by accident once.
-
-### The stale-`man/` gate is a step in an existing job, and a pre-commit hook was rejected
-`R CMD check` already fails on documentation that disagrees with a function's *signature* —
-`tools::codoc()`, confirmed by renaming `deg2rad`'s formal without regenerating `man/`. What it
-cannot see is prose drift: an edited `@description` or `@examples` never regenerated. The same
-edit leaves `codoc()` silent and still reaches the pkgdown site, which builds from `man/`. So
-the gate re-runs roxygen and diffs `man/` and `NAMESPACE`.
-
-Three things about where it lives:
-
-- **A step in `ubuntu-latest (release)`, not a new job or workflow.** Required checks are
-  matched by name, and adding a name to the ruleset is a repo-settings write agents here
-  cannot make — a new job would report without ever blocking. It runs last so a failure
-  cannot cost us the check results.
-- **Not a pre-commit hook.** R hooks were kept out of `.pre-commit-config.yaml` for their own
-  reasons, but the deciding one here is that the check job already has R and every dependency
-  installed, where a hook would install them per run — and an optional local hook is not a
-  gate.
-- **roxygen2 is pinned to `RoxygenNote`, not `any::`.** `.Rd` output varies between generator
-  versions, so `any::` lets a CRAN release of roxygen2 redden a required check on formatting
-  alone — an external event breaking the gate, in an environment that cannot re-run a job. The
-  step asserts the installed version matches `DESCRIPTION` so the pin cannot silently desync;
-  bumping the generator means bumping both.
-
-Nothing rebuilds the *site* locally or in a hook — the pkgdown workflow builds it on every PR
-and deploys on push, which is what catches a vignette that no longer knits.
-
-### `CITATION.cff` is generated by `cffr` and compared, not hand-written and field-checked
-The first version of this was hand-written, with a script comparing each field to a source of
-truth: title and authors to `inst/CITATION`, licence, URLs and addresses to `DESCRIPTION`,
-version and release date to `NEWS.md`. It was rejected *after* being built, because reviewing
-it turned up five defects in four rounds and every one was the same shape — a field the
-comparison did not reach. Unordered URL membership let `repository-code` and `url` swap; author
-comparison by name left the address unchecked, on a package CRAN archived for an undeliverable
-address; a missing source address compared as `""` against `"(absent)"`, which would have
-failed permanently for a future author with no email. A hand-written comparator is a list of
-the fields someone remembered, and the failure mode is silence.
-
-`cffr::cff_create()` derives the whole file, so the comparison is structural — regenerate,
-compare every key, and nothing depends on remembering a field. It also validates against the
-CFF schema, which is what makes a malformed file fail loudly; GitHub declines to render the
-"Cite this repository" button on a file it cannot parse and says nothing.
-
-Two measurements shaped how it is generated. `dependencies = TRUE`, the default, emits 380
-lines describing every dependency's authors, with years read from whichever versions happen to
-be installed — regenerating on a different machine produces a different file, so it is off.
-And `preferred-citation`'s year comes from `inst/CITATION`, which reads the clock when
-`DESCRIPTION` carries no publication date, so that one field changes on 1 January with nothing
-else: the comparison excludes it, or a required check would go red on a calendar boundary.
-`gh_keywords = FALSE` keeps generation off the network.
-
-The dependency and the second version pin — the two costs that argued for hand-writing it —
-are real but bought something. `version` now tracks `DESCRIPTION`, including the `.9000`
-suffix between releases, where the hand-written file deliberately named the last release; that
-is the one thing the switch gave up.
-
----
-
-## Releases and git
-
-The conventions and their rationale are in `AGENTS.md` — trunk-based with tags and no
-`develop` branch, `.9000` on `main` between releases, tarballs built from the tag, squash
-merges, delete merged branches, `NEWS.md` ordered largest-impact first. Two things learned
-the hard way that those entries do not cover:
-
-- **Squash merging is what makes a bad commit cheap.** One branch here carried ~75,000 lines
-  of committed `R CMD check` artifacts across three commits; `main` only ever saw the final
-  tree, so no history rewrite was needed. (Both patterns are now in `.gitignore` and
-  `.Rbuildignore`, and the `git diff --stat main...HEAD` habit is in `CONTRIBUTING.md`.)
-- `git push origin --delete a b` is **atomic**: one stale name fails the whole command and
-  takes the other branch down with it. (`gh pr merge --delete-branch` has already removed the
-  remote branch anyway.)
-
-### External checks run on the release branch; the tag and `.9000` still precede acceptance
-The procedure is in `CONTRIBUTING.md` → "Releasing", step 2. What is not obvious is why it
-can work at all.
-
-**The circularity that appears to force checks after the tag is not real.** It looks as
-though results cannot be recorded in the commit they describe, because writing them changes
-the tree and so invalidates the tarball that was checked. But `cran-comments.md` is
-`.Rbuildignore`d and verifiably absent from the built tarball, so editing it produces the
-same tarball byte for byte. It is not a package artifact at all — it is the text pasted into
-the "Optional comment" field of the CRAN submission form. At 1.2.1 the checks ran *after* the
-tag and the `.9000` reopen, so the results landed on a development tree and the tag recorded
-no evidence that the tree it names had passed anything.
-
-**Deliberately *not* copied from `usethis:::release_checklist()`: tagging and reopening
-`.9000` still happen before CRAN accepts.** The `.9000` suffix is what selects `--quick` over
-the full ~20-minute battery, so holding `main` at a clean version across the weeks CRAN can
-take would run the full gate on every unrelated PR in that window. And a rejection means
-shipping X.Y.Z+1 anyway, leaving the tag naming a tree that was never on CRAN — already true
-of `v1.2.0` and `v1.2.2`, so the repository tolerates that cheaply.
-
-This variant is in one respect tighter than usethis's, which runs win-builder while
-`DESCRIPTION` still carries `.9000` and never re-checks after `use_version()` — recording
-results for a different version string than the one submitted.
-
-### GitHub releases carry notes only — the built tarball is not attached
-Asked and settled at the 1.2.1 release. A release page already offers "Source code (tar.gz)",
-which GitHub generates from the tag, and that is **not** the same artifact `R CMD build`
-produces: the git archive has no built vignettes in `inst/doc/` and does carry every
-`.Rbuildignore`d development file. Attaching the real tarball would put two different
-"source" downloads on one page, which is a support question waiting to happen, and a second
-artifact that can drift from the tag it claims to be.
-
-The convention this follows is r-lib's and the tidyverse's: CRAN hosts the tarball, and
-`remotes::install_github('rdotsch/rcicr@vX.Y.Z')` covers everyone else. That rcicr is
-currently *off* CRAN is the strongest argument the other way, and it was considered — it is
-temporary, and it does not outweigh publishing an artifact the project would then have to
-keep consistent at every release.
-
-What this deliberately gives up: the tarball is **not byte-reproducible from the tag**,
-because `R CMD build` stamps `Packaged: <timestamp>; <user>` into `DESCRIPTION`. So the exact
-bytes sent to CRAN are not archived anywhere and can only be rebuilt, into something
-marginally different. That is accepted: what has to be reproducible is the *tree*, which the
-tag pins exactly, and which is what both the release gate and `R CMD check` actually operate
-on. Nothing about a result depends on the timestamp in a tarball header.
-
-### Answer CRAN from the review text, and never send them a question a sweep can answer
-CRAN's review of 1.2.1 listed two `.Rd` files under "some code lines in examples are
-commented out". Working from a summary that had kept one of them, 1.2.2 replied that we could
-not find the commented line and **asked the reviewer which line she meant** — while the fix
-for the file she had named correctly sat in the same commit, made under a different point.
-Two further drafts repeated it.
-
-Three rules came out of that, and the first two are in `AGENTS.md`: log every reply verbatim
-in `notes/cran-review-<version>.md` and answer from the file; re-verify every claim in
-`cran-comments.md` against the tree rather than carrying it forward. The third is a matter of
-tone: **a question to the reviewer costs a round trip measured in weeks, and a sweep costs
-minutes.** Sweep everything the point could apply to, then report what was found.
-
-The same instinct applies in reverse — **do not explain a note the reviewer does not have.**
-`cran-comments.md` carried a paragraph answering a `medium.com` 403 that appears only on our
-local check, on no external check for 1.2.3, and not in CRAN's own pretest of 1.2.1. It was
-removed; the link stays in `README.md`, because `README.md` ships and removing it would
-invalidate the built tarball and force all five external checks to re-run for something no
-CRAN-side check has ever raised (issue #192).
-
-### Claims must survive on someone else's machine
-`cran-comments.md` twice stated a total runtime for the example set — "about nine seconds",
-then "about fifteen" — measured here. Both win-builder runs report 18s, so the reviewer's own
-log would have contradicted the letter arguing for the package. The rule is in `AGENTS.md`;
-what it is *not* is a ban on numbers. A ratio survives, and so does a comparison to a fixed
-bar such as CRAN's five-second per-example limit; `NEWS.md`'s "about 6x faster, 1.66s to
-0.28s per call" earns its place because a user feels that difference and the ratio holds
-anywhere. A bare absolute describes our hardware to a reader who has their own.
-
-### A work tracker carries no project state
-`BACKLOG.md` once held a "state as of" block plus a "Last updated" narrative — some 78 lines
-describing where the release stood. Every fact in them lived somewhere with a better claim:
-`NEWS.md`, `cran-comments.md`, `CONTRIBUTING.md` → "Releasing", and the open PRs. **It drifted
-four times, each within a day of a release**, which is what a duplicated fact does rather than
-what a careless author does; the fourth fix was to write it more carefully, and it was wrong
-within the hour. The rule outlived the file and applies to the issue tracker: a *hold
-condition* belongs on the issue it holds; the project's current position belongs nowhere in
-the tracker at all.
-
-Same reasoning as deleting the hand-maintained `Version:`/`Date:` table from
-`man/rcicr-package.Rd` in 1.2.3: the way to keep a fact current is to stop writing it twice.
-
-### The backlog moved to GitHub Issues, after the stale issues were triaged
-Done 2026-08-08: 21 issues opened as #174–#194 under `P0`–`P3` labels, and `BACKLOG.md`
-deleted. The sweep came first and was the hard prerequisite.
-
-**The tracker is treated as a working surface, not a curated public product surface** — so
-internal maintenance work belongs in it alongside user-visible bugs, as in r-lib repos. The
-alternative considered was keeping the tracker for things a researcher would recognise as
-affecting them and holding chores elsewhere; rejected because two backlogs is the same
-duplication problem one layer up, and because the drift this file produced came precisely
-from status living somewhere a human has to remember to update.
-
-**The ordering was not incidental.** All 25 open issues dated from 2016–2017, and opening 21
-new ones into that would have buried the triage under the migration. It also matters which half of
-this carries the value: **the sweep alone fixes the thing that actually costs something** —
-a tracker that reads as abandoned in 2017 while the package is being resubmitted to CRAN.
-The migration is the smaller remaining gain, which is why it is sequenced second rather than
-bundled.
-
-What deliberately does **not** become an issue: the "already correct — do not re-fix" entries.
-Those are decisions and belong here, and four moved into this file rather than onto the
-tracker — the InfoVal formula, `return_as_dataframe`'s one-image-per-trial shape, the emptied
-`ref_lookup` rows, and the infoVal test oracle that mirrors its implementation. The formula one
-was *already* duplicated here, which is what made the misfiling visible in the first place.
-
-**Known cost, accepted:** changes to the plan stop going through a reviewed PR, because issue
-edits are not reviewable. For a single maintainer that is close to zero.
-
-### `CLAUDE.md` is a stub that imports `AGENTS.md`, not a symlink
-Claude Code reads `CLAUDE.md` and does not read `AGENTS.md`, so renaming the conventions file
-in #166 silently stopped it loading in every agent session until 2026-08-08 — including the
-rules on `NEWS.md` headings, `.Rbuildignore` and `test-fixed-bugs.R`, each of which costs a
-release when broken.
-
-The documented fixes are a `CLAUDE.md` containing `@AGENTS.md`, or `ln -s AGENTS.md
-CLAUDE.md`. **The symlink was rejected**: it requires Administrator privileges or Developer
-Mode on Windows, and this package has Windows contributors and a Windows CI runner. The
-import is a plain file that git and every platform treat identically, and it leaves room for
-Claude-specific instructions below it. `AGENTS.md` stays the single source of truth.
-
-### `ChangeLog` gets a pointer entry, not a duplicate
-`NEWS.md` supersedes it, but someone opening `ChangeLog` first would otherwise conclude the
-last release is whatever it last recorded. Two changelogs both claiming authority is worse
-than one that defers.
-
----
 
 ## Documentation
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -13,7 +13,7 @@ would still matter if this package were maintained somewhere else entirely belon
 surprising measured, something deliberately not fixed. Entries are grouped by theme, not by
 date, and are edited in place when they stop being true.
 
-**Keep this file under 550 lines.** It is read to answer "why is this like this", and a file
+**Keep this file under 5200 words.** It is read to answer "why is this like this", and a file
 long enough to skim is one whose answer is never found. Over budget, something comes out before
 something goes in. Write the decision and the evidence, not the route taken to it: an entry
 earns its length from a measurement or a rejected alternative, never from narrating how it was
@@ -101,33 +101,28 @@ The same release also fixed `sinIdx` counting from 0 rather than 1, which is wha
 `pre_0.3.0` flag exists for. The two are independent and both live in that boundary.
 
 **The 0-based path in `generateNoiseImage()` looks like it corrupts the whole image and does
-not.** When `min(patchIdx) == 0`, `params[p$patchIdx]` drops every 0-indexed cell (R drops
-rather than `NA`s a 0 subscript), returning a vector too short for the patch array, which
-`array()` then recycles — the setup for a general misalignment. It is harmless because the
-same counter-from-0 leaves the *last* patch layer never written, so every `patchIdx == 0`
-cell is also a `patches == 0` cell (verified at every `nscales`) — the one-way implication
-masking needs, not an equivalence: a populated phase-0 layer has zero pixels too, so the
-converse is false. Those zero-index cells sit contiguously at the end of the column-major
-order, so the recycled values land only where the patch is identically zero and are
-multiplied away. Measured: the warning-branch output equals the
-honest "one patch not shown" result exactly (max abs diff 0) across 36 size/nscales/seed
-combinations, so the warning is accurate, not an understatement. This is not a self-fulfilling
-reconstruction: a stimulus file stores the patch array its own generator wrote
-(`generateStimuli2IFC()` `save()`s `p`), and the genuine pre-0.3.0 generator is the identical
-`co = 0` / `idx = 0` loop the `pre_0.3.0` flag runs — verified against the R-Forge source
-(`git show 7d0d9e6:pkg/R/rcicr.R`), where 0.3.0 only flipped the default and added the flag. So
-no genuine legacy file can carry index 0 on a populated patch, and the 0.3.0 `ChangeLog`
-independently records the effect as two single sinuses fixed in contrast rather than a
-whole-image change. Do **not** "fix" the recycle by 1-offsetting the index — that would change
-which sinusoid is dropped, altering the CI of every genuinely pre-0.3.0 file.
-`test-generateNoiseImage.R` pins the masking implication and the output equality so neither can
-be broken silently.
+not.** When `min(patchIdx) == 0`, `params[p$patchIdx]` drops every 0-indexed cell (R drops rather
+than `NA`s a 0 subscript), returning a vector too short for the patch array, which `array()` then
+recycles — the setup for a general misalignment. It is harmless because the same counter-from-0
+leaves the *last* patch layer never written, so every `patchIdx == 0` cell is also a
+`patches == 0` cell — the one-way implication masking needs, not an equivalence. Those cells sit
+contiguously at the end of the column-major order, so recycled values land only where the patch
+is identically zero and are multiplied away. Measured: identical to the honest "one patch not
+shown" result (max abs diff 0) across 36 size/nscales/seed combinations, so the warning is
+accurate rather than an understatement.
 
-The truncation this left behind in `generateCI()` had a dead branch for eleven years: the
-single-trial path tested for a length of 4092 and truncated to 4092, so it could never fire
-on the 4096-length input it was written for. **A backward-compatibility
-path that nothing exercises is indistinguishable from one that works** — this one had no test
-until 2026-07-28, and neither did the `sinusoids`/`sinIdx` path, which was also broken.
+Not a self-fulfilling reconstruction: a stimulus file stores the patch array its own generator
+wrote, and the genuine pre-0.3.0 generator is the identical `co = 0` / `idx = 0` loop the
+`pre_0.3.0` flag runs — verified against the R-Forge source (`git show 7d0d9e6:pkg/R/rcicr.R`),
+where 0.3.0 only flipped the default and added the flag. Do **not** "fix" the recycle by
+1-offsetting the index: that changes which sinusoid is dropped, altering the CI of every
+genuinely pre-0.3.0 file. `test-generateNoiseImage.R` pins both properties.
+
+The truncation left a dead branch in `generateCI()` for eleven years: the single-trial path
+tested for a length of 4092 and truncated to 4092, so it could never fire on the 4096-length
+input it was written for. **A backward-compatibility path that nothing exercises is
+indistinguishable from one that works** — it had no test until 2026-07-28, and neither did the
+`sinusoids`/`sinIdx` path, also broken.
 
 ### `load()` assigns into the calling frame — check every new argument against saved names
 An object in an `.Rdata` file silently overwrites a function argument of the same name.
@@ -149,33 +144,28 @@ It matches the erratum to Schmitz et al. (2019): the Euclidean norm, with *k* su
 Flagged as a bug and changed; **Ron overruled, and the change was reverted.** `$combined` must
 stay as the caller supplied it, so a combination made before autoscaling survives the call and
 existing scripts keep plotting the same image; `$scaled` carries the autoscaled result. The
-user-facing problem was never the code but that nothing said which field to look at — fixed in
-`?autoscale` and the vignette, plus a test asserting `$combined` comes back identical and
-warning against "fixing" it.
+user-facing problem was never the code but that nothing said which field to look at.
 
-The trap worth knowing: after `batchGenerateCI()` (which scales `'none'` first) `$combined` is
-an overlay of *unscaled* noise and looks almost blank. Build the overlay as `(ci$scaled +
-ci$base) / 2`, which is what `save_as_pngs = TRUE` writes.
+The trap worth knowing: after `batchGenerateCI()` (which scales `'none'` first) `$combined` is an
+overlay of *unscaled* noise and looks almost blank. Build it as `(ci$scaled + ci$base) / 2`, which
+is what `save_as_pngs = TRUE` writes.
 
-**What kept this cheap to undo:** the change was filed under its own "Behaviour change"
-heading rather than slipped in with unambiguous bug fixes. When a fix is debatable, say so.
+What kept this cheap to undo: it was filed under its own "Behaviour change" heading rather than
+slipped in with unambiguous bug fixes. **When a fix is debatable, say so.**
 
 ### `base_face_files` validation rejects two inputs that used to run
-Duplicate names, and a list element that is not a single file name, now stop the call. Both
-ran before, so this is a considered exception to the constraint above rather than a plain bug
-fix — and it is allowed because neither ever produced what the call asked for. `list(face =
-'a.png', face = 'b.png')` looks each name up by string, so it wrote **one** set of stimuli,
-from `a.png`, and nothing from `b.png`; verified against the pre-fix code, four files for two
-trials. A script that "worked" this way was generating stimuli for a base image it never
-named. Every other new check rejects input that already failed, just further downstream —
-inside a parallel worker, as `attempt to select less than one element in get1index`.
+Duplicate names, and a list element that is not a single file name, now stop the call. Both ran
+before, so this is a considered exception to the constraint above — allowed because neither ever
+produced what the call asked for. `list(face = 'a.png', face = 'b.png')` looks each name up by
+string, so it wrote **one** stimulus set, from `a.png`: verified against the pre-fix code, four
+files for two trials. A script that "worked" this way was generating stimuli for a base image it
+never named. Every other new check rejects input that already failed further downstream, inside a
+parallel worker.
 
-**Readability is checked by attempting the read, not by `file.access()`.** The obvious version
-— `file.access(filename, 4)` — is documented as unreliable on Windows and on networked
-filesystems, so it can reject a file that reads fine. `png::readPNG()` / `jpeg::readJPEG()`
-inside `tryCatch()` cannot be wrong about it, and keeping the reader's own message means the
-distinction between "not a PNG" and "permission denied" survives instead of being flattened
-into one guess.
+**Readability is checked by attempting the read, not by `file.access()`**, which is documented as
+unreliable on Windows and networked filesystems and can reject a file that reads fine. Keeping
+the reader's own message also preserves the difference between "not a PNG" and "permission
+denied".
 
 ### `_R_CHECK_LIMIT_CORES_` handling caps cores under check only
 `default_ncores()` returns 2 when that variable is set and `detectCores() - 1` otherwise. Only
@@ -192,20 +182,17 @@ string and a `package_version`, and compare with `numeric_version()` semantics �
 field; it detects the old `sinusoids`/`sinIdx` layout structurally. Just as well.
 
 ### `return_as_dataframe = TRUE` returns one noise image per trial, not per trial × base image
-`generateStimuli2IFC()`'s early `return()` (`R/generateStimuli2IFC.R:231`) sits *inside* the
-per-base-image loop at `:193`, so with several base images it fires on the first and the rest
-never run. Under the default
-`use_same_parameters = TRUE` that is correct — every base image shares one parameter set, so one
-noise image per trial is all there is — and the returned frame has one column per trial, so it
-could not represent the alternative anyway. Documented on `@param return_as_dataframe` rather
-than changed.
+`generateStimuli2IFC()`'s early `return()` sits *inside* the per-base-image loop, so with several
+base images it fires on the first and the rest never run. Under the default
+`use_same_parameters = TRUE` that is correct — every base image shares one parameter set — and
+the returned frame has one column per trial, so it could not represent the alternative anyway.
+Documented on `@param return_as_dataframe` rather than changed.
 
-InfoVal is unaffected, checked rather than assumed:
-`generateReferenceDistribution2IFC()` is the only in-package caller, it never passes
-`use_same_parameters`, and the first base image's parameters come from the same leading block of
-the RNG stream either way — measured identical, max absolute difference 0. Widening the frame to
-trial × base image would change the return shape, so it needs a **new argument**, never a
-redefinition.
+InfoVal is unaffected, checked rather than assumed: `generateReferenceDistribution2IFC()` is the
+only in-package caller, never passes `use_same_parameters`, and the first base image's parameters
+come from the same leading block of the RNG stream either way — measured identical, max absolute
+difference 0. Widening the frame would change the return shape, so it needs a **new argument**,
+never a redefinition.
 
 ### `computeCumulativeCICorrelation()` does not aggregate repeated stimuli, and its curve ends at 1 by construction
 `generateCI()` averages the responses to each unique stimulus before building its CI
@@ -213,30 +200,21 @@ redefinition.
 presentation order. Deliberate — collapsing repeats would discard exactly the order a cumulative
 curve is about.
 
-Two consequences, measured rather than reasoned about. With no `targetci` the function computes
-its own final CI from the same un-aggregated trials as the curve, so wherever the evaluated trials
-reach the last one the curve **ends at exactly 1** — self-consistency, not convergence. That is
-every call at the default `step = 1`, but not all of them: trials are taken at
-`seq(1, length(responses), step)`, so six responses at `step = 2` stop at the fifth and end at
-0.967, and at `step = 3` at the fourth and end at 0.938. Nor when the responses cancel exactly:
-that CI is uniformly zero, and correlating against a constant gives `NA` at *every* point, not
-just the last. And that self-computed final CI equals
-`generateCI()`'s only when every stimulus was presented the same number of times: with equal
-counts the two are bit-identical, while with unequal counts they weight the data differently —
-each trial equally here, each unique stimulus equally there. Measured on 32px sets: counts 3/1
-correlate at 0.845, counts 4/2/1/1 at 0.773, max absolute pixel differences 0.065 and 0.054. Not
-a rounding artefact.
+With no `targetci` the final CI is built from the same un-aggregated trials as the curve, so the
+curve **ends at exactly 1** — self-consistency, not convergence. Three conditions, all measured:
+it holds only where the evaluated trials reach the last one (six responses at `step = 2` stop at
+the fifth and end at 0.967, at `step = 3` at 0.938); and not at all when responses cancel
+exactly, since that CI is uniformly zero and correlating against a constant gives `NA` at *every*
+point.
 
-Documented in `?computeCumulativeCICorrelation` and pinned by a test, rather than changed.
-Aggregating the self-computed final CI would move numeric output for anyone calling it without
-`targetci`, and would stop the curve ending at 1 — a worse default than the one being fixed. The
-advice is to pass `targetci = generateCI(...)` when the comparison you want is against the CI you
-will report.
+That self-computed final CI equals `generateCI()`'s only under equal repeat counts, where the two
+are bit-identical. Unequal counts weight the data differently — each trial equally here, each
+unique stimulus equally there: counts 3/1 correlate at 0.845, counts 4/2/1/1 at 0.773.
 
-Whether `generateCI()`'s own equal-weight-per-unique-stimulus aggregation is the right weighting
-under unequal repeat counts is a separate question, filed rather than settled here: its code
-comment frames the aggregation as reducing memory and processing load, which only holds where the
-two weightings coincide.
+Documented and pinned by a test rather than changed. Aggregating the self-computed final CI would
+move numeric output for anyone calling without `targetci` *and* stop the curve ending at 1 — a
+worse default than the one being fixed. Whether `generateCI()`'s own weighting is right for
+unbalanced designs is filed separately.
 
 ### Repopulating `ref_lookup` costs four measurements — and the two halves stand or fall together
 `AGENTS.md` covers what the table is (not a cache, empty since 2018, every lookup misses). What
@@ -380,29 +358,25 @@ suite, and by the gate only from v1.1.0 onward — the `SINCE` table in `tools/c
 records which extras need which reference.
 
 ### Tolerances: 8 ULP scaled to the values, plus an 8-bit pixel count
-A flat `.Machine$double.eps` is the right bar for a classification image (values around 0.01)
-and far too tight for a z-map, whose values run to several units and whose one-ULP steps are
-therefore ~4× larger. So the tolerance is `8 * eps * max(1, max(abs(reference)))`: a few ULP
-*of the values involved*. Anything that could only come from a changed random stream, algorithm
-or file format — patch indices, drawn stimulus parameters, the base image, the stimulus PNGs —
-is required to be bit-identical instead, with no tolerance at all.
+A flat `.Machine$double.eps` is right for a classification image (values around 0.01) and far too
+tight for a z-map, whose values run to several units and whose one-ULP steps are ~4× larger. So
+the tolerance is `8 * eps * max(1, max(abs(reference)))`: a few ULP *of the values involved*.
+Anything that could only come from a changed random stream, algorithm or file format — patch
+indices, drawn parameters, the base image, the stimulus PNGs — must be bit-identical instead.
 
 **Why 8 and not 1.** These are not single passes over the data. A z-map is a convolution over
-262,144 pixels followed by a standardisation over the same 262,144 values, so a 3.5e-18
-difference in the classification image arrives as **1.33e-15** — measured at 512px, comparing
-the current tree against v1.0.1. One ULP of the largest value (9.0e-16) rejects that; eight
-accepts it and still sits three orders of magnitude below anything observable.
+262,144 pixels then a standardisation over the same values, so a 3.5e-18 difference in the CI
+arrives as **1.33e-15** — measured at 512px against v1.0.1. One ULP of the largest value
+(9.0e-16) rejects that; eight accepts it and still sits three orders of magnitude below anything
+observable.
 
-Widening a tolerance to make a run pass is exactly the move `CONTRIBUTING.md` warns against, so
-the distinction matters: what protects this comparison is not the numeric tolerance but the two
-**exact** checks beside it — 0 of N pixels may differ once quantised to 8 bits, and the NA
-pattern must match cell for cell. The z-map sigma bug moved 1,282 cells across the threshold
-and was caught by the NA check; every numeric tolerance considered here would have passed it.
-
-Image-like outputs additionally have to survive quantisation: 0 of N pixels may differ once
-rounded to 8 bits. That is the check that answers the question a researcher actually has, which
-is whether the PNG they publish changes, and it is why a 1.11e-16 difference in the CI is
-reported as a pass rather than argued about.
+Widening a tolerance to make a run pass is the move `CONTRIBUTING.md` warns against, so the
+distinction matters: what protects this comparison is not the tolerance but the two **exact**
+checks beside it — 0 of N pixels may differ once quantised to 8 bits, and the NA pattern must
+match cell for cell. The z-map sigma bug moved 1,282 cells across the threshold and was caught by
+the NA check; every numeric tolerance considered here would have passed it. The 8-bit check is
+also the one answering the question a researcher actually has — does the PNG I publish change —
+which is why a 1.11e-16 difference in the CI is a pass rather than an argument.
 
 ---
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -4,6 +4,37 @@ How this repository's automation is wired, and why. `CONTRIBUTING.md` is how to 
 `RELEASING.md` how to cut a release, `DECISIONS.md` why the package behaves as it does — this
 file is the machinery around them.
 
+**Keep this file under 1800 words.**
+
+---
+
+## The workflows
+
+| workflow | what it does |
+|---|---|
+| `R-CMD-check.yaml` | `R CMD check` on `ubuntu-latest` (release + devel), `macos-latest`, `windows-latest`. macOS and Windows are the platforms CRAN gates on, and each has caught a failure green on Linux for months. |
+| `reproducibility.yaml` | the release gate: `--quick` on every PR to `main`, full on release PRs, `v*` tags and dispatch. It tells them apart from `DESCRIPTION` — no `.9000` *is* a release — so the version bump turns the full gate on by itself. |
+| `test-coverage.yaml` | Codecov; needs a `CODECOV_TOKEN`. `codecov.yml` sets lenient thresholds because coverage is deliberately partial. |
+| `pkgdown.yaml` | builds the site on every PR, deploys on push to `main`. |
+| `rhub.yaml` | stock R-hub v2, `workflow_dispatch` only. |
+
+**Five required status checks on `main`**: `compare`, `ubuntu-latest (release)`,
+`ubuntu-latest (devel)`, `macos-latest (release)`, `windows-latest (release)`. They are enforced
+by a **ruleset**, not classic branch protection, so `gh api repos/rdotsch/rcicr/branches/main`
+reports no required contexts and looks unconfigured — query
+`gh api repos/rdotsch/rcicr/rules/branches/main` instead.
+
+Two consequences worth knowing before editing a workflow. **Required checks are matched by
+name**, so rows can be added to a matrix freely but never renamed — a renamed check reads as
+pending forever and blocks every PR. And **the gate must never become a `paths:` filter**: a
+skipped required check never reports at all, which GitHub also reads as pending forever, making
+every docs-only PR unmergeable. Instead the job always runs and exits early on an allowlist of
+inert paths, which is in the workflow; anything unrecognised runs the gate.
+
+`.pre-commit-config.yaml` drives pre-commit.ci with minimal language-agnostic hooks only.
+`styler` and `lintr` were deliberately left out: they would reformat nearly every file in one
+sweep and destroy `git blame`.
+
 ---
 
 ## CI, checks and packaging

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -122,4 +122,3 @@ contributors and a Windows CI runner. The `@AGENTS.md` import is a plain file ev
 treats identically.
 
 ---
-

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,125 @@
+# Maintaining the repository
+
+How this repository's automation is wired, and why. `CONTRIBUTING.md` is how to contribute,
+`RELEASING.md` how to cut a release, `DECISIONS.md` why the package behaves as it does — this
+file is the machinery around them.
+
+---
+
+## CI, checks and packaging
+
+### `fail_ci_if_error: false` on the coverage workflow
+Chosen over getting a Codecov token or deleting the workflow. **This does not make coverage
+reporting work** — no token means no badge, no per-PR comments, and `codecov.yml`'s thresholds
+stay inert. What it buys is narrower and more useful: a red `main` now means the package is
+broken. The `token:` input is left wired so adding the secret later restores reporting.
+
+### `^\.git$` is in `.Rbuildignore` because a worktree's `.git` is a *file*
+`R CMD build` drops `.git` on its own, so the entry looks redundant. It is not: the built-in
+exclusion matches a **directory** named `.git`, and in a `git worktree` checkout `.git` is a
+49-byte text file holding a `gitdir:` pointer. It ships. The tarball then draws
+`checking for hidden files and directories ... NOTE`, naming `.git`, from a tree that looks
+identical to a clean one.
+
+This is not hypothetical — it reached win-builder. Building the tag in a worktree (the
+obvious way to honour "never build from `main` HEAD") returned 2 NOTEs where the same commit
+built at the repo root returned 1. Reproduced both ways before believing it: worktree tarball
+contains `rcicr/.git`, repo-root tarball contains no match.
+
+Separately: `.Rbuildignore` was itself listed in `.gitignore` from 2016 until 2026, an
+RStudio-template leftover, so it never reached CI or other contributors. Do not re-add it.
+
+### R-hub runs on `workflow_dispatch` only, never on push
+The stock file `rhub::rhub_setup()` writes, kept unmodified so it can be refreshed upstream. It
+answers a release-time question — does this build under CRAN's own compiler flags, on platforms
+nobody develops on — so running it per-PR would spend a platform matrix on a question nobody
+asked, competing with the reproducibility gate that *is* required.
+
+**R-hub does not stand in for per-platform coverage.** The everyday matrix once varied only the
+R version against a pinned `ubuntu-latest` — one platform twice — and the hole stayed invisible
+until an R-hub dispatch failed a `plotZmap()` test on macOS that had been green on Linux for
+months. CRAN builds on macOS, so it would have landed as a submission ERROR. **"Already covered
+by X" is a claim about what X runs, worth reading X to check.** Both platforms CRAN gates on are
+in the matrix now.
+
+Cost of dispatch-only: the workflow is invisible until it reaches the **default branch** —
+there is no "Run workflow" button for a file on a feature branch — so it merges ahead of the
+release it checks.
+
+### The pkgdown site deploys via a `gh-pages` branch, not the Actions-native route
+Pages was already configured here — `gh api repos/rdotsch/rcicr/pages` reported `status:
+built`, `build_type: legacy`, source branch `gh-pages` — and the only thing missing was that
+no such branch had ever been pushed, which is why the URL 404'd. Publishing that branch from
+a workflow therefore needed **no repository setting to change**. The Actions-native deploy
+would have been the more modern choice and was rejected on one fact: it requires flipping
+`build_type`, a repo-settings write that agents here cannot make (`Resource not accessible by
+integration`), turning a self-contained PR into one that stalls on the maintainer.
+
+`docs/` is the built site and is **git-ignored as well as `.Rbuildignore`d** — the two are not
+interchangeable, and a locally built site has already been committed by accident once.
+
+### The stale-`man/` gate is a step in an existing job, and a pre-commit hook was rejected
+`R CMD check` already fails on documentation that disagrees with a function's *signature* —
+`tools::codoc()`, confirmed by renaming `deg2rad`'s formal without regenerating `man/`. What it
+cannot see is prose drift: an edited `@description` or `@examples` never regenerated. The same
+edit leaves `codoc()` silent and still reaches the pkgdown site, which builds from `man/`. So
+the gate re-runs roxygen and diffs `man/` and `NAMESPACE`.
+
+Three things about where it lives:
+
+- **A step in `ubuntu-latest (release)`, not a new job.** Required checks are matched by name,
+  and adding a name to the ruleset is a repo-settings write agents here cannot make — a new job
+  would report without ever blocking. It runs last so a failure cannot cost us the check results.
+- **Not a pre-commit hook.** The check job already has R and every dependency installed where a
+  hook would install them per run, and an optional local hook is not a gate.
+- **roxygen2 is pinned to `RoxygenNote`, not `any::`.** `.Rd` output varies between generator
+  versions, so `any::` lets a CRAN release of roxygen2 redden a required check on formatting
+  alone — an external event breaking the gate, in an environment that cannot re-run a job. The
+  step asserts the installed version matches `DESCRIPTION`, so bumping one means bumping both.
+
+### `CITATION.cff` is generated by `cffr` and compared, not hand-written and field-checked
+A hand-written file with a field-by-field comparator was built first and **rejected**: review
+found five defects in four rounds, every one the same shape — a field the comparison did not
+reach. Unordered URL membership let `repository-code` and `url` swap; comparing authors by name
+left the *address* unchecked, on a package CRAN archived for an undeliverable address. A
+hand-written comparator is a list of the fields someone remembered, and it fails silently.
+
+`cffr::cff_create()` derives the whole file, so the comparison is structural and nothing depends
+on remembering a field. It also validates against the CFF schema — GitHub silently declines to
+render the "Cite this repository" button on a file it cannot parse.
+
+Two generation settings are load-bearing. `dependencies = TRUE` emits 380 lines of dependency
+authors with years read from whichever versions happen to be installed, so a different machine
+produces a different file: off. And `preferred-citation`'s year comes from `inst/CITATION`, which
+reads the clock when `DESCRIPTION` has no publication date — that field changes on 1 January
+with nothing else, so the comparison excludes it or a required check reddens on a calendar
+boundary. `gh_keywords = FALSE` keeps generation off the network.
+
+---
+
+
+---
+
+## Repository documents
+
+### A work tracker carries no project state
+`BACKLOG.md`'s "state as of" block drifted four times, each within a day of a release — what a
+duplicated fact does, not what a careless author does. The fourth fix was to write it more
+carefully, and it was wrong within the hour. Applies now to the issue tracker: a *hold
+condition* belongs on the issue it holds, the project's current position nowhere in it. Same
+reasoning as deleting the hand-maintained `Version:`/`Date:` table from `man/rcicr-package.Rd`.
+
+The tracker is a **working surface, not a curated public one**, so internal maintenance work
+sits in it alongside user-visible bugs. Splitting chores elsewhere was rejected: two backlogs is
+the same duplication one layer up. What does *not* become an issue is an "already correct — do
+not re-fix" decision; those belong here.
+
+### `CLAUDE.md` is a stub that imports `AGENTS.md`, not a symlink
+Claude Code reads `CLAUDE.md` and not `AGENTS.md`, so the rename in #166 silently stopped the
+conventions loading in every agent session for months. **The symlink form was rejected**: it
+needs Administrator privileges or Developer Mode on Windows, and this package has Windows
+contributors and a Windows CI runner. The `@AGENTS.md` import is a plain file every platform
+treats identically.
+
+---
+

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -143,7 +143,7 @@ reasoning as deleting the hand-maintained `Version:`/`Date:` table from `man/rci
 The tracker is a **working surface, not a curated public one**, so internal maintenance work
 sits in it alongside user-visible bugs. Splitting chores elsewhere was rejected: two backlogs is
 the same duplication one layer up. What does *not* become an issue is an "already correct — do
-not re-fix" decision; those belong here.
+not re-fix" decision about the package; those go in `DECISIONS.md`.
 
 ### `CLAUDE.md` is a stub that imports `AGENTS.md`, not a symlink
 Claude Code reads `CLAUDE.md` and not `AGENTS.md`, so the rename in #166 silently stopped the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -253,4 +253,3 @@ local check, on no external check for 1.2.3, and not in CRAN's own pretest of 1.
 removed; the link stays in `README.md`, because `README.md` ships and removing it would
 invalidate the built tarball and force all five external checks to re-run for something no
 CRAN-side check has ever raised (issue #192).
-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,256 @@
+# Releasing rcicr
+
+The checklist, and why it is ordered the way it is. Maintainer-facing: contributors want
+`CONTRIBUTING.md`. `NEWS.md` records what each release changed, `DECISIONS.md` why the package
+behaves as it does.
+
+---
+
+## The checklist
+
+Releases are squash-merged onto `main` and marked with a tag; there is no `develop` branch.
+The version in `DESCRIPTION` carries a `.9000` suffix between releases, and the release
+commit is the one that drops it.
+
+**Step 1 is the reproducibility gate, and a release does not go out while it is red.**
+
+```sh
+Rscript tools/compare-release-output.R                 # vs v1.0.1 -- the published baseline
+Rscript tools/compare-release-output.R --ref=v1.1.0    # vs the last release
+```
+
+Both runs are required, and they answer different questions. The first asks whether this
+tree still produces the numbers that are *in the literature* — it stays pinned at v1.0.1,
+the last version on CRAN, and never advances, because a reference that moves forward with
+each release lets a tree drift away from those numbers one tolerated epsilon at a time. The
+second asks whether anything broke since the last release, and covers more ground: calls
+that used to crash (masks, small z-maps, undecorated z-maps) have a comparable value in
+v1.1.0 and none at all in v1.0.1.
+
+Exit status is `0` for a clean run, `1` for a difference that is not accounted for, and `2`
+if the comparison could not be run at all. On a difference there are exactly two honest
+outcomes:
+
+- **it was not intended** — fix it; or
+- **it was intended** — write it up in `NEWS.md` under "Reproducibility impact", saying who
+  is affected and what to do, and add an entry to `EXPECTED` in the script naming the
+  reference, the affected output, the reason, and that `NEWS.md` heading. The script fails
+  if an `EXPECTED` entry stops firing (so the list cannot rot) and if it fires while
+  `NEWS.md` says nothing (so a deviation cannot be quiet).
+
+Silently widening a tolerance, deleting a configuration from the battery, or skipping the
+run is none of those things. The whole point is that a change to researchers' numbers can
+only get out deliberately and loudly.
+
+### 1. Prepare the release PR
+
+Branch from `main` (`release-X.Y.Z` by convention) and make these five edits together:
+
+```sh
+Rscript tools/compare-release-output.R              # both gate runs green
+Rscript tools/compare-release-output.R --ref=vA.B.C # the previous release
+R CMD build . && R CMD check --as-cran rcicr_*.tar.gz
+```
+
+- **`NEWS.md`**: rename `# rcicr (development version)` to `# rcicr X.Y.Z (YYYY-MM-DD)`.
+  Until you do, none of this release's entries are in the news database at all — R indexes
+  only sections under a heading it can read a version from. Keep version numbers *out* of
+  `##` section headings, or the whole file stops parsing and `R CMD check` NOTEs.
+- **`DESCRIPTION`**: drop the `.9000`. This is also what switches CI from the everyday
+  `--quick` gate to the full battery, so it has to happen **before** the PR is opened, not
+  after review.
+- **`ChangeLog`**: add a dated pointer entry deferring to `NEWS.md`, never a duplicate — two
+  changelogs both claiming authority is worse than one that defers.
+- **`CITATION.cff`**: regenerate it, after the `DESCRIPTION` edit above, with
+  `cffr::cff_write("DESCRIPTION", dependencies = FALSE, gh_keywords = FALSE)` — it carries the
+  version. `ubuntu-latest (release)` regenerates and compares, so it fails until you do.
+- **`cran-comments.md`**: re-read every claim in it rather than trusting it. It has gone
+  stale *within a single day* before, by describing a URL reference that another PR had
+  just removed, one step short of a CRAN reviewer reading it. Leave the test-environment
+  results for step 2; everything else is written now.
+
+Open the PR. The full battery runs on it, takes ~20 minutes, and is a required check.
+
+### 2. Run the external checks — on the release branch, before merging
+
+win-builder and R-hub run against the release branch, and their results go into
+`cran-comments.md` **in the same PR**, so the release commit carries its own evidence.
+
+```sh
+R CMD build .                                # at the repo root, never in a worktree
+R CMD check --as-cran rcicr_X.Y.Z.tar.gz
+curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-devel/
+curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-release/
+```
+
+Then trigger R-hub from the Actions tab against the release branch. Two NOTEs are expected
+locally and explained in `cran-comments.md` — CRAN incoming feasibility (new submission of
+an archived package) and future file timestamps (no network clock in a sandbox).
+
+This ordering works because **`cran-comments.md` is `.Rbuildignore`d and never reaches the
+tarball**, so writing the results into it cannot invalidate the checks those results
+describe — the tarball is unchanged. And `DESCRIPTION` on the release branch already carries
+the clean version, so the checks see the exact version string that will be submitted.
+
+Neither check is run casually: win-builder mails the maintainer, and both put the tarball in
+front of a third party.
+
+- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()` do the
+  same thing as the `curl` lines above. Each FTPs the tarball to `win-builder.r-project.org`
+  and mails a check log to the maintainer address within the hour; `226` means the transfer
+  completed. The server **will not overwrite an existing upload**: a second attempt at the
+  same filename fails with a bare `Failed FTP upload: 550`, which means "already queued", not
+  "rejected". Confirm with `curl --list-only ftp://win-builder.r-project.org/R-devel/` before
+  re-uploading, or you will conclude the upload failed when it succeeded. The mail carries a
+  result URL; `curl -s https://win-builder.r-project.org/<key>/00check.log` fetches the full
+  log, which beats transcribing the one-line summary. The pages expire after ~72 hours, so
+  `cran-comments.md` is the durable copy.
+- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
+  on this repository's own Actions rather than uploading anywhere. Trigger it from the
+  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
+  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
+  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
+  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
+  **default branch** before it can be triggered at all, and R-hub wants the file on the
+  default branch *and* on whichever branch is being checked.
+
+  To read the results, **download the artifacts — do not use `gh run view --log`**, which
+  truncates long jobs: at 1.2.1 the 38-minute macOS job returned 1548 lines ending four
+  minutes in, with no `Status:` line anywhere. `gh run download <run-id> -D <dir>` and read
+  `*/rcicr.Rcheck/00check.log`. Expect `Status: OK` where win-builder reports 1 NOTE — R-hub
+  does not run the CRAN incoming feasibility check, so that is agreement, not a discrepancy.
+
+  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
+  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
+  optional slot for your own PAT to reach private repositories — not a credential R-hub
+  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
+  any step. This package is public; an unset secret expands to an empty string and the jobs
+  run normally.
+
+### 3. Merge and tag
+
+```sh
+gh pr merge <n> --squash --delete-branch
+git checkout main && git pull && git fetch --prune
+git tag -a vX.Y.Z -m "rcicr X.Y.Z" && git push origin vX.Y.Z
+gh release create vX.Y.Z --title "rcicr X.Y.Z" --notes-file <(...)   # NEWS section
+```
+
+The tag push re-runs the full gate against the released tree, which is the copy that
+matters. Squash-merge, always: one commit per PR on `main`, and the squash message is where
+measurements and rejected alternatives have to live, because the branch commits disappear.
+
+**Confirm the squash did not change the tree** the external checks ran on:
+
+```sh
+git diff <pr-head-sha> vX.Y.Z --stat    # must be empty
+```
+
+Empty output is what lets step 2's results stand for the tagged tree.
+
+### 4. Submit to CRAN
+
+```sh
+git switch --detach vX.Y.Z      # never build from main HEAD, never in a worktree
+R CMD build .
+R CMD check --as-cran rcicr_X.Y.Z.tar.gz
+git switch -                    # back to where you were
+```
+
+Building from the tag is what keeps the development suffix out of the submitted version:
+`Version contains large components` is only a CRAN blocker if the *tarball* carries it.
+
+Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-comments.md`
+into the "Optional comment" field — that file is `.Rbuildignore`d and reaches CRAN only this
+way, never inside the tarball. `devtools::submit_cran()` does the same thing.
+
+**Paste the tag's copy, not `main`'s** — `git show vX.Y.Z:cran-comments.md`. Submission can
+trail tagging by weeks, and `main` moves in between; its copy would describe check results
+from a tree that is not the tarball, and nothing in the submission would contradict it.
+
+**Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
+package archived over an undeliverable address, that confirmation *is* the point of the
+resubmission.
+
+### 5. Reopen development
+
+Bump `DESCRIPTION` to `X.Y.Z.9000` and start a fresh `# rcicr (development version)` heading
+in `NEWS.md`. `main` is protected, so this goes through a small PR like anything else.
+
+`.github/workflows/reproducibility.yaml` runs the gate on every PR to `main` (`--quick`,
+which skips the 512px configuration) and in full on release PRs, version tags and manual
+dispatch. The `compare` job is a **required status check** on `main`, alongside
+`R CMD check` on release and devel, so a red gate blocks the merge rather than merely
+reporting. That is a repository ruleset, not something the workflow can enforce on itself.
+
+
+---
+
+## Why the procedure is shaped this way
+
+
+The conventions and their rationale are in `AGENTS.md` — trunk-based with tags and no
+`develop` branch, `.9000` on `main` between releases, tarballs built from the tag, squash
+merges, delete merged branches, `NEWS.md` ordered largest-impact first. Two things learned
+the hard way that those entries do not cover:
+
+- **Squash merging is what makes a bad commit cheap.** One branch here carried ~75,000 lines
+  of committed `R CMD check` artifacts across three commits; `main` only ever saw the final
+  tree, so no history rewrite was needed. (Both patterns are now in `.gitignore` and
+  `.Rbuildignore`, and the `git diff --stat main...HEAD` habit is in `CONTRIBUTING.md`.)
+- `git push origin --delete a b` is **atomic**: one stale name fails the whole command and
+  takes the other branch down with it. (`gh pr merge --delete-branch` has already removed the
+  remote branch anyway.)
+
+### External checks run on the release branch; the tag and `.9000` still precede acceptance
+The procedure is in `CONTRIBUTING.md` → "Releasing", step 2. What is not obvious is why it
+can work at all.
+
+**The circularity that appears to force checks after the tag is not real.** It looks as
+though results cannot be recorded in the commit they describe, because writing them changes
+the tree and so invalidates the tarball that was checked. But `cran-comments.md` is
+`.Rbuildignore`d and verifiably absent from the built tarball, so editing it produces the
+same tarball byte for byte. It is not a package artifact at all — it is the text pasted into
+the "Optional comment" field of the CRAN submission form. At 1.2.1 the checks ran *after* the
+tag and the `.9000` reopen, so the results landed on a development tree and the tag recorded
+no evidence that the tree it names had passed anything.
+
+**Deliberately *not* copied from `usethis:::release_checklist()`: tagging and reopening
+`.9000` still happen before CRAN accepts.** The `.9000` suffix is what selects `--quick` over
+the full ~20-minute battery, so holding `main` at a clean version across the weeks CRAN can
+take would run the full gate on every unrelated PR in that window. And a rejection means
+shipping X.Y.Z+1 anyway, leaving the tag naming a tree that was never on CRAN — already true
+of `v1.2.0` and `v1.2.2`, so the repository tolerates that cheaply.
+
+
+### GitHub releases carry notes only — the built tarball is not attached
+A release page already offers "Source code (tar.gz)", which GitHub generates from the tag, and
+that is **not** the artifact `R CMD build` produces: the git archive has no built vignettes in
+`inst/doc/` and does carry every `.Rbuildignore`d development file. Attaching the real tarball
+would put two different "source" downloads on one page and a second artifact that can drift from
+the tag it claims to be. Follows r-lib and tidyverse practice: CRAN hosts the tarball,
+`remotes::install_github('rdotsch/rcicr@vX.Y.Z')` covers everyone else. Being off CRAN is the
+strongest counter-argument and was considered; it is temporary.
+
+Accepted cost: the tarball is **not byte-reproducible from the tag**, because `R CMD build`
+stamps `Packaged: <timestamp>; <user>`. What has to be reproducible is the *tree*, which the tag
+pins exactly and which the gate and `R CMD check` actually operate on.
+
+### Answer CRAN from the review text, and never send them a question a sweep can answer
+CRAN's review of 1.2.1 listed two `.Rd` files under "some code lines in examples are
+commented out". Working from a summary that had kept one of them, 1.2.2 replied that we could
+not find the commented line and **asked the reviewer which line she meant** — while the fix
+for the file she had named correctly sat in the same commit, made under a different point.
+Two further drafts repeated it.
+
+The logging and re-verification rules that came out of it are in `AGENTS.md`. The one that is
+not: **a question to the reviewer costs a round trip measured in weeks, and a sweep costs
+minutes.** Sweep everything the point could apply to, then report what was found.
+
+The same instinct applies in reverse — **do not explain a note the reviewer does not have.**
+`cran-comments.md` carried a paragraph answering a `medium.com` 403 that appears only on our
+local check, on no external check for 1.2.3, and not in CRAN's own pretest of 1.2.1. It was
+removed; the link stays in `README.md`, because `README.md` ships and removing it would
+invalidate the built tarball and force all five external checks to re-run for something no
+CRAN-side check has ever raised (issue #192).
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,80 +1,62 @@
 # Releasing rcicr
 
-The checklist, and why it is ordered the way it is. Maintainer-facing: contributors want
-`CONTRIBUTING.md`. `NEWS.md` records what each release changed, `DECISIONS.md` why the package
-behaves as it does.
+Maintainer-facing; contributors want `CONTRIBUTING.md`. Releases are squash-merged onto `main`
+and marked with a tag — no `develop` branch. `DESCRIPTION` carries a `.9000` suffix between
+releases and the release commit drops it.
+
+**Keep this file under 1600 words.**
 
 ---
 
-## The checklist
+## 0. The reproducibility gate
 
-Releases are squash-merged onto `main` and marked with a tag; there is no `develop` branch.
-The version in `DESCRIPTION` carries a `.9000` suffix between releases, and the release
-commit is the one that drops it.
-
-**Step 1 is the reproducibility gate, and a release does not go out while it is red.**
+**A release does not go out while this is red.** Both runs are required; they answer different
+questions.
 
 ```sh
-Rscript tools/compare-release-output.R                 # vs v1.0.1 -- the published baseline
-Rscript tools/compare-release-output.R --ref=v1.1.0    # vs the last release
+Rscript tools/compare-release-output.R               # vs v1.0.1 -- the published baseline
+Rscript tools/compare-release-output.R --ref=v1.1.0  # vs the previous release
 ```
 
-Both runs are required, and they answer different questions. The first asks whether this
-tree still produces the numbers that are *in the literature* — it stays pinned at v1.0.1,
-the last version on CRAN, and never advances, because a reference that moves forward with
-each release lets a tree drift away from those numbers one tolerated epsilon at a time. The
-second asks whether anything broke since the last release, and covers more ground: calls
-that used to crash (masks, small z-maps, undecorated z-maps) have a comparable value in
-v1.1.0 and none at all in v1.0.1.
+The v1.0.1 run asks whether this tree still produces the numbers that are *in the literature*.
+It never advances, because a reference that moves forward with each release lets a tree drift
+away from those numbers one tolerated epsilon at a time. The second asks whether anything broke
+since the last release, and reaches further: calls that used to crash — masks, small z-maps,
+undecorated z-maps — have a comparable value in v1.1.0 and none at all in v1.0.1.
 
-Exit status is `0` for a clean run, `1` for a difference that is not accounted for, and `2`
-if the comparison could not be run at all. On a difference there are exactly two honest
-outcomes:
+Exit `0` clean, `1` an unaccounted difference, `2` could not run. On a difference there are two
+honest outcomes: **it was not intended**, so fix it; or **it was intended**, so write it up in
+`NEWS.md` under "Reproducibility impact" — who is affected, what to do — and add an `EXPECTED`
+entry naming the reference, the output, the reason and that heading. The script fails if an
+`EXPECTED` entry stops firing (the list cannot rot) and if one fires while `NEWS.md` is silent
+(a deviation cannot be quiet).
 
-- **it was not intended** — fix it; or
-- **it was intended** — write it up in `NEWS.md` under "Reproducibility impact", saying who
-  is affected and what to do, and add an entry to `EXPECTED` in the script naming the
-  reference, the affected output, the reason, and that `NEWS.md` heading. The script fails
-  if an `EXPECTED` entry stops firing (so the list cannot rot) and if it fires while
-  `NEWS.md` says nothing (so a deviation cannot be quiet).
+Widening a tolerance, dropping a configuration, or skipping the run is none of those.
 
-Silently widening a tolerance, deleting a configuration from the battery, or skipping the
-run is none of those things. The whole point is that a change to researchers' numbers can
-only get out deliberately and loudly.
+## 1. Prepare the release PR
 
-### 1. Prepare the release PR
+Branch from `main` (`release-X.Y.Z`) and make five edits together:
 
-Branch from `main` (`release-X.Y.Z` by convention) and make these five edits together:
+- **`NEWS.md`** — rename `# rcicr (development version)` to `# rcicr X.Y.Z (YYYY-MM-DD)`. Until
+  you do, none of this release's entries are in the news database: R indexes only sections under
+  a heading it can read a version from. Keep version numbers *out* of `##` headings or the file
+  stops parsing and `R CMD check` NOTEs.
+- **`DESCRIPTION`** — drop the `.9000`. This also switches CI from the `--quick` gate to the full
+  battery, so it must happen **before** the PR is opened.
+- **`ChangeLog`** — a dated pointer entry deferring to `NEWS.md`, never a duplicate.
+- **`CITATION.cff`** — regenerate *after* the `DESCRIPTION` edit, with
+  `cffr::cff_write("DESCRIPTION", dependencies = FALSE, gh_keywords = FALSE)`. CI compares it and
+  fails until you do.
+- **`cran-comments.md`** — re-read every claim rather than trusting it. It has gone stale *within
+  a single day*, describing a URL reference another PR had just removed, one step short of a CRAN
+  reviewer reading it. Test-environment results come in step 2.
 
-```sh
-Rscript tools/compare-release-output.R              # both gate runs green
-Rscript tools/compare-release-output.R --ref=vA.B.C # the previous release
-R CMD build . && R CMD check --as-cran rcicr_*.tar.gz
-```
+Open the PR; the full battery runs on it (~20 min) and is a required check.
 
-- **`NEWS.md`**: rename `# rcicr (development version)` to `# rcicr X.Y.Z (YYYY-MM-DD)`.
-  Until you do, none of this release's entries are in the news database at all — R indexes
-  only sections under a heading it can read a version from. Keep version numbers *out* of
-  `##` section headings, or the whole file stops parsing and `R CMD check` NOTEs.
-- **`DESCRIPTION`**: drop the `.9000`. This is also what switches CI from the everyday
-  `--quick` gate to the full battery, so it has to happen **before** the PR is opened, not
-  after review.
-- **`ChangeLog`**: add a dated pointer entry deferring to `NEWS.md`, never a duplicate — two
-  changelogs both claiming authority is worse than one that defers.
-- **`CITATION.cff`**: regenerate it, after the `DESCRIPTION` edit above, with
-  `cffr::cff_write("DESCRIPTION", dependencies = FALSE, gh_keywords = FALSE)` — it carries the
-  version. `ubuntu-latest (release)` regenerates and compares, so it fails until you do.
-- **`cran-comments.md`**: re-read every claim in it rather than trusting it. It has gone
-  stale *within a single day* before, by describing a URL reference that another PR had
-  just removed, one step short of a CRAN reviewer reading it. Leave the test-environment
-  results for step 2; everything else is written now.
+## 2. External checks, on the release branch, before merging
 
-Open the PR. The full battery runs on it, takes ~20 minutes, and is a required check.
-
-### 2. Run the external checks — on the release branch, before merging
-
-win-builder and R-hub run against the release branch, and their results go into
-`cran-comments.md` **in the same PR**, so the release commit carries its own evidence.
+win-builder and R-hub run against the release branch and their results go into `cran-comments.md`
+**in the same PR**, so the release commit carries its own evidence.
 
 ```sh
 R CMD build .                                # at the repo root, never in a worktree
@@ -84,172 +66,96 @@ curl -T rcicr_X.Y.Z.tar.gz ftp://win-builder.r-project.org/R-release/
 ```
 
 Then trigger R-hub from the Actions tab against the release branch. Two NOTEs are expected
-locally and explained in `cran-comments.md` — CRAN incoming feasibility (new submission of
-an archived package) and future file timestamps (no network clock in a sandbox).
+locally and explained in `cran-comments.md`: CRAN incoming feasibility (new submission of an
+archived package) and future file timestamps (no network clock in a sandbox).
 
-This ordering works because **`cran-comments.md` is `.Rbuildignore`d and never reaches the
-tarball**, so writing the results into it cannot invalidate the checks those results
-describe — the tarball is unchanged. And `DESCRIPTION` on the release branch already carries
-the clean version, so the checks see the exact version string that will be submitted.
+**Why results can be written into the commit they describe:** `cran-comments.md` is
+`.Rbuildignore`d and verifiably absent from the tarball, so editing it produces the same tarball
+byte for byte. It is not a package artifact at all — it is the text pasted into the submission
+form. At 1.2.1 these checks ran *after* the tag and the `.9000` reopen, so the results landed on
+a development tree and the tag recorded no evidence that the tree it names had passed anything.
 
 Neither check is run casually: win-builder mails the maintainer, and both put the tarball in
 front of a third party.
 
-- **win-builder** — `devtools::check_win_devel()` and `devtools::check_win_release()` do the
-  same thing as the `curl` lines above. Each FTPs the tarball to `win-builder.r-project.org`
-  and mails a check log to the maintainer address within the hour; `226` means the transfer
-  completed. The server **will not overwrite an existing upload**: a second attempt at the
-  same filename fails with a bare `Failed FTP upload: 550`, which means "already queued", not
-  "rejected". Confirm with `curl --list-only ftp://win-builder.r-project.org/R-devel/` before
-  re-uploading, or you will conclude the upload failed when it succeeded. The mail carries a
-  result URL; `curl -s https://win-builder.r-project.org/<key>/00check.log` fetches the full
-  log, which beats transcribing the one-line summary. The pages expire after ~72 hours, so
-  `cran-comments.md` is the durable copy.
-- **R-hub** — `.github/workflows/rhub.yaml` is the stock R-hub v2 workflow, so the check runs
-  on this repository's own Actions rather than uploading anywhere. Trigger it from the
-  Actions tab ("R-hub" → Run workflow), which needs nothing but repository access.
-  `rhub::rhub_check()` does the same over the API but requires a GitHub PAT with the `repo`
-  scope, stored via `gitcreds::gitcreds_set()` — `rhub::rhub_doctor()` reports whether yours
-  has it. Because the workflow is `workflow_dispatch`-only, it must be merged to the
-  **default branch** before it can be triggered at all, and R-hub wants the file on the
-  default branch *and* on whichever branch is being checked.
+- **win-builder** — `226` means the transfer completed. The server **will not overwrite an
+  existing upload**: a second attempt at the same filename fails with a bare `550`, meaning
+  "already queued", not "rejected". Confirm with
+  `curl --list-only ftp://win-builder.r-project.org/R-devel/` before re-uploading. The mail
+  carries a result URL; `curl -s https://win-builder.r-project.org/<key>/00check.log` fetches the
+  full log. Pages expire after ~72 hours, so `cran-comments.md` is the durable copy.
+- **R-hub** — the stock v2 workflow, run from this repository's Actions tab. Because it is
+  `workflow_dispatch`-only it must reach the **default branch** before it can be triggered at
+  all. **Download the artifacts; do not use `gh run view --log`**, which truncates: at 1.2.1 the
+  38-minute macOS job returned 1548 lines ending four minutes in, with no `Status:` line.
+  `gh run download <run-id> -D <dir>`, then read `*/rcicr.Rcheck/00check.log`. Expect
+  `Status: OK` where win-builder reports 1 NOTE — R-hub does not run the incoming feasibility
+  check, so that is agreement, not a discrepancy.
+- **`RHUB_TOKEN` is deliberately unset and nothing is missing.** The stock workflow passes it to
+  four actions, which makes it look required. It is an optional slot for your own PAT to reach
+  *private* repositories, not a credential R-hub issues, and no step in `r-hub/actions@v1`
+  references it. This package is public; an unset secret expands to empty and the jobs run.
 
-  To read the results, **download the artifacts — do not use `gh run view --log`**, which
-  truncates long jobs: at 1.2.1 the 38-minute macOS job returned 1548 lines ending four
-  minutes in, with no `Status:` line anywhere. `gh run download <run-id> -D <dir>` and read
-  `*/rcicr.Rcheck/00check.log`. Expect `Status: OK` where win-builder reports 1 NOTE — R-hub
-  does not run the CRAN incoming feasibility check, so that is agreement, not a discrepancy.
-
-  **`RHUB_TOKEN` is deliberately unset, and nothing is missing.** The stock workflow passes
-  `secrets.RHUB_TOKEN` to four actions, which makes it look like a prerequisite. It is an
-  optional slot for your own PAT to reach private repositories — not a credential R-hub
-  issues — and as of `r-hub/actions@v1` none of those four actions references the input in
-  any step. This package is public; an unset secret expands to an empty string and the jobs
-  run normally.
-
-### 3. Merge and tag
+## 3. Merge and tag
 
 ```sh
 gh pr merge <n> --squash --delete-branch
 git checkout main && git pull && git fetch --prune
 git tag -a vX.Y.Z -m "rcicr X.Y.Z" && git push origin vX.Y.Z
 gh release create vX.Y.Z --title "rcicr X.Y.Z" --notes-file <(...)   # NEWS section
+git diff <pr-head-sha> vX.Y.Z --stat                                 # must be empty
 ```
 
-The tag push re-runs the full gate against the released tree, which is the copy that
-matters. Squash-merge, always: one commit per PR on `main`, and the squash message is where
-measurements and rejected alternatives have to live, because the branch commits disappear.
+The tag push re-runs the full gate against the released tree. The empty diff is what lets step
+2's results stand for the tagged tree.
 
-**Confirm the squash did not change the tree** the external checks ran on:
+**The release page carries notes only — the tarball is not attached.** GitHub already offers
+"Source code (tar.gz)" generated from the tag, and that is *not* what `R CMD build` produces: no
+built vignettes in `inst/doc/`, and every `.Rbuildignore`d development file present. Two
+different "source" downloads on one page is a support question waiting to happen. CRAN hosts the
+real tarball and `remotes::install_github('rdotsch/rcicr@vX.Y.Z')` covers everyone else. Accepted
+cost: the tarball is not byte-reproducible from the tag, because `R CMD build` stamps
+`Packaged: <timestamp>; <user>`. What must be reproducible is the *tree*, which the tag pins.
+
+## 4. Submit to CRAN
 
 ```sh
-git diff <pr-head-sha> vX.Y.Z --stat    # must be empty
-```
-
-Empty output is what lets step 2's results stand for the tagged tree.
-
-### 4. Submit to CRAN
-
-```sh
-git switch --detach vX.Y.Z      # never build from main HEAD, never in a worktree
+git switch --detach vX.Y.Z      # never from main HEAD, never in a worktree
 R CMD build .
 R CMD check --as-cran rcicr_X.Y.Z.tar.gz
-git switch -                    # back to where you were
+git switch -
 ```
 
-Building from the tag is what keeps the development suffix out of the submitted version:
-`Version contains large components` is only a CRAN blocker if the *tarball* carries it.
+Building from the tag keeps the development suffix out of the submitted version:
+`Version contains large components` only blocks if the *tarball* carries it.
 
-Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-comments.md`
-into the "Optional comment" field — that file is `.Rbuildignore`d and reaches CRAN only this
-way, never inside the tarball. `devtools::submit_cran()` does the same thing.
+Submit at <https://cran.r-project.org/submit.html>, pasting the body of `cran-comments.md` into
+the "Optional comment" field — `.Rbuildignore`d, so it reaches CRAN only this way. **Paste the
+tag's copy** (`git show vX.Y.Z:cran-comments.md`): submission can trail tagging by weeks while
+`main` moves, and `main`'s copy would describe check results from a tree that is not the tarball.
 
-**Paste the tag's copy, not `main`'s** — `git show vX.Y.Z:cran-comments.md`. Submission can
-trail tagging by weeks, and `main` moves in between; its copy would describe check results
-from a tree that is not the tarball, and nothing in the submission would contradict it.
+**Ron submits personally.** CRAN emails the maintainer address to confirm, and for a package
+archived over an undeliverable address, that confirmation *is* the point of the resubmission.
 
-**Ron submits to CRAN personally.** CRAN emails the maintainer address to confirm, and for a
-package archived over an undeliverable address, that confirmation *is* the point of the
-resubmission.
+### Answering a review
 
-### 5. Reopen development
+**Never send CRAN a question a sweep can answer.** A round trip costs weeks; a sweep costs
+minutes. The review of 1.2.1 named two `.Rd` files with commented-out example lines; working from
+a summary that had kept only one, 1.2.2 asked the reviewer which line she meant — while the fix
+for the file she had named sat in the same commit under a different point. Two further drafts
+repeated it. Sweep everything the point could apply to, then report what was found.
 
-Bump `DESCRIPTION` to `X.Y.Z.9000` and start a fresh `# rcicr (development version)` heading
-in `NEWS.md`. `main` is protected, so this goes through a small PR like anything else.
+**And do not explain a note the reviewer does not have.** `cran-comments.md` once answered a
+`medium.com` 403 that appears only on our local check — not on any external check, not in CRAN's
+own pretest. Removed; the link stays in `README.md` (issue #192).
 
-`.github/workflows/reproducibility.yaml` runs the gate on every PR to `main` (`--quick`,
-which skips the 512px configuration) and in full on release PRs, version tags and manual
-dispatch. The `compare` job is a **required status check** on `main`, alongside
-`R CMD check` on release and devel, so a red gate blocks the merge rather than merely
-reporting. That is a repository ruleset, not something the workflow can enforce on itself.
+## 5. Reopen development
 
+Bump `DESCRIPTION` to `X.Y.Z.9000` and start a fresh `# rcicr (development version)` heading in
+`NEWS.md`, through a small PR like anything else.
 
----
-
-## Why the procedure is shaped this way
-
-
-The conventions and their rationale are in `AGENTS.md` — trunk-based with tags and no
-`develop` branch, `.9000` on `main` between releases, tarballs built from the tag, squash
-merges, delete merged branches, `NEWS.md` ordered largest-impact first. Two things learned
-the hard way that those entries do not cover:
-
-- **Squash merging is what makes a bad commit cheap.** One branch here carried ~75,000 lines
-  of committed `R CMD check` artifacts across three commits; `main` only ever saw the final
-  tree, so no history rewrite was needed. (Both patterns are now in `.gitignore` and
-  `.Rbuildignore`, and the `git diff --stat main...HEAD` habit is in `CONTRIBUTING.md`.)
-- `git push origin --delete a b` is **atomic**: one stale name fails the whole command and
-  takes the other branch down with it. (`gh pr merge --delete-branch` has already removed the
-  remote branch anyway.)
-
-### External checks run on the release branch; the tag and `.9000` still precede acceptance
-The procedure is in `CONTRIBUTING.md` → "Releasing", step 2. What is not obvious is why it
-can work at all.
-
-**The circularity that appears to force checks after the tag is not real.** It looks as
-though results cannot be recorded in the commit they describe, because writing them changes
-the tree and so invalidates the tarball that was checked. But `cran-comments.md` is
-`.Rbuildignore`d and verifiably absent from the built tarball, so editing it produces the
-same tarball byte for byte. It is not a package artifact at all — it is the text pasted into
-the "Optional comment" field of the CRAN submission form. At 1.2.1 the checks ran *after* the
-tag and the `.9000` reopen, so the results landed on a development tree and the tag recorded
-no evidence that the tree it names had passed anything.
-
-**Deliberately *not* copied from `usethis:::release_checklist()`: tagging and reopening
-`.9000` still happen before CRAN accepts.** The `.9000` suffix is what selects `--quick` over
-the full ~20-minute battery, so holding `main` at a clean version across the weeks CRAN can
-take would run the full gate on every unrelated PR in that window. And a rejection means
-shipping X.Y.Z+1 anyway, leaving the tag naming a tree that was never on CRAN — already true
-of `v1.2.0` and `v1.2.2`, so the repository tolerates that cheaply.
-
-
-### GitHub releases carry notes only — the built tarball is not attached
-A release page already offers "Source code (tar.gz)", which GitHub generates from the tag, and
-that is **not** the artifact `R CMD build` produces: the git archive has no built vignettes in
-`inst/doc/` and does carry every `.Rbuildignore`d development file. Attaching the real tarball
-would put two different "source" downloads on one page and a second artifact that can drift from
-the tag it claims to be. Follows r-lib and tidyverse practice: CRAN hosts the tarball,
-`remotes::install_github('rdotsch/rcicr@vX.Y.Z')` covers everyone else. Being off CRAN is the
-strongest counter-argument and was considered; it is temporary.
-
-Accepted cost: the tarball is **not byte-reproducible from the tag**, because `R CMD build`
-stamps `Packaged: <timestamp>; <user>`. What has to be reproducible is the *tree*, which the tag
-pins exactly and which the gate and `R CMD check` actually operate on.
-
-### Answer CRAN from the review text, and never send them a question a sweep can answer
-CRAN's review of 1.2.1 listed two `.Rd` files under "some code lines in examples are
-commented out". Working from a summary that had kept one of them, 1.2.2 replied that we could
-not find the commented line and **asked the reviewer which line she meant** — while the fix
-for the file she had named correctly sat in the same commit, made under a different point.
-Two further drafts repeated it.
-
-The logging and re-verification rules that came out of it are in `AGENTS.md`. The one that is
-not: **a question to the reviewer costs a round trip measured in weeks, and a sweep costs
-minutes.** Sweep everything the point could apply to, then report what was found.
-
-The same instinct applies in reverse — **do not explain a note the reviewer does not have.**
-`cran-comments.md` carried a paragraph answering a `medium.com` 403 that appears only on our
-local check, on no external check for 1.2.3, and not in CRAN's own pretest of 1.2.1. It was
-removed; the link stays in `README.md`, because `README.md` ships and removing it would
-invalidate the built tarball and force all five external checks to re-run for something no
-CRAN-side check has ever raised (issue #192).
+**Tagging and reopening `.9000` deliberately precede CRAN acceptance**, unlike
+`usethis:::release_checklist()`. The `.9000` suffix is what selects `--quick` over the full
+~20-minute battery, so holding `main` at a clean version for the weeks CRAN can take would run
+the full gate on every unrelated PR in that window. A rejection means shipping X.Y.Z+1 anyway,
+leaving a tag naming a tree that was never on CRAN — already true of `v1.2.0` and `v1.2.2`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security policy
 
+**Keep this file under 600 words.**
+
 ## Reporting a vulnerability
 
 Email the maintainer at the address in `DESCRIPTION` rather than opening a public issue. A

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Email the maintainer at the address in `DESCRIPTION` rather than opening a public issue. A
+report is most useful with a reproducible example and the rcicr version.
+
+`rcicr` generates images and reads `.png`, `.jpg` and `.Rdata` files supplied by the user. It
+opens no network connections and runs no code from the files it reads, so the realistic surface
+is malformed input reaching an image decoder, or an untrusted `.Rdata` file — `load()` can
+execute code on read, which is a property of R, not of this package. **Only load `.Rdata` files
+you or your collaborators generated.**
+
+## Supported versions
+
+The most recent release. Fixes are not backported; upgrade to the current version.
+
+## Dependency posture
+
+`.github/dependabot.yml` covers `github-actions` and nothing else. The asymmetry is deliberate.
+
+**The R dependencies cannot be watched, and pretending otherwise is worse than the gap.**
+Dependabot has no CRAN ecosystem, and CRAN publishes no security advisory database. Sonatype's
+OSS Index via `oysteR` was weighed and rejected: a scanner whose CRAN coverage is thin reports
+"clean" because its database is empty, not because the tree is safe, and a green badge that
+means nothing is worse than a known gap. The realistic dependency failure — an import getting
+archived — is caught by `R CMD check` on four platforms on every push.
+
+The real CVE surface is not in R code at all. It is in the C libraries the compiled
+dependencies bind to — libpng via `png`, libjpeg via `jpeg` — and those are patched by the
+user's operating system, not by CRAN, and not by anything this package does.
+
+**The actions genuinely needed watching**: twelve of the thirteen in use were on floating major
+tags, so whoever controls those repositories could change what runs in CI at any time. That is
+the one supply-chain surface here with real incident history, and the one Dependabot supports.
+Updates are grouped into a single PR, because `.github/workflows/` is deliberately not on the
+reproducibility gate's inert allowlist and ungrouped bumps would each spend a full CI round.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,8 +6,9 @@ template:
 # pkgdown renders every root-level .md except a hardcoded few, with no way to
 # opt out, so AGENTS.md and CLAUDE.md become pages whether or not that is
 # wanted. Nothing links to them, but they were landing in site search ahead of
-# real documentation. CONTRIBUTING.md and DECISIONS.md stay indexed: those are
-# for humans and worth finding. The pages still exist and still appear in
+# real documentation. CONTRIBUTING.md, DECISIONS.md, RELEASING.md,
+# MAINTENANCE.md and SECURITY.md stay indexed: those are for humans and worth
+# finding. The pages still exist and still appear in
 # sitemap.xml -- that is built from the files on disk and has no exclusion hook.
 search:
   exclude:

--- a/tools/compare-release-output.R
+++ b/tools/compare-release-output.R
@@ -23,7 +23,7 @@
 # A difference is only tolerated if it is listed in EXPECTED below, with a
 # reason and the NEWS.md heading that documents it for users. Adding an entry is
 # a deliberate, reviewable act -- which is the point. See CONTRIBUTING.md
-# ("Releasing") for where this sits in the release checklist.
+# RELEASING.md for where this sits in the release checklist.
 
 args <- commandArgs(trailingOnly = TRUE)
 opt <- function(flag, default = NULL) {

--- a/tools/compare-release-output.R
+++ b/tools/compare-release-output.R
@@ -22,8 +22,8 @@
 #
 # A difference is only tolerated if it is listed in EXPECTED below, with a
 # reason and the NEWS.md heading that documents it for users. Adding an entry is
-# a deliberate, reviewable act -- which is the point. See CONTRIBUTING.md
-# RELEASING.md for where this sits in the release checklist.
+# a deliberate, reviewable act -- which is the point. See RELEASING.md for
+# where this sits in the release checklist.
 
 args <- commandArgs(trailingOnly = TRUE)
 opt <- function(flag, default = NULL) {

--- a/tools/make-logo.R
+++ b/tools/make-logo.R
@@ -10,7 +10,7 @@
 # template cleanly. A CI from noisy responses is a grey smudge, which is true to
 # life but illegible at favicon size.
 #
-# The base face is synthetic, never a photograph (DECISIONS.md, "Base images in
+# The base face is synthetic, never a photograph (CONTRIBUTING.md, "Base images in
 # tests and vignettes are always synthetic").
 
 suppressMessages(devtools::load_all(".", quiet = TRUE))


### PR DESCRIPTION
`DECISIONS.md` had grown to 811 lines, and roughly a third of it was about the **repository**
rather than the package — Dependabot, R-hub triggers, the pkgdown deploy route, the release
checklist's rationale, which documents exist. Someone opening it to learn why `generateCI()`
returns what it does had to wade through CI wiring first.

## The split

| file | lines | job |
|---|---|---|
| `DECISIONS.md` | **811 → 518** | why the **package** behaves as it does |
| `CONTRIBUTING.md` | **476 → 304** | how to contribute: setup, tests, PRs, conventions |
| `RELEASING.md` | new, 256 | the release checklist *and* its rationale |
| `MAINTENANCE.md` | new, 125 | how CI, the gates, pkgdown and `CITATION.cff` are wired |
| `SECURITY.md` | new, 37 | vulnerability reporting and dependency posture |

Nothing load-bearing was deleted — it moved. The names follow convention: `RELEASING.md` is
widely used for a maintainer release process, and `SECURITY.md` is a GitHub community-health
file that gets its own repository tab, which is exactly where a dependency posture belongs.

**`RELEASING.md` also fixes a split that predates this.** The release *checklist* lived in
`CONTRIBUTING.md` while its *rationale* lived in `DECISIONS.md`; they are now one document.

## The test for an entry

Would this still matter if the package were maintained somewhere else entirely? `AGENTS.md`
gains a table of which file a thing goes in, because misfiling into `DECISIONS.md` is what
produced the sprawl in the first place.

Two entries that *looked* like packaging stayed: **write paths are required arguments** is an
API contract, and **`captureArgs()` skips required-and-absent arguments** is an internal guard.
Both are package behaviour.

## Budgets

Every doc now states a line budget, as `AGENTS.md` already did — so an addition has to displace
something instead of accumulating. `DECISIONS.md` 550, `CONTRIBUTING.md` 320, `AGENTS.md` 200
(currently 180).

## Verification

- Every inter-document anchor link checked **programmatically**, not by eye; all resolve. One
  was already broken before this branch and is fixed.
- The three new top-level files are in `.Rbuildignore` in the same commit, verified by building
  the tarball and confirming none of them ships.
- Suite: 171 files, 545 assertions, 0 failures. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)