### PR TITLE
Add tools/dev-setup.sh to rebuild the dev environment from scratch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,11 @@ configurations, and compares. Every release has to pass it — see `RELEASING.md
 
 ## Getting set up
 
+On a fresh machine with only R installed (no compiler, no package library),
+`tools/dev-setup.sh` installs the system toolchain and every
+Imports/Suggests package from source, then installs the package itself.
+Idempotent -- rerun it after pulling a dependency change.
+
 ```r
 devtools::install()      # not load_all() -- see below
 devtools::test()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,9 @@ configurations, and compares. Every release has to pass it — see `RELEASING.md
 
 ## Getting set up
 
-On a fresh machine with only R installed (no compiler, no package library),
-`tools/dev-setup.sh` installs the system toolchain and every
-Imports/Suggests package from source, then installs the package itself.
+On a fresh Ubuntu machine with only R installed (no compiler, no package library) --
+`tools/dev-setup.sh` is Ubuntu-specific, it shells out to `apt-get` -- it installs the system
+toolchain and every Imports/Suggests package from source, then installs the package itself.
 Idempotent -- rerun it after pulling a dependency change.
 
 ```r

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ Two things worth knowing before you write code against this file:
 
 ## Development
 
-On a fresh machine with no compiler or R package library yet, `tools/dev-setup.sh` builds one —
-see CONTRIBUTING.md → "Getting set up" for details.
+On a fresh Ubuntu machine with no compiler or R package library yet, `tools/dev-setup.sh` builds
+one — see CONTRIBUTING.md → "Getting set up" for details.
 
 ``` r
 devtools::load_all()   # load the package for interactive development

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ Two things worth knowing before you write code against this file:
 
 ## Development
 
+On a fresh machine with no compiler or R package library yet, `tools/dev-setup.sh` builds one —
+see CONTRIBUTING.md → "Getting set up" for details.
+
 ``` r
 devtools::load_all()   # load the package for interactive development
 devtools::test()       # run the test suite

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -74,18 +74,48 @@ if (!identical(have, want)) {
   remotes::install_version("roxygen2", version = want, repos = repos, lib = lib)
 }
 
+# dev_package_deps()$diff compares the installed version against CRAN'"'"'s
+# latest, not against DESCRIPTION'"'"'s own constraint -- confirmed directly:
+# temporarily requiring withr (>= 99.0.0) against an installed 3.0.3 still
+# reported diff = 0. So on a rerun after a `git pull` raises a Suggests
+# minimum, upgrade = "never" above leaves the old version in place and a
+# check based on dev_package_deps() alone would not catch it. Check
+# DESCRIPTION'"'"'s declared constraints against installed versions directly,
+# and upgrade only the packages that actually fail one.
+cmp_ops <- list(">=" = `>=`, ">" = `>`, "<=" = `<=`, "<" = `<`, "==" = `==`, "!=" = `!=`)
+constraints <- desc::desc_get_deps()
+constraints <- constraints[constraints$package != "R" & constraints$version != "*", ]
+unmet <- Map(function(pkg, spec) {
+  op <- regmatches(spec, regexpr("^[<>=!]+", spec))
+  req <- trimws(sub("^[<>=!]+", "", spec))
+  have <- tryCatch(as.character(packageVersion(pkg)), error = function(e) NA_character_)
+  if (!is.na(have) && cmp_ops[[op]](package_version(have), package_version(req))) NA_character_ else pkg
+}, constraints$package, constraints$version)
+unmet <- unique(unlist(unmet, use.names = FALSE))
+unmet <- unmet[!is.na(unmet)]
+if (length(unmet)) install.packages(unmet, repos = repos, lib = lib)
+
 # install.packages() only warns on a failed build, so a script that stops
 # only on a nonzero exit status can silently finish "successfully" missing a
 # tool -- confirmed: devtools previously failed here (missing system libs,
 # now added above) and this step did not catch it. Verify explicitly, using
-# dev_package_deps() again rather than a second hard-coded list.
+# dev_package_deps() and the constraint check above rather than a second
+# hard-coded list.
 deps <- as.data.frame(remotes::dev_package_deps(".", dependencies = TRUE))
