### PR TITLE
De-duplicate the mask-import logic between generateCI() and plotZmap() (#185)

### DIFF
--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -36,22 +36,38 @@ shape, disappears entirely under the revision above — see below), each checked
 suite for whether resolving it toward `applyMask()`'s behaviour changes anything currently
 tested or reachable through documented usage:
 
-1. **Size check no longer needs generalising.** The first draft worried that `applyMask()`
-   compares against a scalar `img_size` while `plotZmap()` compares `nrow(zmap)`/`ncol(zmap)`
-   separately, and proposed a `target_dims` vector to reconcile them. That concern only existed
-   because of the abandoned `importMask()` indirection. Calling `applyMask(zmap, mask, img_size =
-   nrow(zmap))` directly needs no such change: `img_size` is just "the dimension to check the
-   mask against", and every z-map is square (built from a square CI), so `nrow(zmap)` is exactly
-   the right scalar to pass. `applyMask()`'s own signature and size-check logic are untouched.
+1. **Size check: wrong to assume every z-map is square.** An earlier revision of this plan
+   argued `plotZmap(mask = zmap, img_size = nrow(zmap))` needed no generalisation because
+   "every z-map is square (built from a square CI)" — true for z-maps `generateCI()` builds
+   internally, false as a constraint on `plotZmap()` itself. It is a public, exported function;
+   its roxygen for `mask` says only "the same dimensions as zmap", never square, and nothing in
+   its body requires `nrow(zmap) == ncol(zmap))`. A caller passing a rectangular `zmap` with a
+   matching rectangular mask works on current `main` (`nrow(zmap) == dim(mask)[1] && ncol(zmap)
+   == dim(mask)[2]`, checked independently) and would wrongly error under a single scalar
+   `img_size`, caught by review before it was written, not after.
+
+   Checked rather than assumed how much actually needs to change: `applyMask()`'s existing
+   comparison, `dim(mask_matrix) == img_size`, already works correctly for a length-2 `img_size`
+   with no edit at all — R recycles a length-1 `img_size` against `dim()`'s length-2 result
+   (today's scalar behaviour, unchanged) and compares element-wise against a length-2 one
+   (verified directly: `applyMask(matrix(1,4,6), matrix(0,4,6), img_size = c(4,6))` returns a
+   4×6 result on unmodified `main`). Only the size-mismatch *message* hardcodes `img_size` for
+   both dimensions and needs a small change — see the shared-helper code below. `plotZmap()`
+   passes `img_size = c(nrow(zmap), ncol(zmap))` instead of a bare scalar; `generateCI()`'s
+   existing calls keep passing a scalar, unaffected.
 
 2. **Error wording mentions "stimuli" unconditionally** in `applyMask()`'s size-mismatch
    message, which is inaccurate when called from `plotZmap()`. Resolution: `applyMask()` gains
-   one new optional parameter, `context = 'stimuli'`. `generateCI()`'s existing call sites pass
-   nothing and get byte-for-byte the same message as today; `plotZmap()` passes `context =
-   'z-map'`. `tests/testthat/test-error-paths.R:159-168` only asserts the substrings `"same
-   dimensions"`, `"8"`, `"4"` — none of which depend on the context word — so this is safe
-   against the pinned assertions, and the new parameter is additive so no existing call
-   (positional or named) breaks.
+   one new optional parameter, `context = 'stimuli'`, used everywhere the message currently
+   hardcodes the word. `generateCI()`'s existing call sites pass nothing and get the same
+   substantive message as today, with one incidental correction: the current text reads "...the
+   stimuli! (stimulus dimensions: ..." — plural then singular, a pre-existing inconsistency
+   (checked directly against `R/generateCI.R:461-462`) — which a single `context` value used in
+   both places normalizes to "stimuli" throughout. Not byte-for-byte identical, then, but not a
+   claim worth engineering around either: `tests/testthat/test-error-paths.R:159-168` only
+   asserts the substrings `"same dimensions"`, `"8"`, `"4"`, none of which depend on the word,
+   and the new parameter is additive so no existing call (positional or named) breaks.
+   `plotZmap()` passes `context = 'z-map'`.
 
 3. **Multi-channel collapsing.** `applyMask()` hardcodes three channels
    (`list(mask_matrix[,,1], mask_matrix[,,2], mask_matrix[,,3])`), so it throws `subscript out
@@ -138,15 +154,21 @@ applyMask <- function(ci, mask, img_size = nrow(ci), context = 'stimuli') {
   # ... same import/validate logic as today, with:
   #  - the channel-collapse block generalised per point 3's alpha-aware n_color rule
   #  - "stimuli" in the size-mismatch message replaced by the `context` argument (point 2)
+  #  - the size-mismatch message's two hardcoded `img_size` reads replaced by
+  #    `img_size[1]` and `img_size[length(img_size)]`, so it reports correctly whether
+  #    img_size is a scalar (generateCI()'s calls, unchanged output) or length-2 (point 1)
 }
 ```
+
+`img_size = nrow(ci)` stays the default (unchanged — every `generateCI()` call site already
+passes a scalar or relies on this default, both untouched).
 
 `R/plotZmap.R`'s ~50-line inline `if (!is.null(mask)) { ... }` import/validate block (current
 `main` lines ~126-177) is deleted and replaced with:
 
 ```r
 if (!is.null(mask)) {
-  zmap <- applyMask(zmap, mask, img_size = nrow(zmap), context = 'z-map')
+  zmap <- applyMask(zmap, mask, img_size = c(nrow(zmap), ncol(zmap)), context = 'z-map')
 }
 ```
 
@@ -164,8 +186,14 @@ NA`. Sequencing is unchanged: threshold is applied first, then the mask, exactly
 - No other existing test asserts `plotZmap()`'s previous mask-import wording (checked via
   `grep` across `tests/testthat/`), so nothing else needs updating.
 - `tests/testthat/test-error-paths.R`'s four `applyMask()` guard tests need no change: every
-  existing call (three positional args plus `img_size =`) keeps its exact signature and exact
-  message text for every case they cover, since `context` is additive with a default.
+  existing call (three positional args plus `img_size =`) keeps its exact signature, and the
+  substrings they assert (`"same dimensions"`, `"8"`, `"4"`, `"other than 0 or 1"`, `"not a
+  greyscale image"`, `"neither a string nor a matrix"`) are all still present — see point 2 on
+  the one incidental wording normalization that does not affect any of them.
+- Add a test for the rectangular-mask case found during review: `applyMask()` (and so
+  `plotZmap()`) accepts a mask whose dimensions match a non-square target passed as
+  `img_size = c(rows, cols)`, and still reports both dimensions correctly (not the same value
+  twice) when they do not match.
 - Add one new test exercising `plotZmap()`'s newly-inherited "neither a string nor a matrix"
   guard directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable
   behaviour for that function and nothing currently covers it.

--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -1,0 +1,126 @@
+# Plan: extract one mask-import helper, shared by generateCI() and plotZmap()
+
+Issue #185. Originally reported as #89 (closed) — the duplication is still there and has
+already produced divergent behaviour once: `plotZmap(mask = ...)` validated its mask and then
+never applied it (fixed for 1.1.0; see `DECISIONS.md` → "`plotZmap(mask = ...)` was applied
+rather than deprecated"). The two implementations have kept drifting since.
+
+## Where the duplication lives today
+
+- `R/generateCI.R`'s `applyMask(ci, mask, img_size)` (internal, tested directly via `rcicr:::`
+  in `tests/testthat/test-error-paths.R` and `test-plotZmap.R`).
+- `R/plotZmap.R`'s inline `if (!is.null(mask)) { ... }` block inside `plotZmap()` itself
+  (lines ~125-177 on current `main`).
+
+Per `DECISIONS.md` → "When the docs and the code disagreed about `mask`, the code was the
+contract": `applyMask()` is the copy that has "been executing for a decade" and is the one
+`tests/testthat/test-error-paths.R` calls the canonical guard tests against (comment there:
+"plotZmap() has one of these covered; generateCI() has none -- and generateCI() is the copy
+that has always been live"). So the direction is: extract `applyMask()`'s import/validate logic
+into a shared helper, and make `plotZmap()` use it — not the reverse.
+
+## Behavioural differences found while reading both, and how each is resolved
+
+Read both implementations line by line (`R/generateCI.R:421-480`, `R/plotZmap.R:125-177` on
+current `main`) rather than assuming they agree. Four differences, each checked against the
+test suite for whether resolving it toward `applyMask()`'s behaviour changes anything currently
+tested or reachable through documented usage:
+
+1. **Size check.** `applyMask()` compares `dim(mask_matrix)` against a scalar `img_size` (an
+   implicit square-target assumption already baked into every caller — CIs are always square).
+   `plotZmap()` compares `dim(mask)` against `nrow(zmap)`/`ncol(zmap)` directly. Resolution: the
+   shared helper takes `target_dims = c(nrow, ncol)` instead of a scalar, so both callers keep
+   their exact current comparison (`applyMask` passes `c(img_size, img_size)`) with no behaviour
+   change for any square target — which is every real one.
+
+2. **Error wording mentions "stimuli" unconditionally** in `applyMask()`'s size-mismatch
+   message. Not meaningful from `plotZmap()`. Resolution: the helper takes a `context` string
+   (`'stimuli'` default, so `applyMask()`'s call site and its existing message text are
+   byte-for-byte unchanged; `plotZmap()` passes `'z-map'`).
+   `tests/testthat/test-error-paths.R:159-168` only asserts the substrings `"same dimensions"`,
+   `"8"`, `"4"` — none of which depend on the context word — so this is safe against the pinned
+   assertions.
+
+3. **RGB/RGBA channel collapsing.** `applyMask()` checks channels 1:3 for identity (ignoring a
+   4th/alpha channel if present). `plotZmap()` loops over *all* layers pairwise, so a
+   4-channel PNG needs channel 4 (alpha) to match too, or it errors. No test exercises an RGBA
+   mask for either function (`test-error-paths.R:194-217` only covers a 3-channel RGB mask).
+   Resolution: use `applyMask()`'s channel-1:3 logic in the shared helper — this is a behaviour
+   change for `plotZmap()` on an untested, undocumented input (an RGBA mask), making it match
+   `generateCI()`'s established behaviour instead of erroring where `generateCI()` would not.
+
+4. **Type-check on a non-string, non-matrix mask.** `applyMask()` explicitly rejects it
+   (`"neither a string nor a matrix"`, tested). `plotZmap()` has no such check — it calls
+   `png::readPNG()` on whatever isn't `is.matrix()`, which fails with a low-level, unrelated
+   error for something like `mask = TRUE` or `mask = list()`. No test pins `plotZmap()`'s
+   current cryptic failure mode here. Resolution: `plotZmap()` gains `applyMask()`'s clear
+   error for this case — a robustness improvement, not a change to any currently-succeeding
+   call.
+
+None of the four changes alters the result of any call that currently succeeds or that any
+test currently exercises. Two (#3, #4) change the *error path* for inputs nothing in the test
+suite or documented usage reaches today. This is not a numeric-output or call-syntax change
+under the "guiding constraint" in `AGENTS.md` — it changes what happens for previously-broken
+inputs — but it is still an observable behaviour change worth a `NEWS.md` entry under
+"Internal", named explicitly rather than left for someone to notice.
+
+## The shared helper
+
+New file `R/importMask.R`:
+
+```r
+importMask <- function(mask, target_dims, context = 'stimuli') {
+  # ... exact logic of the current applyMask() import/validate block, generalised
+  # per points 1-2 above, returning a logical matrix (TRUE = masked, i.e. mask == 0).
+}
+```
+
+`R/generateCI.R`'s `applyMask(ci, mask, img_size = nrow(ci))` keeps its exact existing name and
+signature (tests call it directly with `img_size =`) and becomes a thin wrapper:
+
+```r
+applyMask <- function(ci, mask, img_size = nrow(ci)) {
+  bool_mask <- importMask(mask, target_dims = c(img_size, img_size))
+  ci[bool_mask] <- NA
+  return(ci)
+}
+```
+
+`R/plotZmap.R`'s inline block becomes:
+
+```r
+if (!is.null(mask)) {
+  mask <- importMask(mask, target_dims = c(nrow(zmap), ncol(zmap)), context = 'z-map')
+}
+```
+
+leaving the existing `if (!is.null(mask)) { zmap[mask] <- NA }` below it untouched (already
+expects a boolean matrix in that convention).
+
+## Test changes
+
+- `tests/testthat/test-plotZmap.R`'s `"mismatched mask and zmap dimensions error"` test
+  currently asserts the message matches `"not the same size"` (plotZmap's own old wording).
+  Update the expected pattern to `"same dimensions"` (the now-shared wording) — this is
+  asserting our own error text, not a numeric contract.
+- No other existing test asserts `plotZmap()`'s previous mask-import wording (checked via
+  `grep` across `tests/testthat/`), so nothing else needs updating.
+- `tests/testthat/test-error-paths.R`'s four `applyMask()` guard tests need no change: the
+  wrapper preserves the exact call signature and exact message text for every case they cover.
+- Add one new test exercising `plotZmap()`'s newly-shared "neither a string nor a matrix" guard
+  directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable behaviour for
+  that function and nothing currently covers it.
+
+## Verification before marking ready
+
+- `testthat::test_local()` — full suite green, including the updated and new assertions above.
+- `lintr::lint_package()` — zero new lints (the `.lintr` baseline from #183 must not need
+  regenerating; if it does, that is a signal something more than intended changed).
+- `tools/compare-release-output.R --quick` — the release gate. Checked what its `mask` scenario
+  actually calls (`tools/compare-harness.R:271-278`): only `generateCI(mask = ...)`, never
+  `plotZmap(mask = ...)`. So the gate covers `applyMask()`'s path but not the shared helper's
+  use from `plotZmap()` — that side's regression coverage is `tests/testthat/test-plotZmap.R`
+  alone, which is why its existing mask tests (same-half, all-zero, matrix-vs-PNG-agree,
+  dimension-mismatch) all have to keep passing unchanged, not just the new one.
+- `NEWS.md` gets an "## Internal" entry describing the dedup and naming the two resolved
+  behaviour differences (points 3-4 above) explicitly.

--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -1,4 +1,4 @@
-# Plan: extract one mask-import helper, shared by generateCI() and plotZmap()
+# Plan: de-duplicate mask-import logic between generateCI() and plotZmap()
 
 Issue #185. Originally reported as #89 (closed) — the duplication is still there and has
 already produced divergent behaviour once: `plotZmap(mask = ...)` validated its mask and then
@@ -16,30 +16,42 @@ Per `DECISIONS.md` → "When the docs and the code disagreed about `mask`, the c
 contract": `applyMask()` is the copy that has "been executing for a decade" and is the one
 `tests/testthat/test-error-paths.R` calls the canonical guard tests against (comment there:
 "plotZmap() has one of these covered; generateCI() has none -- and generateCI() is the copy
-that has always been live"). So the direction is: extract `applyMask()`'s import/validate logic
-into a shared helper, and make `plotZmap()` use it — not the reverse.
+that has always been live"). So the direction is: `plotZmap()` starts calling `applyMask()`
+directly — not the reverse, and not a third function in between either.
+
+**Revision, made in review:** the first draft of this plan invented a separate `importMask()`
+helper returning a boolean matrix, with `applyMask()` reduced to a thin wrapper around it. Ron
+asked directly on the PR why not just call `applyMask()` from `plotZmap()` and skip the extra
+layer — and there is no reason not to. `applyMask(ci, mask, img_size)` does not care what the
+matrix it masks represents; it imports, validates, and sets masked cells to `NA` on whatever
+numeric matrix is passed in. `plotZmap()` can call `applyMask(zmap, mask, img_size = nrow(zmap))`
+exactly as `generateCI()` calls `applyMask(ci, mask, img_size)`. One existing function, one new
+caller, no new file.
 
 ## Behavioural differences found while reading both, and how each is resolved
 
 Read both implementations line by line (`R/generateCI.R:421-480`, `R/plotZmap.R:125-177` on
-current `main`) rather than assuming they agree. Four differences, each checked against the
-test suite for whether resolving it toward `applyMask()`'s behaviour changes anything currently
+current `main`) rather than assuming they agree. Three differences (a fourth, the size-check
+shape, disappears entirely under the revision above — see below), each checked against the test
+suite for whether resolving it toward `applyMask()`'s behaviour changes anything currently
 tested or reachable through documented usage:
 
-1. **Size check.** `applyMask()` compares `dim(mask_matrix)` against a scalar `img_size` (an
-   implicit square-target assumption already baked into every caller — CIs are always square).
-   `plotZmap()` compares `dim(mask)` against `nrow(zmap)`/`ncol(zmap)` directly. Resolution: the
-   shared helper takes `target_dims = c(nrow, ncol)` instead of a scalar, so both callers keep
-   their exact current comparison (`applyMask` passes `c(img_size, img_size)`) with no behaviour
-   change for any square target — which is every real one.
+1. **Size check no longer needs generalising.** The first draft worried that `applyMask()`
+   compares against a scalar `img_size` while `plotZmap()` compares `nrow(zmap)`/`ncol(zmap)`
+   separately, and proposed a `target_dims` vector to reconcile them. That concern only existed
+   because of the abandoned `importMask()` indirection. Calling `applyMask(zmap, mask, img_size =
+   nrow(zmap))` directly needs no such change: `img_size` is just "the dimension to check the
+   mask against", and every z-map is square (built from a square CI), so `nrow(zmap)` is exactly
+   the right scalar to pass. `applyMask()`'s own signature and size-check logic are untouched.
 
 2. **Error wording mentions "stimuli" unconditionally** in `applyMask()`'s size-mismatch
-   message. Not meaningful from `plotZmap()`. Resolution: the helper takes a `context` string
-   (`'stimuli'` default, so `applyMask()`'s call site and its existing message text are
-   byte-for-byte unchanged; `plotZmap()` passes `'z-map'`).
-   `tests/testthat/test-error-paths.R:159-168` only asserts the substrings `"same dimensions"`,
-   `"8"`, `"4"` — none of which depend on the context word — so this is safe against the pinned
-   assertions.
+   message, which is inaccurate when called from `plotZmap()`. Resolution: `applyMask()` gains
+   one new optional parameter, `context = 'stimuli'`. `generateCI()`'s existing call sites pass
+   nothing and get byte-for-byte the same message as today; `plotZmap()` passes `context =
+   'z-map'`. `tests/testthat/test-error-paths.R:159-168` only asserts the substrings `"same
+   dimensions"`, `"8"`, `"4"` — none of which depend on the context word — so this is safe
+   against the pinned assertions, and the new parameter is additive so no existing call
+   (positional or named) breaks.
 
 3. **Multi-channel collapsing.** `applyMask()` hardcodes three channels
    (`list(mask_matrix[,,1], mask_matrix[,,2], mask_matrix[,,3])`), so it throws `subscript out
@@ -50,78 +62,72 @@ tested or reachable through documented usage:
    `plotZmap(mask = <2-channel PNG, planes identical>, decoration = FALSE, ...)` **succeeds**,
    while the equivalent `applyMask()` call on the same file throws `subscript out of bounds` —
    confirmed by sourcing both files and calling each against a real 2-channel PNG written with
-   `png::writePNG()`. So naively adopting `applyMask()`'s hardcoded-3 logic, as an earlier draft
-   of this plan did, would have broken a call that works today on `plotZmap()` — caught by
-   review, not by the earlier draft's own (insufficiently checked) reasoning.
+   `png::writePNG()`. So routing `plotZmap()` through `applyMask()` unchanged would have broken
+   a call that works today — caught by review, not by the earlier draft's own reasoning.
 
-   Resolution: neither existing implementation is right to copy as-is. The shared helper
-   generalises to arbitrary channel count `n = dim(mask_matrix)[3]`: collapse when every channel
-   is identical to channel 1 (`all(sapply(2:n, function(i) identical(mask_matrix[,,i],
-   mask_matrix[,,1])))`), else the existing "not a greyscale image" error. This is equivalent to
-   `plotZmap()`'s pairwise-consecutive loop by transitivity (so its currently-working
-   2-channel and 3-channel calls are unaffected) and equivalent to `applyMask()`'s current
-   behaviour for the tested 3-channel case (same three channels, same comparison, same result).
-   For 4-channel (RGBA) input it is *stricter* than `applyMask()`'s current hardcoded check
-   (which silently ignores channel 4): now the alpha channel must match too, or the mask is
-   rejected as non-greyscale rather than silently accepted with alpha discarded. Untested either
-   way (`test-error-paths.R:194-217` only covers 3-channel RGB) — reject-on-mismatch is the
-   safer default for previously-unreachable input, matching how every other guard in this helper
-   already errs toward rejecting an ambiguous mask rather than guessing.
+   Resolution: fix `applyMask()`'s channel-collapse in place, since it is now the one
+   implementation both functions share. Generalise to arbitrary channel count `n =
+   dim(mask_matrix)[3]`: collapse when every channel is identical to channel 1
+   (`all(sapply(2:n, function(i) identical(mask_matrix[,,i], mask_matrix[,,1])))`), else the
+   existing "not a greyscale image" error. This is equivalent to `plotZmap()`'s
+   pairwise-consecutive loop by transitivity (so its currently-working 2-channel and 3-channel
+   calls are unaffected) and equivalent to `applyMask()`'s current behaviour for the tested
+   3-channel case (same three channels, same comparison, same result) — a genuine bug fix for
+   `generateCI()` too: a 2-channel mask PNG crashes it today, and will not after this change.
+   For 4-channel (RGBA) input the new logic is *stricter* than today's hardcoded check (which
+   silently ignores channel 4): the alpha channel must now match too, or the mask is rejected as
+   non-greyscale. Untested either way (`test-error-paths.R:194-217` only covers 3-channel RGB) —
+   reject-on-mismatch is the safer default for previously-unreachable input, matching how every
+   other guard in this function already errs toward rejecting an ambiguous mask over guessing.
 
    Added to the test plan below: a 2-channel (greyscale + alpha) mask with identical planes must
-   still succeed through both `applyMask()` and `plotZmap()`, and one with differing planes must
-   still error as non-greyscale through both — the exact case review caught, pinned so it cannot
+   succeed through `applyMask()` directly (and so through both callers), and one with differing
+   planes must error as non-greyscale — the exact case review caught, pinned so it cannot
    regress again.
 
 4. **Type-check on a non-string, non-matrix mask.** `applyMask()` explicitly rejects it
-   (`"neither a string nor a matrix"`, tested). `plotZmap()` has no such check — it calls
-   `png::readPNG()` on whatever isn't `is.matrix()`, which fails with a low-level, unrelated
-   error for something like `mask = TRUE` or `mask = list()`. No test pins `plotZmap()`'s
-   current cryptic failure mode here. Resolution: `plotZmap()` gains `applyMask()`'s clear
-   error for this case — a robustness improvement, not a change to any currently-succeeding
-   call.
+   (`"neither a string nor a matrix"`, tested). `plotZmap()`'s current inline code has no such
+   check — it calls `png::readPNG()` on whatever isn't `is.matrix()`, which fails with a
+   low-level, unrelated error for something like `mask = TRUE` or `mask = list()`. No test pins
+   `plotZmap()`'s current cryptic failure mode here. Resolution: once `plotZmap()` calls
+   `applyMask()`, it inherits this clear error for free — a robustness improvement, not a change
+   to any currently-succeeding call.
 
-None of the four changes alters the result of any call that currently succeeds or that any
-test currently exercises. Two (#3, #4) change the *error path* for inputs nothing in the test
-suite or documented usage reaches today. This is not a numeric-output or call-syntax change
-under the "guiding constraint" in `AGENTS.md` — it changes what happens for previously-broken
-inputs — but it is still an observable behaviour change worth a `NEWS.md` entry under
-"Internal", named explicitly rather than left for someone to notice.
+None of the four points changes the result of any call that currently succeeds through either
+function, except point 3's 2-channel case, which changes `generateCI()` from crashing to working
+(a bug fix) and leaves `plotZmap()`'s already-working behaviour unchanged. Points 3 (RGBA) and 4
+change the *error path* for inputs nothing in the test suite or documented usage reaches today.
+This is not a numeric-output or call-syntax change under the "guiding constraint" in
+`AGENTS.md`, but it is still an observable behaviour change worth a `NEWS.md` entry, named
+explicitly rather than left for someone to notice.
 
-## The shared helper
+## The change itself
 
-New file `R/importMask.R`:
+`R/generateCI.R`'s `applyMask()` keeps its exact name, its exact three existing parameters
+(`ci, mask, img_size = nrow(ci)`), and its exact behaviour for every case currently tested. It
+gains one additive parameter and a generalised channel-collapse loop:
 
 ```r
-importMask <- function(mask, target_dims, context = 'stimuli') {
-  # ... exact logic of the current applyMask() import/validate block, generalised
-  # per points 1-2 above, plus the channel-count generalisation from point 3
-  # (collapse when every channel equals channel 1, for any n = dim()[3] >= 2),
-  # returning a logical matrix (TRUE = masked, i.e. mask == 0).
+applyMask <- function(ci, mask, img_size = nrow(ci), context = 'stimuli') {
+  # ... same import/validate logic as today, with:
+  #  - the channel-collapse block generalised to arbitrary n = dim(mask_matrix)[3] (point 3)
+  #  - "stimuli" in the size-mismatch message replaced by the `context` argument (point 2)
 }
 ```
 
-`R/generateCI.R`'s `applyMask(ci, mask, img_size = nrow(ci))` keeps its exact existing name and
-signature (tests call it directly with `img_size =`) and becomes a thin wrapper:
-
-```r
-applyMask <- function(ci, mask, img_size = nrow(ci)) {
-  bool_mask <- importMask(mask, target_dims = c(img_size, img_size))
-  ci[bool_mask] <- NA
-  return(ci)
-}
-```
-
-`R/plotZmap.R`'s inline block becomes:
+`R/plotZmap.R`'s ~50-line inline `if (!is.null(mask)) { ... }` import/validate block (current
+`main` lines ~126-177) is deleted and replaced with:
 
 ```r
 if (!is.null(mask)) {
-  mask <- importMask(mask, target_dims = c(nrow(zmap), ncol(zmap)), context = 'z-map')
+  zmap <- applyMask(zmap, mask, img_size = nrow(zmap), context = 'z-map')
 }
 ```
 
-leaving the existing `if (!is.null(mask)) { zmap[mask] <- NA }` below it untouched (already
-expects a boolean matrix in that convention).
+This also folds in the separate `zmap[abs(zmap) < threshold] <- NA` / `zmap[mask] <- NA`
+two-step that currently follows the inline block — `applyMask()` already does the "set masked
+cells to NA" step internally, so `plotZmap()` no longer needs its own trailing `zmap[mask] <-
+NA`. Sequencing is unchanged: threshold is applied first, then the mask, exactly as today.
 
 ## Test changes
 
@@ -131,14 +137,15 @@ expects a boolean matrix in that convention).
   asserting our own error text, not a numeric contract.
 - No other existing test asserts `plotZmap()`'s previous mask-import wording (checked via
   `grep` across `tests/testthat/`), so nothing else needs updating.
-- `tests/testthat/test-error-paths.R`'s four `applyMask()` guard tests need no change: the
-  wrapper preserves the exact call signature and exact message text for every case they cover.
-- Add one new test exercising `plotZmap()`'s newly-shared "neither a string nor a matrix" guard
-  directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable behaviour for
-  that function and nothing currently covers it.
+- `tests/testthat/test-error-paths.R`'s four `applyMask()` guard tests need no change: every
+  existing call (three positional args plus `img_size =`) keeps its exact signature and exact
+  message text for every case they cover, since `context` is additive with a default.
+- Add one new test exercising `plotZmap()`'s newly-inherited "neither a string nor a matrix"
+  guard directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable
+  behaviour for that function and nothing currently covers it.
 - Add a test pinning the 2-channel (greyscale + alpha) case found during review: a mask PNG with
-  identical grayscale and alpha planes succeeds (through both `applyMask()` and `plotZmap()`),
-  one with differing planes errors as non-greyscale (through both) — see point 3 above.
+  identical grayscale and alpha planes succeeds through `applyMask()` directly, one with
+  differing planes errors as non-greyscale — see point 3 above.
 
 ## Verification before marking ready
 
@@ -147,9 +154,10 @@ expects a boolean matrix in that convention).
   regenerating; if it does, that is a signal something more than intended changed).
 - `tools/compare-release-output.R --quick` — the release gate. Checked what its `mask` scenario
   actually calls (`tools/compare-harness.R:271-278`): only `generateCI(mask = ...)`, never
-  `plotZmap(mask = ...)`. So the gate covers `applyMask()`'s path but not the shared helper's
-  use from `plotZmap()` — that side's regression coverage is `tests/testthat/test-plotZmap.R`
-  alone, which is why its existing mask tests (same-half, all-zero, matrix-vs-PNG-agree,
-  dimension-mismatch) all have to keep passing unchanged, not just the new one.
-- `NEWS.md` gets an "## Internal" entry describing the dedup and naming the two resolved
-  behaviour differences (points 3-4 above) explicitly.
+  `plotZmap(mask = ...)`. So the gate covers `applyMask()`'s import/validate logic (now shared)
+  but not `plotZmap()`'s specific call site — that side's regression coverage is
+  `tests/testthat/test-plotZmap.R` alone, which is why its existing mask tests (same-half,
+  all-zero, matrix-vs-PNG-agree, dimension-mismatch) all have to keep passing unchanged, not
+  just the new ones.
+- `NEWS.md` gets an entry describing the dedup, the 2-channel bug fix, and the two resolved
+  error-path differences (points 3-4 above) explicitly.

--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -208,12 +208,15 @@ NA`. Sequencing is unchanged: threshold is applied first, then the mask, exactly
 - `testthat::test_local()` — full suite green, including the updated and new assertions above.
 - `lintr::lint_package()` — zero new lints (the `.lintr` baseline from #183 must not need
   regenerating; if it does, that is a signal something more than intended changed).
-- `tools/compare-release-output.R --quick` — the release gate. Checked what its `mask` scenario
-  actually calls (`tools/compare-harness.R:271-278`): only `generateCI(mask = ...)`, never
-  `plotZmap(mask = ...)`. So the gate covers `applyMask()`'s import/validate logic (now shared)
-  but not `plotZmap()`'s specific call site — that side's regression coverage is
-  `tests/testthat/test-plotZmap.R` alone, which is why its existing mask tests (same-half,
-  all-zero, matrix-vs-PNG-agree, dimension-mismatch) all have to keep passing unchanged, not
-  just the new ones.
+- `tools/compare-release-output.R --quick` for the default v1.0.1 reference, **and**
+  `tools/compare-release-output.R --ref=v1.1.0 --quick` — the `mask` extra is gated behind
+  `SINCE = c(mask = "1.1.0", ...)` in `tools/compare-harness.R`, so the default v1.0.1 run skips
+  it entirely and only the `--ref=v1.1.0` run actually exercises `applyMask()`'s import/validate
+  logic. Checked what that scenario calls (`tools/compare-harness.R:271-278`): only
+  `generateCI(mask = ...)`, never `plotZmap(mask = ...)`. So even the v1.1.0 run covers
+  `applyMask()`'s shared logic but not `plotZmap()`'s specific call site — that side's
+  regression coverage is `tests/testthat/test-plotZmap.R` alone, which is why its existing mask
+  tests (same-half, all-zero, matrix-vs-PNG-agree, dimension-mismatch) all have to keep passing
+  unchanged, not just the new ones.
 - `NEWS.md` gets an entry describing the dedup, the 2-channel bug fix, and the two resolved
   error-path differences (points 3-4 above) explicitly.

--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -41,13 +41,37 @@ tested or reachable through documented usage:
    `"8"`, `"4"` — none of which depend on the context word — so this is safe against the pinned
    assertions.
 
-3. **RGB/RGBA channel collapsing.** `applyMask()` checks channels 1:3 for identity (ignoring a
-   4th/alpha channel if present). `plotZmap()` loops over *all* layers pairwise, so a
-   4-channel PNG needs channel 4 (alpha) to match too, or it errors. No test exercises an RGBA
-   mask for either function (`test-error-paths.R:194-217` only covers a 3-channel RGB mask).
-   Resolution: use `applyMask()`'s channel-1:3 logic in the shared helper — this is a behaviour
-   change for `plotZmap()` on an untested, undocumented input (an RGBA mask), making it match
-   `generateCI()`'s established behaviour instead of erroring where `generateCI()` would not.
+3. **Multi-channel collapsing.** `applyMask()` hardcodes three channels
+   (`list(mask_matrix[,,1], mask_matrix[,,2], mask_matrix[,,3])`), so it throws `subscript out
+   of bounds` — not a clean error — on any PNG with `dim()[3] != 3`. `plotZmap()` instead loops
+   `for (i in 2:dim(mask)[3])`, which works for any channel count including 2 (an 8-bit
+   grayscale-plus-alpha PNG, which `png::readPNG()` decodes to a 2-channel array). Verified
+   directly rather than assumed: on current `main`,
+   `plotZmap(mask = <2-channel PNG, planes identical>, decoration = FALSE, ...)` **succeeds**,
+   while the equivalent `applyMask()` call on the same file throws `subscript out of bounds` —
+   confirmed by sourcing both files and calling each against a real 2-channel PNG written with
+   `png::writePNG()`. So naively adopting `applyMask()`'s hardcoded-3 logic, as an earlier draft
+   of this plan did, would have broken a call that works today on `plotZmap()` — caught by
+   review, not by the earlier draft's own (insufficiently checked) reasoning.
+
+   Resolution: neither existing implementation is right to copy as-is. The shared helper
+   generalises to arbitrary channel count `n = dim(mask_matrix)[3]`: collapse when every channel
+   is identical to channel 1 (`all(sapply(2:n, function(i) identical(mask_matrix[,,i],
+   mask_matrix[,,1])))`), else the existing "not a greyscale image" error. This is equivalent to
+   `plotZmap()`'s pairwise-consecutive loop by transitivity (so its currently-working
+   2-channel and 3-channel calls are unaffected) and equivalent to `applyMask()`'s current
+   behaviour for the tested 3-channel case (same three channels, same comparison, same result).
+   For 4-channel (RGBA) input it is *stricter* than `applyMask()`'s current hardcoded check
+   (which silently ignores channel 4): now the alpha channel must match too, or the mask is
+   rejected as non-greyscale rather than silently accepted with alpha discarded. Untested either
+   way (`test-error-paths.R:194-217` only covers 3-channel RGB) — reject-on-mismatch is the
+   safer default for previously-unreachable input, matching how every other guard in this helper
+   already errs toward rejecting an ambiguous mask rather than guessing.
+
+   Added to the test plan below: a 2-channel (greyscale + alpha) mask with identical planes must
+   still succeed through both `applyMask()` and `plotZmap()`, and one with differing planes must
+   still error as non-greyscale through both — the exact case review caught, pinned so it cannot
+   regress again.
 
 4. **Type-check on a non-string, non-matrix mask.** `applyMask()` explicitly rejects it
    (`"neither a string nor a matrix"`, tested). `plotZmap()` has no such check — it calls
@@ -71,7 +95,9 @@ New file `R/importMask.R`:
 ```r
 importMask <- function(mask, target_dims, context = 'stimuli') {
   # ... exact logic of the current applyMask() import/validate block, generalised
-  # per points 1-2 above, returning a logical matrix (TRUE = masked, i.e. mask == 0).
+  # per points 1-2 above, plus the channel-count generalisation from point 3
+  # (collapse when every channel equals channel 1, for any n = dim()[3] >= 2),
+  # returning a logical matrix (TRUE = masked, i.e. mask == 0).
 }
 ```
 
@@ -110,6 +136,9 @@ expects a boolean matrix in that convention).
 - Add one new test exercising `plotZmap()`'s newly-shared "neither a string nor a matrix" guard
   directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable behaviour for
   that function and nothing currently covers it.
+- Add a test pinning the 2-channel (greyscale + alpha) case found during review: a mask PNG with
+  identical grayscale and alpha planes succeeds (through both `applyMask()` and `plotZmap()`),
+  one with differing planes errors as non-greyscale (through both) — see point 3 above.
 
 ## Verification before marking ready
 

--- a/notes/plan-dedupe-mask-import.md
+++ b/notes/plan-dedupe-mask-import.md
@@ -65,24 +65,49 @@ tested or reachable through documented usage:
    `png::writePNG()`. So routing `plotZmap()` through `applyMask()` unchanged would have broken
    a call that works today — caught by review, not by the earlier draft's own reasoning.
 
-   Resolution: fix `applyMask()`'s channel-collapse in place, since it is now the one
-   implementation both functions share. Generalise to arbitrary channel count `n =
-   dim(mask_matrix)[3]`: collapse when every channel is identical to channel 1
-   (`all(sapply(2:n, function(i) identical(mask_matrix[,,i], mask_matrix[,,1])))`), else the
-   existing "not a greyscale image" error. This is equivalent to `plotZmap()`'s
-   pairwise-consecutive loop by transitivity (so its currently-working 2-channel and 3-channel
-   calls are unaffected) and equivalent to `applyMask()`'s current behaviour for the tested
-   3-channel case (same three channels, same comparison, same result) — a genuine bug fix for
-   `generateCI()` too: a 2-channel mask PNG crashes it today, and will not after this change.
-   For 4-channel (RGBA) input the new logic is *stricter* than today's hardcoded check (which
-   silently ignores channel 4): the alpha channel must now match too, or the mask is rejected as
-   non-greyscale. Untested either way (`test-error-paths.R:194-217` only covers 3-channel RGB) —
-   reject-on-mismatch is the safer default for previously-unreachable input, matching how every
-   other guard in this function already errs toward rejecting an ambiguous mask over guessing.
+   **First revision, made in review:** generalising to "all `n` channels must match channel 1"
+   (as an earlier draft of this plan proposed) is *also* wrong, caught by a second review
+   comment. `applyMask()`'s current channels-1:3-only check is not incidental — for an RGBA
+   mask whose RGB planes carry a genuine binary pattern and whose alpha plane is a constant
+   (e.g. fully opaque, the common case for a mask authored in an external tool), `applyMask()`
+   **succeeds today** by ignoring alpha, and real `generateCI()` scripts can depend on that.
+   Verified directly: built exactly this array (RGB planes = a varying 0/1 pattern, alpha =
+   constant 1) and confirmed `applyMask()` accepts it on current `main` while `plotZmap()`
+   — using its all-channels-must-match loop — rejects the *same file*. So the two functions
+   already disagree on this exact input; "all channels must match" would have resolved that
+   disagreement by breaking the one call that currently works, not by fixing the drift.
 
-   Added to the test plan below: a 2-channel (greyscale + alpha) mask with identical planes must
-   succeed through `applyMask()` directly (and so through both callers), and one with differing
-   planes must error as non-greyscale — the exact case review caught, pinned so it cannot
+   Resolution: alpha is not colour information, so it should never be compared. Generalise
+   using PNG's own channel semantics instead of a generic "all channels equal" rule — a
+   trailing channel is alpha whenever the total is even (2 = greyscale+alpha, 4 = RGBA); every
+   other channel is colour and must agree with channel 1:
+
+   ```r
+   n <- dim(mask_matrix)[3]
+   n_color <- if (n %in% c(2, 4)) n - 1L else n
+   if (n_color > 1 && !all(sapply(2:n_color, function(i) {
+     identical(mask_matrix[,,i], mask_matrix[,,1])
+   }))) {
+     stop(<existing "not a greyscale image" message>)
+   }
+   mask_matrix <- mask_matrix[,,1]
+   ```
+
+   Checked against six cases by direct execution, not just read through: 3-channel
+   identical/differing (the two existing tests — unchanged results), 2-channel
+   identical/differing (Codex's first finding — both now succeed, ignoring alpha), and
+   4-channel with uniform RGB but differing alpha in both orders (Codex's second finding — the
+   RGBA case still succeeds through `applyMask()` exactly as today, since alpha is dropped
+   before the comparison; a 4-channel case where the RGB planes themselves differ still errors).
+   No case that currently succeeds in either function changes result. What changes is only:
+   `applyMask()` on 2-channel input goes from an unconditional crash to success (a bug fix,
+   channel content does not matter — alpha was never compared for 3- or 4-channel input either);
+   and `plotZmap()` on a 2-channel mask with a differing alpha plane goes from erroring to
+   succeeding (previously-erroring path only, same category as points 2 and 4).
+
+   Added to the test plan below: a 2-channel mask (identical planes, and differing planes) must
+   succeed through `applyMask()` directly, and a 4-channel mask with uniform RGB but a differing
+   alpha plane must also still succeed — the two cases review caught, pinned so neither can
    regress again.
 
 4. **Type-check on a non-string, non-matrix mask.** `applyMask()` explicitly rejects it
@@ -94,12 +119,13 @@ tested or reachable through documented usage:
    to any currently-succeeding call.
 
 None of the four points changes the result of any call that currently succeeds through either
-function, except point 3's 2-channel case, which changes `generateCI()` from crashing to working
-(a bug fix) and leaves `plotZmap()`'s already-working behaviour unchanged. Points 3 (RGBA) and 4
-change the *error path* for inputs nothing in the test suite or documented usage reaches today.
-This is not a numeric-output or call-syntax change under the "guiding constraint" in
-`AGENTS.md`, but it is still an observable behaviour change worth a `NEWS.md` entry, named
-explicitly rather than left for someone to notice.
+function. Point 3 changes two previously-*erroring* paths to succeed (a 2-channel mask crashing
+`applyMask()` unconditionally; a 2-channel mask with a differing alpha plane erroring in
+`plotZmap()`) while leaving every currently-succeeding call — including the 4-channel RGBA case
+found in review — at its current result. Point 4 changes the error path for an input nothing in
+the test suite or documented usage reaches today. This is not a numeric-output or call-syntax
+change under the "guiding constraint" in `AGENTS.md`, but it is still an observable behaviour
+change worth a `NEWS.md` entry, named explicitly rather than left for someone to notice.
 
 ## The change itself
 
@@ -110,7 +136,7 @@ gains one additive parameter and a generalised channel-collapse loop:
 ```r
 applyMask <- function(ci, mask, img_size = nrow(ci), context = 'stimuli') {
   # ... same import/validate logic as today, with:
-  #  - the channel-collapse block generalised to arbitrary n = dim(mask_matrix)[3] (point 3)
+  #  - the channel-collapse block generalised per point 3's alpha-aware n_color rule
   #  - "stimuli" in the size-mismatch message replaced by the `context` argument (point 2)
 }
 ```
@@ -143,9 +169,11 @@ NA`. Sequencing is unchanged: threshold is applied first, then the mask, exactly
 - Add one new test exercising `plotZmap()`'s newly-inherited "neither a string nor a matrix"
   guard directly (`plotZmap(mask = TRUE, ...)` or similar), since this is new observable
   behaviour for that function and nothing currently covers it.
-- Add a test pinning the 2-channel (greyscale + alpha) case found during review: a mask PNG with
-  identical grayscale and alpha planes succeeds through `applyMask()` directly, one with
-  differing planes errors as non-greyscale — see point 3 above.
+- Add tests pinning the two channel-count cases found during review, all through `applyMask()`
+  directly: a 2-channel (greyscale + alpha) mask succeeds whether the planes are identical or
+  differing (alpha is always ignored); a 4-channel (RGBA) mask with uniform RGB planes and a
+  differing alpha plane succeeds (matching current `main`'s behaviour exactly); a 4-channel mask
+  whose RGB planes themselves differ still errors as non-greyscale — see point 3 above.
 
 ## Verification before marking ready
 


### PR DESCRIPTION
Closes #185.

## Plan first

Per CONTRIBUTING.md → "Plan first, in the same pull request": this touches `R/` behaviour (two
functions' mask-import paths), so the first commit is a plan (`notes/plan-dedupe-mask-import.md`)
reviewed before any implementation is written. See that file for the full analysis of where the
two implementations currently diverge and how each difference is resolved.

Marking as draft and requesting review on the plan now.