### PR TITLE
Stop saving loop counter `trial` in the .Rdata file (#179)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,11 @@
   noise on the far more common legacy file. Nothing warns that did not previously produce a
   wrong answer, and no numeric output changes.
 
+- **`generateStimuli2IFC()` no longer saves `trial` in the `.Rdata` file.** It was the loop
+  counter left over from stimulus generation — always equal to `n_trials`, which is already
+  saved. Nothing in the package or the documented contract reads it. Existing `.Rdata` files
+  that contain `trial` continue to work; the field is simply ignored on load.
+
 ## Reproducibility impact
 
 - **`computeCumulativeCICorrelation()` with a masked `targetci`** now returns numeric

--- a/R/generateStimuli2IFC.R
+++ b/R/generateStimuli2IFC.R
@@ -272,7 +272,7 @@ generateStimuli2IFC <- function(base_face_files, n_trials=770, img_size=512, sti
     # set later (notably generateReferenceDistribution2IFC(), which builds the
     # infoVal null distribution) reproduces the same noise basis. They were
     # previously omitted, so re-generation silently fell back to the defaults.
-    save(base_face_files, base_faces, img_size, label, n_trials, noise_type, nscales, sigma, p, seed, stimuli_params, stimulus_path, trial, use_same_parameters, generator_version, file=paste(stimulus_path, paste(label, "seed", seed, "time", format(Sys.time(), format="%b_%d_%Y_%H_%M.Rdata"), sep="_"), sep='/'), envir=environment())
+    save(base_face_files, base_faces, img_size, label, n_trials, noise_type, nscales, sigma, p, seed, stimuli_params, stimulus_path, use_same_parameters, generator_version, file=paste(stimulus_path, paste(label, "seed", seed, "time", format(Sys.time(), format="%b_%d_%Y_%H_%M.Rdata"), sep="_"), sep='/'), envir=environment())
   }
 
   # Return CIs

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ See `?plotZmap`.
 | `use_same_parameters` | Whether every base image shared one parameter set (`TRUE`) or each got its own. |
 | `label`, `stimulus_path` | What the files were called and where they were written. |
 | `generator_version` | The rcicr version that wrote the file — see the caveat below. |
-| `trial` | A leftover loop counter, equal to `n_trials`. Carries no information; ignore it. |
 
 `computeInfoVal2IFC()` and `generateReferenceDistribution2IFC()` **add** two more fields to
 the same file the first time you compute an informational value:


### PR DESCRIPTION
## Summary

- Remove `trial` from the `save()` call in `generateStimuli2IFC()`. It was the loop counter left over from stimulus generation — always equal to `n_trials`, which is already saved. Nothing reads it, and it is a `load()` collision hazard for any function that uses `trial` as a local variable after loading the file.
- Existing `.Rdata` files that contain `trial` continue to work; the field is simply ignored on load.

## Test plan

- [x] `devtools::test()` — 548 pass
- [ ] CI clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)