### PR TITLE
Use && / || instead of & / | in if-condition scalar comparisons (#241)

### DIFF
--- a/R/computeCumulativeCICorrelation.R
+++ b/R/computeCumulativeCICorrelation.R
@@ -96,7 +96,7 @@ computeCumulativeCICorrelation <- function(stimuli, responses, baseimage, rdata,
   list2env(.args, envir = environment())
 
   # Check whether critical variables have been loaded
-  if (!exists('s', envir=environment(), inherits=FALSE) & !exists('p', envir=environment(), inherits=FALSE) ) {
+  if (!exists('s', envir=environment(), inherits=FALSE) && !exists('p', envir=environment(), inherits=FALSE) ) {
     stop('File specified in rdata argument did not contain s or p variable.', rdataWriterNote(environment()))
   }
 

--- a/R/computeInfoVal2IFC.R
+++ b/R/computeInfoVal2IFC.R
@@ -102,7 +102,7 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
   }
 
   # Check whether reference norms are present or can be looked up from table. If not, re-generate.
-  if (!force_gen_ref_dist & !exists("reference_norms", envir=environment(), inherits=FALSE)) {
+  if (!force_gen_ref_dist && !exists("reference_norms", envir=environment(), inherits=FALSE)) {
 
     # Pre-computed reference distribution table (TODO: read from external file).
     #
@@ -180,7 +180,7 @@ computeInfoVal2IFC <- function(target_ci, rdata, iter = 10000, force_gen_ref_dis
     # explicitly asked for one. force_gen_ref_dist previously only skipped the
     # lookup-table branch above and never reached here, so it was silently
     # ignored whenever reference_norms already existed in the .Rdata file.
-    if (force_gen_ref_dist | !exists("reference_norms", envir=environment(), inherits=FALSE)) {
+    if (force_gen_ref_dist || !exists("reference_norms", envir=environment(), inherits=FALSE)) {
 
       # Reference norms not present in rdata file (or regeneration forced).
       #

--- a/R/generateCI.R
+++ b/R/generateCI.R
@@ -177,7 +177,7 @@ generateCI <- function(stimuli, responses, baseimage, rdata, participants=NA,
   list2env(.args, envir = environment())
 
   # Check whether critical variables have been loaded
-  if (!exists('s', envir=environment(), inherits=FALSE) &
+  if (!exists('s', envir=environment(), inherits=FALSE) &&
       !exists('p', envir=environment(), inherits=FALSE)) {
     stop('File specified in rdata did not contain s or p variable.', rdataWriterNote(environment()))
   }
@@ -489,7 +489,7 @@ applyScaling <- function(base, ci, scaling, constant) {
   # Scaling with a constant scaling factor
   } else if (scaling == 'constant') {
     scaled <- (ci + constant) / (2*constant)
-    if (max(scaled[!is.na(scaled)]) > 1.0 | min(scaled[!is.na(scaled)]) < 0) {
+    if (max(scaled[!is.na(scaled)]) > 1.0 || min(scaled[!is.na(scaled)]) < 0) {
       warning(paste0('Chosen constant value for constant scaling made noise ',
                      'of classification image exceed possible intensity range ',
                      'of pixels (<0 or >1). Choose a lower value, or clipping ',

--- a/R/generateNoiseImage.R
+++ b/R/generateNoiseImage.R
@@ -24,7 +24,7 @@ generateNoiseImage <- function(params, p) {
   # Abort stimulus generation if number of params doesn't equal number of patches
   if (length(params) != max(p$patchIdx)) {
 
-    if ((length(params) == max(p$patchIdx) + 1)& (min(p$patchIdx) == 0)) {
+    if ((length(params) == max(p$patchIdx) + 1) && (min(p$patchIdx) == 0)) {
       # Some versions of dependencies created patch indices starting with 0, latest dependencies
       # start counting at 1. Fix this.
 

--- a/R/plotZmap.R
+++ b/R/plotZmap.R
@@ -129,9 +129,9 @@ plotZmap <- function(zmap, bgimage = '', sigma, threshold = 3, mask = NULL, deco
       mask <- png::readPNG(mask)
     }
     # Are mask and zmap the same size?
-    if (nrow(zmap) == dim(mask)[1] & ncol(zmap) == dim(mask)[2]) {
+    if (nrow(zmap) == dim(mask)[1] && ncol(zmap) == dim(mask)[2]) {
       # Are all the values either 0/1, or TRUE/FALSE?
-      if (all(mask %in% c(0, 1)) | all(mask %in% c(TRUE, FALSE))) {
+      if (all(mask %in% c(0, 1)) || all(mask %in% c(TRUE, FALSE))) {
         # If we have more than 1 layer (i.e. the PNG was not greyscale but RGB or
         # CMYK), are all the layers identical? If so, remove superfluous layers
         if (length(dim(mask)) != 2) {


### PR DESCRIPTION
## Summary

- lintr's `vector_logic_linter`, surfaced while working #183, flagged 8 sites using `&`/`|` to combine scalar comparisons inside `if()`.
- Checked each: every operand traces to a scalar-returning call (`exists()`, `max()`, `min()`, `length()`, `nrow()`/`ncol()`/`dim()[i]`, `all()`), so `&`/`&&` behave identically at all 8 sites today — this is not a live bug, and not the same class as the `if (matrix)` length-*n* conditions behind #183's cited P0s (a non-scalar object used directly as a condition).
- Value is style + defense-in-depth: matches R's own recommended `if`-condition style, and guards against a future edit accidentally introducing a non-scalar operand — which, since R 4.3, is a hard error rather than a silent truncation.
- Zero behavior change, so no plan-first gate and no `NEWS.md` entry (same precedent as the `zzz.R` house-move PR).

Closes #241.

## Test plan

- [x] `lintr::lint_package(linters = vector_logic_linter())` — 0 remaining hits
- [x] `testthat::test_local()` — 565/565 pass, 0 failures/warnings, unmodified