### PR TITLE
Update required-check count to six now that lint is enforced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ A standard R package — roxygen2 docs, a testthat suite under `tests/testthat/`
 
 ## Testing and CI
 
-**The workflow inventory, the five required check names, and the two rules for editing them
+**The workflow inventory, the six required check names, and the two rules for editing them
 (never rename a job, never convert the gate to a `paths:` filter) are in `MAINTENANCE.md`.** Read
 it before touching `.github/workflows/`.
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -17,17 +17,18 @@ file is the machinery around them.
 | `test-coverage.yaml` | Codecov; needs a `CODECOV_TOKEN`. `codecov.yml` sets lenient thresholds because coverage is deliberately partial. |
 | `pkgdown.yaml` | builds the site on every PR, deploys on push to `main`. |
 | `rhub.yaml` | stock R-hub v2, `workflow_dispatch` only. |
-| `lint.yaml` | `lintr::lint_package()`, gated by `.lintr`'s `exclusions:` baseline so only a *new* lint fails it. Not yet a required check (below); `lintr` is pinned in the workflow, and `tools/regenerate-lintr-baseline.R` regenerates the baseline. |
+| `lint.yaml` | `lintr::lint_package()`, gated by `.lintr`'s `exclusions:` baseline so only a *new* lint fails it. A required check (below); `lintr` is pinned in the workflow, and `tools/regenerate-lintr-baseline.R` regenerates the baseline. |
 
-**Five required status checks on `main`**: `compare`, `ubuntu-latest (release)`,
-`ubuntu-latest (devel)`, `macos-latest (release)`, `windows-latest (release)`. They are enforced
-by a **ruleset**, not classic branch protection, so `gh api repos/rdotsch/rcicr/branches/main`
-reports no required contexts and looks unconfigured — query
-`gh api repos/rdotsch/rcicr/rules/branches/main` instead. `lint` is deliberately not among them:
-adding a check *name* to the ruleset is a repo-settings write agents here cannot make, so it
-needs the maintainer, once by hand, via GitHub → Settings → Rules → Rulesets — a UI edit rather
-than a hand-built API payload, since a malformed `PUT` risks dropping unrelated ruleset fields.
-Until then `lint` reports on PRs but does not block one.
+**Six required status checks on `main`**: `compare`, `ubuntu-latest (release)`,
+`ubuntu-latest (devel)`, `macos-latest (release)`, `windows-latest (release)`, `lint`. They are
+enforced by a **ruleset**, not classic branch protection, so
+`gh api repos/rdotsch/rcicr/branches/main` reports no required contexts and looks unconfigured —
+query `gh api repos/rdotsch/rcicr/rules/branches/main` instead. `lint` was added last, once the
+maintainer added its check *name* to the ruleset by hand via GitHub → Settings → Rules →
+Rulesets: adding a name to the ruleset is a repo-settings write agents here cannot make, so a
+newly added workflow's check reports on PRs but does not block one until the maintainer does
+this — a UI edit rather than a hand-built API payload, since a malformed `PUT` risks dropping
+unrelated ruleset fields.
 
 Two consequences worth knowing before editing a workflow. **Required checks are matched by
 name**, so rows can be added to a matrix freely but never renamed — a renamed check reads as


### PR DESCRIPTION
## Summary

- `lint` was just added to the "Protect main" ruleset's required status checks by hand (the
  repo-settings write agents can't make themselves, per `MAINTENANCE.md`'s own note about this).
- `AGENTS.md` and `MAINTENANCE.md` both still said "five required checks" and described `lint`
  as reporting-only, not blocking. Updated both to the current state: six required checks,
  `lint` included.

Prose-only, no `R/` behaviour or CI machinery touched — exempt from Plan-first per
`AGENTS.md`'s own exemption list.

## Test plan

- [x] `wc -w AGENTS.md` → 2795/2800, `wc -w MAINTENANCE.md` → 1689/1800, both under budget
- [x] Confirmed live against `gh api repos/rdotsch/rcicr/rulesets/19791793` that `lint` is now
      in `required_status_checks`