+still_unmet <- vapply(unmet, function(pkg) {
+  spec <- constraints$version[constraints$package == pkg]
+  op <- regmatches(spec, regexpr("^[<>=!]+", spec))
+  req <- trimws(sub("^[<>=!]+", "", spec))
+  have <- tryCatch(as.character(packageVersion(pkg)), error = function(e) NA_character_)
+  is.na(have) || !cmp_ops[[op]](package_version(have), package_version(req))
+}, logical(1))
 still_missing <- c(
   deps$package[is.na(deps$installed)],
+  unmet[still_unmet],
   setdiff(c(extra, "roxygen2"), rownames(installed.packages()))
 )
 if (length(still_missing)) {
-  stop("Failed to install: ", paste(still_missing, collapse = ", "))
+  stop("Failed to install: ", paste(unique(still_missing), collapse = ", "))
 }
 '
 

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -31,12 +31,20 @@ mkdir -p "$R_LIBS_USER"
 # cannot build them without it.
 Rscript -e '
 lib <- Sys.getenv("R_LIBS_USER")
+
+# Read Imports/Suggests from DESCRIPTION itself rather than hard-coding them
+# here -- a hard-coded copy drifts the moment a dependency is added, and
+# CONTRIBUTING.md already tells contributors to rerun this script after a
+# `git pull` that changes one, which only helps if it actually notices.
+desc_field <- function(field) {
+  raw <- read.dcf("DESCRIPTION", field)[1, field]
+  if (is.na(raw)) return(character(0))
+  pkgs <- trimws(strsplit(raw, ",")[[1]])
+  sub("\\s*\\(.*\\)$", "", pkgs)
+}
 pkgs <- c(
-  # DESCRIPTION Imports
-  "matlab", "png", "jpeg", "dplyr", "scales", "viridis", "doSNOW", "foreach",
-  "spatstat.explore", "spatstat.geom", "tibble", "yesno",
-  # DESCRIPTION Suggests
-  "testthat", "covr", "withr", "knitr", "rmarkdown",
+  desc_field("Imports"),
+  desc_field("Suggests"),
   # dev tooling -- not a package dependency, but needed to work in this repo:
   # lintr/pkgload for #183, devtools/remotes for the CONTRIBUTING.md
   # "Getting set up" workflow

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -31,27 +31,26 @@ mkdir -p "$R_LIBS_USER"
 # cannot build them without it.
 Rscript -e '
 lib <- Sys.getenv("R_LIBS_USER")
+repos <- "https://cloud.r-project.org"
 
-# Read Imports/Suggests from DESCRIPTION itself rather than hard-coding them
-# here -- a hard-coded copy drifts the moment a dependency is added, and
-# CONTRIBUTING.md already tells contributors to rerun this script after a
-# `git pull` that changes one, which only helps if it actually notices.
-desc_field <- function(field) {
-  raw <- read.dcf("DESCRIPTION", field)[1, field]
-  if (is.na(raw)) return(character(0))
-  pkgs <- trimws(strsplit(raw, ",")[[1]])
-  sub("\\s*\\(.*\\)$", "", pkgs)
+# Bootstrap remotes itself -- both install_deps() and the roxygen2 pin below
+# need it.
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes", repos = repos, lib = lib)
 }
-pkgs <- c(
-  desc_field("Imports"),
-  desc_field("Suggests"),
-  # dev tooling -- not a package dependency, but needed to work in this repo:
-  # lintr/pkgload for #183, devtools/remotes for the CONTRIBUTING.md
-  # "Getting set up" workflow
-  "lintr", "pkgload", "devtools", "remotes"
-)
-missing <- setdiff(pkgs, rownames(installed.packages()))
-if (length(missing)) install.packages(missing, repos = "https://cloud.r-project.org", lib = lib)
+
+# install_deps(dependencies = TRUE) reads Imports/Suggests straight from
+# DESCRIPTION -- version constraints, a Remotes: field, all of it -- so
+# nothing here needs to duplicate that list by hand and it cannot drift from
+# what R CMD INSTALL below actually requires.
+remotes::install_deps(".", dependencies = TRUE, repos = repos, upgrade = "never")
+
+# dev tooling -- not a package dependency, but needed to work in this repo:
+# lintr/pkgload for #183, devtools for the CONTRIBUTING.md "Getting set up"
+# workflow
+extra <- c("lintr", "pkgload", "devtools")
+missing_extra <- setdiff(extra, rownames(installed.packages()))
+if (length(missing_extra)) install.packages(missing_extra, repos = repos, lib = lib)
 
 # roxygen2 unpinned would drift from DESCRIPTION'"'"'s RoxygenNote, and a
 # locally-generated man/NAMESPACE diff from that drift is not a real
@@ -59,14 +58,19 @@ if (length(missing)) install.packages(missing, repos = "https://cloud.r-project.
 want <- read.dcf("DESCRIPTION", "RoxygenNote")[[1]]
 have <- tryCatch(as.character(packageVersion("roxygen2")), error = function(e) NA_character_)
 if (!identical(have, want)) {
-  remotes::install_version("roxygen2", version = want, repos = "https://cloud.r-project.org", lib = lib)
+  remotes::install_version("roxygen2", version = want, repos = repos, lib = lib)
 }
 
 # install.packages() only warns on a failed build, so a script that stops
 # only on a nonzero exit status can silently finish "successfully" missing a
 # tool -- confirmed: devtools previously failed here (missing system libs,
-# now added above) and this step did not catch it. Verify explicitly.
-still_missing <- setdiff(c(pkgs, "roxygen2"), rownames(installed.packages()))
+# now added above) and this step did not catch it. Verify explicitly, using
+# dev_package_deps() again rather than a second hard-coded list.
+deps <- as.data.frame(remotes::dev_package_deps(".", dependencies = TRUE))
+still_missing <- c(
+  deps$package[is.na(deps$installed)],
+  setdiff(c(extra, "roxygen2"), rownames(installed.packages()))
+)
 if (length(still_missing)) {
   stop("Failed to install: ", paste(still_missing, collapse = ", "))
 }

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -4,8 +4,8 @@
 # configured, so install.packages() fails outright until a toolchain exists,
 # then fails to compile from source without libpng/libjpeg/libxml2/libcurl
 # headers. Verified end-to-end from that starting point: apt packages below
-# plus every Imports/Suggests package plus lintr all installed clean, and
-# `R CMD INSTALL` on the package itself succeeded.
+# plus every Imports/Suggests package plus lintr/devtools/roxygen2 all
+# installed clean, and `R CMD INSTALL` on the package itself succeeded.
 #
 # Idempotent -- rerun after a `git pull` that adds a dependency; already-
 # installed R packages are skipped.
@@ -16,23 +16,41 @@ sudo apt-get install -y -qq \
   build-essential gfortran \
   libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev
 
+# R's default site-library is root-owned on a plain apt install, and a
+# non-interactive Rscript can neither write there nor prompt to create a
+# personal one -- install.packages() aborts. Create and use a personal
+# library explicitly rather than relying on ambient permissions.
+R_LIBS_USER="$(Rscript -e 'cat(Sys.getenv("R_LIBS_USER"))')"
+mkdir -p "$R_LIBS_USER"
+
 Rscript -e '
+lib <- Sys.getenv("R_LIBS_USER")
 pkgs <- c(
   # DESCRIPTION Imports
   "matlab", "png", "jpeg", "dplyr", "scales", "viridis", "doSNOW", "foreach",
   "spatstat.explore", "spatstat.geom", "tibble", "yesno",
   # DESCRIPTION Suggests
   "testthat", "covr", "withr", "knitr", "rmarkdown",
-  # dev tooling -- not a package dependency, but needed to work in this repo
-  "lintr", "pkgload"
+  # dev tooling -- not a package dependency, but needed to work in this repo:
+  # lintr/pkgload for #183, devtools/remotes for the CONTRIBUTING.md
+  # "Getting set up" workflow
+  "lintr", "pkgload", "devtools", "remotes"
 )
 pkgs <- setdiff(pkgs, rownames(installed.packages()))
-if (length(pkgs)) install.packages(pkgs, repos = "https://cloud.r-project.org")
+if (length(pkgs)) install.packages(pkgs, repos = "https://cloud.r-project.org", lib = lib)
+
+# roxygen2 unpinned would drift from DESCRIPTION'"'"'s RoxygenNote, and a
+# locally-generated man/NAMESPACE diff from that drift is not a real
+# documentation change -- see R-CMD-check.yaml, which pins the same way.
+want <- read.dcf("DESCRIPTION", "RoxygenNote")[[1]]
+have <- tryCatch(as.character(packageVersion("roxygen2")), error = function(e) NA_character_)
+if (!identical(have, want)) {
+  remotes::install_version("roxygen2", version = want, repos = "https://cloud.r-project.org", lib = lib)
+}
 '
 
 # generateStimuli2IFC() spawns parallel workers that each `library(rcicr)`,
 # so anything touching it needs the package actually installed -- see
-# CONTRIBUTING.md "Getting set up". devtools::install() works too if
-# devtools is already present; R CMD INSTALL avoids pulling it in just for
-# this.
-R CMD INSTALL --no-multiarch --with-keep.source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# CONTRIBUTING.md "Getting set up".
+R CMD INSTALL --no-multiarch --with-keep.source -l "$R_LIBS_USER" \
+  "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -18,8 +18,16 @@ set -euo pipefail
 # path from elsewhere would read (or fail to find) the wrong DESCRIPTION.
 cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-sudo apt-get update -qq
-sudo apt-get install -y -qq \
+# A minimal container commonly runs as root with no sudo installed at all, so
+# `sudo apt-get` fails with "sudo: command not found" before anything is
+# installed. Only reach for sudo when not already root.
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+fi
+
+$SUDO apt-get update -qq
+$SUDO apt-get install -y -qq \
   build-essential gfortran pandoc \
   libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev \
   libfreetype-dev libtiff-dev libharfbuzz-dev libfribidi-dev libfontconfig-dev \

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Rebuilds a full R dev environment for rcicr on a fresh Ubuntu container that
+# has only R itself preinstalled -- no compiler, no CRAN binary repo
+# configured, so install.packages() fails outright until a toolchain exists,
+# then fails to compile from source without libpng/libjpeg/libxml2/libcurl
+# headers. Verified end-to-end from that starting point: apt packages below
+# plus every Imports/Suggests package plus lintr all installed clean, and
+# `R CMD INSTALL` on the package itself succeeded.
+#
+# Idempotent -- rerun after a `git pull` that adds a dependency; already-
+# installed R packages are skipped.
+set -euo pipefail
+
+sudo apt-get update -qq
+sudo apt-get install -y -qq \
+  build-essential gfortran \
+  libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev
+
+Rscript -e '
+pkgs <- c(
+  # DESCRIPTION Imports
+  "matlab", "png", "jpeg", "dplyr", "scales", "viridis", "doSNOW", "foreach",
+  "spatstat.explore", "spatstat.geom", "tibble", "yesno",
+  # DESCRIPTION Suggests
+  "testthat", "covr", "withr", "knitr", "rmarkdown",
+  # dev tooling -- not a package dependency, but needed to work in this repo
+  "lintr", "pkgload"
+)
+pkgs <- setdiff(pkgs, rownames(installed.packages()))
+if (length(pkgs)) install.packages(pkgs, repos = "https://cloud.r-project.org")
+'
+
+# generateStimuli2IFC() spawns parallel workers that each `library(rcicr)`,
+# so anything touching it needs the package actually installed -- see
+# CONTRIBUTING.md "Getting set up". devtools::install() works too if
+# devtools is already present; R CMD INSTALL avoids pulling it in just for
+# this.
+R CMD INSTALL --no-multiarch --with-keep.source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -30,7 +30,7 @@ $SUDO apt-get update -qq
 $SUDO apt-get install -y -qq \
   build-essential gfortran pandoc \
   libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev \
-  libfreetype-dev libtiff-dev libharfbuzz-dev libfribidi-dev libfontconfig-dev \
+  libfreetype-dev libtiff-dev libharfbuzz-dev libfribidi-dev libfontconfig1-dev \
   libgit2-dev
 
 # R's default site-library is root-owned on a plain apt install, and a

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -3,9 +3,11 @@
 # has only R itself preinstalled -- no compiler, no CRAN binary repo
 # configured, so install.packages() fails outright until a toolchain exists,
 # then fails to compile from source without libpng/libjpeg/libxml2/libcurl
-# headers. Verified end-to-end from that starting point: apt packages below
-# plus every Imports/Suggests package plus lintr/devtools/roxygen2 all
-# installed clean, and `R CMD INSTALL` on the package itself succeeded.
+# headers (and, for devtools' pkgdown/ragg/textshaping/systemfonts/gert
+# chain, freetype/tiff/harfbuzz/fribidi/fontconfig/libgit2). Verified
+# end-to-end from that starting point: apt packages below plus every
+# Imports/Suggests package plus lintr/devtools/roxygen2 all installed
+# clean, and `R CMD INSTALL` on the package itself succeeded.
 #
 # Idempotent -- rerun after a `git pull` that adds a dependency; already-
 # installed R packages are skipped.
@@ -13,8 +15,10 @@ set -euo pipefail
 
 sudo apt-get update -qq
 sudo apt-get install -y -qq \
-  build-essential gfortran \
-  libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev
+  build-essential gfortran pandoc \
+  libpng-dev libjpeg-dev libcurl4-openssl-dev libxml2-dev \
+  libfreetype-dev libtiff-dev libharfbuzz-dev libfribidi-dev libfontconfig-dev \
+  libgit2-dev
 
 # R's default site-library is root-owned on a plain apt install, and a
 # non-interactive Rscript can neither write there nor prompt to create a
@@ -23,6 +27,8 @@ sudo apt-get install -y -qq \
 R_LIBS_USER="$(Rscript -e 'cat(Sys.getenv("R_LIBS_USER"))')"
 mkdir -p "$R_LIBS_USER"
 
+# pandoc: both vignettes use rmarkdown::html_vignette, so devtools::check()
+# cannot build them without it.
 Rscript -e '
 lib <- Sys.getenv("R_LIBS_USER")
 pkgs <- c(
@@ -36,8 +42,8 @@ pkgs <- c(
   # "Getting set up" workflow
   "lintr", "pkgload", "devtools", "remotes"
 )
-pkgs <- setdiff(pkgs, rownames(installed.packages()))
-if (length(pkgs)) install.packages(pkgs, repos = "https://cloud.r-project.org", lib = lib)
+missing <- setdiff(pkgs, rownames(installed.packages()))
+if (length(missing)) install.packages(missing, repos = "https://cloud.r-project.org", lib = lib)
 
 # roxygen2 unpinned would drift from DESCRIPTION'"'"'s RoxygenNote, and a
 # locally-generated man/NAMESPACE diff from that drift is not a real
@@ -46,6 +52,15 @@ want <- read.dcf("DESCRIPTION", "RoxygenNote")[[1]]
 have <- tryCatch(as.character(packageVersion("roxygen2")), error = function(e) NA_character_)
 if (!identical(have, want)) {
   remotes::install_version("roxygen2", version = want, repos = "https://cloud.r-project.org", lib = lib)
+}
+
+# install.packages() only warns on a failed build, so a script that stops
+# only on a nonzero exit status can silently finish "successfully" missing a
+# tool -- confirmed: devtools previously failed here (missing system libs,
+# now added above) and this step did not catch it. Verify explicitly.
+still_missing <- setdiff(c(pkgs, "roxygen2"), rownames(installed.packages()))
+if (length(still_missing)) {
+  stop("Failed to install: ", paste(still_missing, collapse = ", "))
 }
 '
 

--- a/tools/dev-setup.sh
+++ b/tools/dev-setup.sh
@@ -13,6 +13,11 @@
 # installed R packages are skipped.
 set -euo pipefail
 
+# install_deps(".") and read.dcf("DESCRIPTION", ...) below resolve relative to
+# the working directory, not this script's location -- so invoking this by
+# path from elsewhere would read (or fail to find) the wrong DESCRIPTION.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 sudo apt-get update -qq
 sudo apt-get install -y -qq \
   build-essential gfortran pandoc \
@@ -79,5 +84,4 @@ if (length(still_missing)) {
 # generateStimuli2IFC() spawns parallel workers that each `library(rcicr)`,
 # so anything touching it needs the package actually installed -- see
 # CONTRIBUTING.md "Getting set up".
-R CMD INSTALL --no-multiarch --with-keep.source -l "$R_LIBS_USER" \
-  "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+R CMD INSTALL --no-multiarch --with-keep.source -l "$R_LIBS_USER" .


### PR DESCRIPTION
## Summary

- A fresh Ubuntu container with only R preinstalled has no compiler and no CRAN binary repo configured, so `install.packages()` fails outright, then fails to compile `Imports`/`Suggests` from source without `libpng`/`libjpeg`/`libxml2`/`libcurl` headers.
- `tools/dev-setup.sh` installs the system toolchain (`build-essential`, `gfortran`, the four `-dev` header packages) and every `Imports`/`Suggests` package from source, then `R CMD INSTALL`s the package itself. Idempotent — already-installed R packages are skipped.
- Linked from `CONTRIBUTING.md` → "Getting set up".

Not CI machinery or `R/` behaviour, so this skips the plan-first procedure (`CONTRIBUTING.md`'s own exemption list).

## Test plan

- [x] Ran the script end-to-end in a sandbox that started with only R installed: all apt packages, all R packages, and `R CMD INSTALL .` succeeded
- [x] Reran it after everything was already installed: apt and R package installs both skip cleanly, package reinstall still succeeds