### PR TITLE
Document generateCI()'s aggregation weighting (#227)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -174,6 +174,13 @@
   `targetci = generateCI(...)` when you want the curve to describe the CI you will report.
   Nothing changed in what the function computes.
 
+- **`?generateCI` documents the weighting of repeated stimulus presentations.** When
+  `participants` is `NA`, repeated presentations are collapsed before building the CI: each
+  unique stimulus gets equal weight, regardless of how many times it was presented. With equal
+  repeat counts this changes nothing; with unequal counts it is a different estimand from
+  weighting each trial equally, and the difference can be substantial. Previously this was
+  described only as a performance optimisation in a code comment.
+
 - **There is now a documentation website: <https://rdotsch.github.io/rcicr/>.** The
   function reference, both vignettes and this changelog are readable without installing
   the package first. It is generated from the same sources — `README.md` is the home page,

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -23,6 +23,24 @@
 #' When creating multiple classification images a good strategy is to find the lowest constant that works for all
 #' classification images. This can be automatized using the \code{autoscale} function.
 #'
+#' @section Repeated presentations of the same stimulus:
+#' When \code{participants} is \code{NA} (the default), repeated presentations of the same
+#' stimulus are collapsed before building the CI: each unique stimulus gets equal weight,
+#' regardless of how many times it was presented. Where every stimulus was presented the same
+#' number of times, this is equivalent to weighting each trial equally and changes nothing. Where
+#' repeat counts differ, it changes the estimand: a stimulus presented three times counts the same
+#' as one presented once, rather than three times as much.
+#'
+#' This is worth knowing for unbalanced designs. If a participant saw some stimuli more often than
+#' others -- because of an adaptive procedure, a crashed session, or a design choice -- the CI
+#' reflects the average response per unique stimulus, not per trial. The difference can be
+#' substantial: on an 8-trial set with counts 4/2/1/1 the two weightings correlate at 0.77.
+#'
+#' \code{\link{computeCumulativeCICorrelation}} does \emph{not} aggregate and weights each trial
+#' equally, so its self-computed final CI diverges from the one this function returns under
+#' unequal counts. Pass this function's output as \code{targetci} to compare against the CI you
+#' will actually report.
+#'
 #' @export
 #' @import png
 #' @import parallel
@@ -182,9 +200,8 @@ generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
   }
 
   if (all(is.na(participants))) {
-    # Average responses for each presented stimulus (in case stimuli have been
-    # presented multiple times, or group-wise classification images are being
-    # calculated, in order to reduce memory and processing load)
+    # Collapse repeated presentations: each unique stimulus gets equal weight,
+    # regardless of how many times it was presented.
     aggregated <- aggregate(responses, by=list(stimuli=stimuli), FUN=mean)
     responses <- aggregated$x
     stimuli <- aggregated$stimuli

--- a/man/generateCI.Rd
+++ b/man/generateCI.Rd
@@ -105,6 +105,26 @@ that you want to compare). The higher the constant, the less visible the noise w
 When creating multiple classification images a good strategy is to find the lowest constant that works for all
 classification images. This can be automatized using the \code{autoscale} function.
 }
+\section{Repeated presentations of the same stimulus}{
+
+When \code{participants} is \code{NA} (the default), repeated presentations of the same
+stimulus are collapsed before building the CI: each unique stimulus gets equal weight,
+regardless of how many times it was presented. Where every stimulus was presented the same
+number of times, this is equivalent to weighting each trial equally and changes nothing. Where
+repeat counts differ, it changes the estimand: a stimulus presented three times counts the same
+as one presented once, rather than three times as much.
+
+This is worth knowing for unbalanced designs. If a participant saw some stimuli more often than
+others -- because of an adaptive procedure, a crashed session, or a design choice -- the CI
+reflects the average response per unique stimulus, not per trial. The difference can be
+substantial: on an 8-trial set with counts 4/2/1/1 the two weightings correlate at 0.77.
+
+\code{\link{computeCumulativeCICorrelation}} does \emph{not} aggregate and weights each trial
+equally, so its self-computed final CI diverges from the one this function returns under
+unequal counts. Pass this function's output as \code{targetci} to compare against the CI you
+will actually report.
+}
+
 \examples{
 # a synthetic square grayscale image stands in for a real base face photo
 base_face <- tempfile(fileext = ".png")


### PR DESCRIPTION
## Summary

- Corrected the code comment at `R/generateCI.R:184-187` — collapsing repeated stimulus presentations is not a performance optimisation; with unequal repeat counts it changes the estimand (equal weight per unique stimulus, not per trial).
- Added a `@section Repeated presentations of the same stimulus` to `?generateCI` so users with unbalanced designs know what weighting they are getting.
- `NEWS.md` entry under Documentation.

No code behaviour changes, no numeric output changes.

## Test plan

- [x] `devtools::test()` — 545 pass
- [x] `roxygen2::roxygenise()` regenerates `man/generateCI.Rd`
- [ ] CI clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)